### PR TITLE
fix(test): people-p1 2.5.10 需要 named 身份，缺则 skip

### DIFF
--- a/package/website/tests/e2e/helpers/data-probe.ts
+++ b/package/website/tests/e2e/helpers/data-probe.ts
@@ -249,6 +249,43 @@ export async function requireAnyIdentity(
   return { ok: true, identity: identities[0] }
 }
 
+/**
+ * 探测至少一个「已命名」人物身份（types=named）。
+ *
+ * requireAnyIdentity 接受 named 或 unnamed；但 2.5.10 这类用例会把筛选切到
+ * types=named，若库中只有 unnamed 身份，named 列表为空 → .flow-grid 不渲染 →
+ * 用例误报失败。本探针只取 named，缺则 skip，避免假失败。
+ */
+export async function requireNamedIdentity(
+  request: APIRequestContext,
+  testInfo: SkipCapable,
+): Promise<{ ok: true; identity: FaceIdentitySummary } | { ok: false }> {
+  const token = await ensureP0Fixtures(request, testInfo)
+  if (!token) {
+    return { ok: false }
+  }
+
+  const res = await tryGet<FaceIdentitySummary[] | BaseResponse<FaceIdentitySummary[]>>(
+    request,
+    `/faces/identities?skip=0&limit=100&types=named`,
+    token,
+  )
+  if (!res.ok) {
+    if (skipIfUnreachable(testInfo, res.status)) return { ok: false }
+    testInfo.skip(true, `Faces identities (named) endpoint failed (HTTP ${res.status})`)
+    return { ok: false }
+  }
+  const identities = Array.isArray(res.data) ? res.data : (res.data as BaseResponse<FaceIdentitySummary[]>).data ?? []
+  if (identities.length === 0) {
+    testInfo.skip(
+      true,
+      `Need at least 1 NAMED face identity for this case (filtering types=named), found 0. Name an identity first or run a prior people case that names one.`,
+    )
+    return { ok: false }
+  }
+  return { ok: true, identity: identities[0] }
+}
+
 /** 探测至少一个含封面照片的人物（face_count > 0）。 */
 export async function requireIdentityWithPhotos(
   request: APIRequestContext,

--- a/package/website/tests/e2e/specs/album/people-p1.spec.ts
+++ b/package/website/tests/e2e/specs/album/people-p1.spec.ts
@@ -3,6 +3,7 @@ import { test, expect, type APIRequestContext, type Page, type Locator } from '@
 import { ensureAuthSession, authHeaders } from '../../helpers/auth'
 import {
   requireAnyIdentity,
+  requireNamedIdentity,
   requireIdentityWithPhotos,
   type BaseResponse,
   type FaceIdentitySummary,
@@ -216,7 +217,9 @@ test.describe.serial('P1 - 人物相册', () => {
   })
 
   test('2.5.10 筛选 named - 关闭 unnamed 后 API 调用只带 types=named', async ({ page, request }, testInfo) => {
-    const probe = await requireAnyIdentity(request, testInfo)
+    // 本用例会把筛选切到 types=named 并断言列表渲染，必须有「已命名」身份；
+    // requireAnyIdentity 接受 unnamed，named 列表为空时 .flow-grid 不渲染会误报。
+    const probe = await requireNamedIdentity(request, testInfo)
     if (!probe.ok) return
 
     await gotoRetry(page, '/album/people')


### PR DESCRIPTION
合入 #82 后 master 两次 run（push 30191019103 + nightly 30191450307）都挂在 people-p1:218「2.5.10 筛选 named」：关闭 unnamed 后断言 .flow-grid 可见，但 named 列表为空。

根因：2.5.10 用 requireAnyIdentity（接受 named 或 unnamed）做前置探针，随后切到 types=named。若当时只有 unnamed 身份（命名身份依赖其它用例先跑，跨 worker 顺序不保证），named 列表空 → .flow-grid 不渲染 → 误报失败。PR run 里命名身份恰好先就绪故通过，master run 顺序不同故挂。

修法：新增 requireNamedIdentity（只取 types=named，缺则 skip），2.5.10 改用。无命名身份时 skip 而非 fail，与其它 require* 探针一致。不改并发模型（PEOPLE_MUTEX 仍在）。

I have read and agree to the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)