### PR TITLE
test(e2e): 修复 00-setup / 位置卡片 / 人物批量隐藏三处偶发失败

### DIFF
--- a/package/website/playwright/service-manager.mjs
+++ b/package/website/playwright/service-manager.mjs
@@ -3,7 +3,9 @@ import path from 'node:path'
 
 export async function isPortInUse(port) {
   try {
-    const res = await fetch(`http://localhost:${port}/system/version`, { signal: AbortSignal.timeout(2000) })
+    // 用 127.0.0.1 而非 localhost：Windows 下 localhost 可能先解析到 IPv6 ::1，
+    // 若服务只绑了 IPv4 会误判端口空闲（参见 commit 2569165 健康检查同类问题）。
+    const res = await fetch(`http://127.0.0.1:${port}/system/version`, { signal: AbortSignal.timeout(2000) })
     return res.ok || res.status < 500
   } catch {
     return false
@@ -17,15 +19,20 @@ export async function startServices() {
   const serverRunning8000 = await isPortInUse(8000)
   const serverRunning8800 = await isPortInUse(8800)
   const serverRunning = serverRunning8000 || serverRunning8800
-  
+
   if (serverRunning) {
     console.log('Services are already running.')
+    // 只在未设置时兜底，绝不覆盖 .env.test 已注入的 TS_API_BASE_URL / TS_WEB_BASE_URL。
+    // photo-fixtures 的 state cache 以 apiBaseUrl 为 key（photo-fixtures.ts getStatePaths），
+    // scan-prep 用的是 .env.test 里的 127.0.0.1:8000；若这里把 127.0.0.1 改写成 localhost，
+    // full_setup 阶段会算出不同的 cache key → 缓存未命中 → 00-setup 重复 POST /settings/directories，
+    // 撞上瞬时状态就回 400 Path does not exist。统一用 127.0.0.1 也可避开 IPv6 ::1 歧义。
     if (serverRunning8800) {
-      process.env.TS_API_BASE_URL = 'http://localhost:8800'
-      process.env.TS_WEB_BASE_URL = 'http://localhost:8082'
+      process.env.TS_API_BASE_URL ??= 'http://127.0.0.1:8800'
+      process.env.TS_WEB_BASE_URL ??= 'http://127.0.0.1:8082'
     } else {
-      process.env.TS_API_BASE_URL = 'http://localhost:8000'
-      process.env.TS_WEB_BASE_URL = 'http://localhost:5176'
+      process.env.TS_API_BASE_URL ??= 'http://127.0.0.1:8000'
+      process.env.TS_WEB_BASE_URL ??= 'http://127.0.0.1:5176'
     }
     return { startedByUs: false }
   }
@@ -35,8 +42,8 @@ export async function startServices() {
   if (isCI || isDocker) {
     // Docker compose start
     execSync('node playwright/e2e-up.mjs up', { stdio: 'inherit' })
-    process.env.TS_API_BASE_URL = 'http://localhost:8800'
-    process.env.TS_WEB_BASE_URL = 'http://localhost:8082'
+    process.env.TS_API_BASE_URL ??= 'http://127.0.0.1:8800'
+    process.env.TS_WEB_BASE_URL ??= 'http://127.0.0.1:8082'
     return { startedByUs: true, method: 'docker' }
   } else {
     // Dev environment start
@@ -62,8 +69,8 @@ export async function startServices() {
       retries--
     }
     
-    process.env.TS_API_BASE_URL = 'http://localhost:8000'
-    process.env.TS_WEB_BASE_URL = 'http://localhost:5176'
+    process.env.TS_API_BASE_URL ??= 'http://127.0.0.1:8000'
+    process.env.TS_WEB_BASE_URL ??= 'http://127.0.0.1:5176'
     return { startedByUs: true, method: 'dev', processes: [serverProcess, aiProcess] }
   }
 }

--- a/package/website/tests/e2e/specs/album/location-p0.spec.ts
+++ b/package/website/tests/e2e/specs/album/location-p0.spec.ts
@@ -211,11 +211,21 @@ test.describe.serial('P0 - 位置相册', () => {
     const card = locationGridCard(page).first()
     await expect(card).toBeVisible({ timeout: 15_000 })
 
-    // 先挂导航监听再点击，消除 click-then-wait 竞态；锚定详情路由，避免误匹配列表页
-    await Promise.all([
-      page.waitForURL(/\/album\/location\/[^/?#]+/, { timeout: 15_000 }),
-      card.click(),
-    ])
+    // 卡片 @click → goToLocation → router.push 详情路由。偶发点击不触发导航
+    // （URL 停在列表页，waitForURL 干等到超时）：click 落在卡片正中的透明 overlay
+    // 上可能未冒泡，或负载下 router.push 未及时提交。改点稳定的 h3 标题（不在
+    // overlay 覆盖区），并重试点击直到 URL 命中详情路由——单次 click+wait 改成
+    // 多轮，吸收偶发 miss；任一轮触发导航即提前退出。
+    const heading = card.locator('h3')
+    await expect(heading).toBeVisible({ timeout: 10_000 })
+    const detailUrl = /\/album\/location\/[^/?#]+/
+    for (let attempt = 0; attempt < 4 && !detailUrl.test(page.url()); attempt += 1) {
+      await Promise.all([
+        page.waitForURL(detailUrl, { timeout: 6_000 }).catch(() => undefined),
+        heading.click().catch(() => undefined),
+      ])
+    }
+    await expect(page, 'card click should navigate to /album/location/:name').toHaveURL(detailUrl)
   })
 
   test('2.4.6 位置详情页加载 - 子标题"N 个项目"+ 至少一张照片 @p0', async ({ page, request }, testInfo) => {

--- a/package/website/tests/e2e/specs/album/people-p1.spec.ts
+++ b/package/website/tests/e2e/specs/album/people-p1.spec.ts
@@ -609,16 +609,16 @@ test.describe.serial('P1 - 人物相册', () => {
         await page.waitForTimeout(400)
       })
 
-      // 等 PeopleList 重新拉取（fetchIdentities 在 handleBulkHide finally 后触发）。
-      // 给网络请求一点时间，再用 filter 验证。
-      await page.waitForTimeout(500)
-
-      // 默认筛选（named+unnamed）下临时 identities 已隐藏 → 列表中找不到它们
+      // 等 PeopleList 重新拉取。handleBulkHide 里的 fetchIdentities() 是
+      // fire-and-forget（不 await），固定 waitForTimeout 在负载下来不及等它完成，
+      // 会读到残留卡片 → 误报 "should be hidden"。默认筛选（named+unnamed）会排除
+      // hidden，故隐藏落库 + 重拉后卡片必然从 DOM 消失；用 expect.poll 等到 0。
       for (const name of ids.map((_, i) => `P1-BatchHS-${i}-`)) {
         // 用 regex 而不是精确字符串（Date.now() 部分动态）
-        await page.waitForTimeout(500)
-        const after = await page.locator('.flow-grid > div').filter({ hasText: new RegExp(name) }).count()
-        expect(after, `identity ${name} should be hidden after batch hide`).toBe(0)
+        const hiddenCard = page.locator('.flow-grid > div').filter({ hasText: new RegExp(name) })
+        await expect
+          .poll(async () => hiddenCard.count(), { timeout: 15_000, message: `identity ${name} should be hidden after batch hide` })
+          .toBe(0)
       }
 
       // 验证后端：拿含 hidden 的列表，应能看到这些 identity 已 is_hidden=true。


### PR DESCRIPTION
## 改动

三处 e2e 偶发失败的修复，均在测试侧（`package/website/`），不动 production 代码：

### 1. `playwright/service-manager.mjs` — 00-setup `Path does not exist`
`startServices()` 无条件把 `TS_API_BASE_URL` 从 `.env.test` 的 `127.0.0.1:8000` 改写成 `localhost:8000`。photo-fixtures 的 state cache 以 `apiBaseUrl` 为 key，导致 scan-prep（127.0.0.1）写的缓存 full_setup（localhost）命中不到 → 00-setup 重复 POST `/settings/directories`，撞瞬时状态回 `400 Path does not exist`。

改为保写不覆盖（`??=`），并统一用 `127.0.0.1`（与 commit 2569165 健康检查同源，避开 Windows localhost → IPv6 ::1 歧义）。

### 2. `location-p0.spec.ts` 2.4.5 — 点击卡片跳详情偶发超时
`card.click()` 偶发不触发 `router.push`（URL 停列表页 → `waitForURL` 15s 超时）。改点稳定的 `h3` 标题（不在透明 overlay 覆盖区），并重试点击直到命中详情路由。

### 3. `people-p1.spec.ts` 2.5.17 — 批量隐藏后 count 误报
`handleBulkHide` 的 `fetchIdentities()` 是 fire-and-forget，固定 `waitForTimeout(500)` 在负载下来不及等重拉 → 残留卡片 `count=1` 误报。改 `expect.poll` 等卡片消失。

## 验证
- 本地 `run-tests.ps1 -Layer e2e -Level full`：00-setup 通过，211 passed。
- 本地 `-Layer e2e -Level p1`：73 passed（含 2.5.17）。
- 本地 `-Layer e2e -Level p0`：60 passed（含 2.4.5），跑两遍均通过。

## CLA
I have read and agree to the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)