### PR TITLE
test(nightly): cover moment_api / task_manager / notification_manager + region/screenshot components

### DIFF
--- a/package/server/tests/unit/test_moment_api.py
+++ b/package/server/tests/unit/test_moment_api.py
@@ -1,0 +1,78 @@
+"""Focused unit coverage for the moments REST router."""
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api import moment as moment_api
+from app.schemas.moment import MomentDayCaptionGenerateRequest, MomentDayCaptionUpsert
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _user():
+    return SimpleNamespace(id=uuid4())
+
+
+def test_upsert_day_caption_trims_text_and_marks_manual_source():
+    db = MagicMock()
+    user = _user()
+    expected = SimpleNamespace(caption="A clear morning")
+
+    with patch.object(moment_api.moment_crud, "upsert_caption", return_value=expected) as upsert:
+        result = moment_api.upsert_day_caption(
+            day=date(2026, 7, 29),
+            payload=MomentDayCaptionUpsert(caption="  A clear morning  "),
+            scope_type="all",
+            scope_id=None,
+            current_user=user,
+            db=db,
+        )
+
+    assert result is expected
+    upsert.assert_called_once_with(
+        db, user.id, "all", None, date(2026, 7, 29), "A clear morning", source="manual"
+    )
+
+
+def test_list_day_captions_rejects_inverted_date_range():
+    with patch.object(moment_api.moment_crud, "list_captions") as list_captions:
+        with pytest.raises(HTTPException) as exc_info:
+            moment_api.list_day_captions(
+                start=date(2026, 7, 30),
+                end=date(2026, 7, 29),
+                current_user=_user(),
+                db=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 400
+    assert "start" in exc_info.value.detail
+    list_captions.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_day_caption_maps_service_value_error_to_http_400():
+    request = MomentDayCaptionGenerateRequest(
+        day=date(2026, 7, 29),
+        stream=False,
+    )
+
+    with patch.object(
+        moment_api,
+        "generate_caption_sync",
+        new=AsyncMock(side_effect=ValueError("invalid timezone")),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await moment_api.generate_day_caption(
+                request=request,
+                current_user=_user(),
+                db=MagicMock(),
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "invalid timezone"

--- a/package/server/tests/unit/test_notification_manager_service.py
+++ b/package/server/tests/unit/test_notification_manager_service.py
@@ -1,0 +1,57 @@
+"""Unit coverage for user-scoped notification pub/sub."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.service.notification_manager import NotificationManager
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
+
+
+def test_targeted_publish_reaches_matching_and_legacy_broadcast_subscribers():
+    manager = NotificationManager()
+    alice = manager.subscribe("alice")
+    bob = manager.subscribe("bob")
+    legacy = manager.subscribe(None)
+
+    manager.publish_to_user("alice", "notification.created", {"id": 7})
+
+    expected = {"event": "notification.created", "data": {"id": 7}}
+    assert alice.get_nowait() == expected
+    assert bob.empty()
+    assert legacy.get_nowait() == expected
+
+
+def test_none_user_broadcasts_to_every_subscriber():
+    manager = NotificationManager()
+    queues = [manager.subscribe("alice"), manager.subscribe("bob")]
+
+    manager.publish_to_user(None, "system.notice", {"message": "maintenance"})
+
+    for queue in queues:
+        assert queue.get_nowait() == {
+            "event": "system.notice",
+            "data": {"message": "maintenance"},
+        }
+
+
+def test_attached_loop_schedules_publish_and_unsubscribe_removes_queue():
+    manager = NotificationManager()
+    queue = manager.subscribe("alice")
+    loop = MagicMock()
+    manager.attach_loop(loop)
+
+    manager.publish_to_user("alice", "notification.read", {"id": 3})
+
+    loop.call_soon_threadsafe.assert_called_once_with(
+        manager._do_publish,
+        "alice",
+        "notification.read",
+        {"id": 3},
+    )
+    assert queue.empty()
+
+    manager.unsubscribe(queue)
+    assert manager._subscribers == []

--- a/package/server/tests/unit/test_task_manager_service.py
+++ b/package/server/tests/unit/test_task_manager_service.py
@@ -1,0 +1,60 @@
+"""Unit coverage for task-manager pub/sub and worker cold starts."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.service.task_manager import TaskManager
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
+
+
+def test_publish_event_delivers_envelope_and_unsubscribe_stops_delivery():
+    manager = TaskManager()
+    queue = manager.subscribe()
+
+    with patch("app.service.notification_manager.NotificationManager.get_instance") as get_notifications:
+        manager.publish_event("task.updated", {"id": "task-1"})
+
+    assert queue.get_nowait() == {
+        "event": "task.updated",
+        "data": {"id": "task-1"},
+    }
+    get_notifications.return_value.publish_to_user.assert_called_once()
+
+    manager.unsubscribe(queue)
+    manager.publish_event("task.updated", {"id": "task-2"})
+    assert queue.empty()
+
+
+def test_publish_event_drops_oldest_item_when_subscriber_queue_is_full():
+    manager = TaskManager()
+    queue = manager.subscribe()
+    for index in range(queue.maxsize):
+        queue.put_nowait({"event": "old", "data": {"index": index}})
+
+    with patch("app.service.notification_manager.NotificationManager.get_instance"):
+        manager.publish_event("task.updated", {"id": "latest"})
+
+    assert queue.qsize() == queue.maxsize
+    assert queue.get_nowait()["data"]["index"] == 1
+    last = None
+    while not queue.empty():
+        last = queue.get_nowait()
+    assert last == {"event": "task.updated", "data": {"id": "latest"}}
+
+
+def test_start_worker_publishes_snapshot_only_after_actual_start():
+    manager = TaskManager()
+
+    with patch.object(manager, "_start_worker_locked", side_effect=[False, True]) as start, patch.object(
+        manager, "_publish_active_tasks_snapshot"
+    ) as snapshot:
+        manager.start_worker_if_needed()
+        snapshot.assert_not_called()
+
+        manager.start_worker_if_needed()
+
+    assert start.call_count == 2
+    snapshot.assert_called_once_with()

--- a/package/website/tests/e2e/fixtures/nightly-view-host.html
+++ b/package/website/tests/e2e/fixtures/nightly-view-host.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nightly view host</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/tests/e2e/fixtures/nightly-view-host.ts"></script>
+  </body>
+</html>

--- a/package/website/tests/e2e/fixtures/nightly-view-host.ts
+++ b/package/website/tests/e2e/fixtures/nightly-view-host.ts
@@ -1,0 +1,107 @@
+import { createApp, defineComponent, h, onMounted, ref } from 'vue'
+import ElementPlus from 'element-plus'
+import { createPinia } from 'pinia'
+import 'element-plus/dist/index.css'
+import '@/style.css'
+
+import RegionDetailsPanel from '@/views/album/location/components/RegionDetailsPanel.vue'
+import ScreenshotCleanupDialog from '@/views/settings/ScreenshotCleanupDialog.vue'
+import type { AlbumImage } from '@/types/album'
+import type { TimelineNode } from '@/types/location'
+
+const fixture = new URLSearchParams(window.location.search).get('fixture') ?? 'region'
+const pixel =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+
+const photos: AlbumImage[] = [
+  {
+    id: 'region-photo-1',
+    url: pixel,
+    thumbnail: pixel,
+    preview: pixel,
+    srcset: '',
+    timestamp: Date.parse('2026-04-05T10:00:00Z'),
+    albumIds: [],
+    filename: 'east-lake.png',
+    file_type: 'image',
+    size: 1024,
+  },
+]
+
+const visits: TimelineNode[] = [
+  {
+    type: 'city',
+    startDate: '2026-04-05',
+    endDate: '2026-04-06',
+    locationName: '\u6b66\u6c49\u5e02',
+    level: 'city',
+    photoCount: 8,
+  },
+]
+
+const NightlyViewHost = defineComponent({
+  name: 'NightlyViewHost',
+  setup() {
+    const visible = ref(fixture === 'screenshots' ? false : true)
+    const events = ref<string[]>([])
+
+    const record = (event: string) => {
+      events.value = [...events.value, event]
+    }
+
+    onMounted(() => {
+      if (fixture === 'screenshots') visible.value = true
+    })
+
+    return () => {
+      let view
+
+      if (fixture === 'region' || fixture === 'region-empty') {
+        const empty = fixture === 'region-empty'
+        view = h(RegionDetailsPanel, {
+          level: empty ? 'city' : 'province',
+          selectedRegion: empty ? '\u6b66\u6c49\u5e02' : '\u6e56\u5317\u7701',
+          selectedRegionCount: empty ? 0 : 12,
+          regionPhotos: empty ? [] : photos,
+          regionTimeSpan: empty ? '' : '2024-2026',
+          regionFirstVisit: empty ? '' : '2024-05-01',
+          regionTags: empty ? [] : [{ name: '\u6c5f\u57ce', count: 4 }],
+          regionSubLevel: empty ? 'district' : 'city',
+          regionExploredCount: empty ? 0 : 3,
+          regionTotalCount: empty ? 4 : 6,
+          regionTopSubRegions: empty
+            ? []
+            : [
+                { name: '\u6b66\u6c49\u5e02', count: 8 },
+                { name: '\u9ec4\u77f3\u5e02', count: 4 },
+              ],
+          regionRecentVisits: empty ? [] : visits,
+          onClearSelection: () => record('clear-selection'),
+          onClickLocation: (name: string, level?: string) =>
+            record(`click-location:${name}:${level ?? 'none'}`),
+          onChangeLevel: (
+            level: string,
+            state: { parentRegion?: string },
+          ) => record(`change-level:${level}:${state.parentRegion ?? 'none'}`),
+        })
+      } else if (fixture === 'screenshots') {
+        view = h(ScreenshotCleanupDialog, {
+          modelValue: visible.value,
+          'onUpdate:modelValue': (value: boolean) => {
+            visible.value = value
+            record(`visible:${value}`)
+          },
+        })
+      } else {
+        view = h('p', { id: 'unknown-fixture' }, `Unknown fixture: ${fixture}`)
+      }
+
+      return h('main', { id: 'nightly-view-host' }, [
+        view,
+        h('pre', { id: 'event-log' }, events.value.join('\n')),
+      ])
+    }
+  },
+})
+
+createApp(NightlyViewHost).use(createPinia()).use(ElementPlus).mount('#app')

--- a/package/website/tests/e2e/specs/views-coverage/views-deeper-p7.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/views-deeper-p7.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from '@playwright/test'
+
+const hostPath = '/tests/e2e/fixtures/nightly-view-host.html'
+const pixel =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('P1 - nightly component coverage @views-coverage', () => {
+  test.beforeEach(async ({ page }) => {
+    // CI docker compose 首次加载时 Vite 需要 cold-transform Vue / Pinia /
+    // ElementPlus / RegionDetailsPanel.vue，domcontentloaded 触发时
+    // #nightly-view-host 还没挂载；把默认 timeout 提到 20s。
+    page.setDefaultTimeout(20_000)
+  })
+
+  async function mountFixture(page: any, fixture: string) {
+    await page.goto(`${hostPath}?fixture=${fixture}`, { waitUntil: 'load' })
+    const host = page.locator('#nightly-view-host')
+    await expect(host).toBeAttached({ timeout: 20_000 })
+    return host
+  }
+
+  test('RegionDetailsPanel renders metrics and emits navigation events', async ({ page }) => {
+    const host = await mountFixture(page, 'region')
+
+    await expect(host.getByRole('heading', { name: '\u6e56\u5317\u7701' })).toBeVisible()
+    await expect(host.getByText('12', { exact: true })).toBeVisible()
+    await expect(host.getByText('50%', { exact: true })).toBeVisible()
+    await expect(host.getByText('#\u6c5f\u57ce', { exact: true })).toBeVisible()
+    await expect(host.getByText('\u9ec4\u77f3\u5e02', { exact: true })).toBeVisible()
+    await expect(host.getByText('\u7cbe\u5f69\u77ac\u95f4', { exact: true })).toBeVisible()
+
+    await host.getByText('\u6b66\u6c49\u5e02', { exact: true }).first().click()
+    await expect(page.locator('#event-log')).toContainText('click-location:\u6b66\u6c49\u5e02:city')
+
+    await host.getByRole('button', { name: '\u8fdb\u5165\u57ce\u5e02\u5730\u56fe' }).click()
+    await expect(page.locator('#event-log')).toContainText('change-level:city:\u6e56\u5317\u7701')
+  })
+
+  test('RegionDetailsPanel renders empty states and clears selection', async ({ page }) => {
+    const host = await mountFixture(page, 'region-empty')
+
+    await expect(host.getByText('\u8fd9\u91cc\u8fd8\u662f\u4e00\u7247\u672a\u77e5\u9886\u57df\uff0c\u5feb\u53bb\u63a2\u7d22\u5427\uff01')).toBeVisible()
+    await expect(host.getByText('\u6682\u65e0\u6700\u8fd1\u8bbf\u95ee\u8bb0\u5f55')).toBeVisible()
+    await expect(host.getByText('\u6682\u65e0\u7167\u7247\u9884\u89c8')).toBeVisible()
+    await expect(host.getByText('0%', { exact: true })).toBeVisible()
+
+    await host.locator('button').first().click()
+    await expect(page.locator('#event-log')).toContainText('clear-selection')
+  })
+
+  test('ScreenshotCleanupDialog loads screenshots and totals their size', async ({ page }) => {
+    let requestUrl = ''
+    await page.route('**/api/storage/screenshots**', async (route) => {
+      requestUrl = route.request().url()
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 0,
+          msg: 'success',
+          data: [
+            {
+              id: 'capture-1',
+              url: pixel,
+              thumbnail: pixel,
+              preview: pixel,
+              srcset: '',
+              timestamp: 1,
+              albumIds: [],
+              filename: 'capture-a.png',
+              file_type: 'image',
+              size: 1024,
+            },
+            {
+              id: 'capture-2',
+              url: pixel,
+              thumbnail: pixel,
+              preview: pixel,
+              srcset: '',
+              timestamp: 2,
+              albumIds: [],
+              filename: 'capture-b.png',
+              file_type: 'image',
+              size: 2048,
+            },
+          ],
+        }),
+      })
+    })
+
+    const host = await mountFixture(page, 'screenshots')
+
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText('\u7ba1\u7406\u622a\u56fe\u4e0e\u8868\u60c5\u5305')).toBeVisible()
+    await expect(page.getByText('\u5171 2 \u5f20\u622a\u56fe\uff0c\u5360\u7528 3 KB')).toBeVisible()
+    await expect(page.locator('img[alt="capture-a.png"]')).toBeVisible()
+    expect(requestUrl).toContain('skip=0')
+    expect(requestUrl).toContain('limit=1000')
+  })
+
+  test('ScreenshotCleanupDialog renders its empty state', async ({ page }) => {
+    await page.route('**/api/storage/screenshots**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: [] }),
+      })
+    })
+
+    await mountFixture(page, 'screenshots')
+
+    await expect(page.getByText('\u592a\u68d2\u4e86\uff0c\u6ca1\u6709\u627e\u5230\u622a\u56fe\uff01')).toBeVisible()
+    await expect(page.getByText('\u5171 0 \u5f20\u622a\u56fe\uff0c\u5360\u7528 0 B')).toBeVisible()
+  })
+
+  test('ScreenshotCleanupDialog reports API failures', async ({ page }) => {
+    await page.route('**/api/storage/screenshots**', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 500, msg: 'storage unavailable', data: null }),
+      })
+    })
+
+    await mountFixture(page, 'screenshots')
+
+    await expect(page.locator('.el-message', { hasText: '\u52a0\u8f7d\u622a\u56fe\u5931\u8d25' })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## 摘要

夜间测试值守 2026-07-29 新增 5 模块 / 14 用例：

- `package/server/tests/unit/test_moment_api.py` — 3 用例 (happy/edge/error)
- `package/server/tests/unit/test_notification_manager_service.py` — 3 用例
- `package/server/tests/unit/test_task_manager_service.py` — 3 用例
- `package/website/tests/e2e/specs/views-coverage/views-deeper-p7.spec.ts` — 5 用例
  - `RegionDetailsPanel` 渲染指标 + 触发导航 (2)
  - `ScreenshotCleanupDialog` 加载截图 + 总额 + 错误态 (3)
- `package/website/tests/e2e/fixtures/nightly-view-host.{ts,html}` — 自包含 host fixture，无需后端实例

## 改动范围（按 §0 影响范围）

- ✅ `package/server/tests/unit/`
- ✅ `package/website/tests/e2e/`

无业务代码 / 数据库迁移 / 跨边界改动。

## 测试结果

- 单 worker 复跑所有新用例：`pytest` 单元 + `playwright --grep` 全部 PASS
- 全量 e2e 240-249 passed（伴随已知 14 worker 并发 flake `views-deeper-p5.spec.ts:223` / `toolbox-pages.spec.ts:25` / `redirect.spec.ts:88`，单 worker 复跑均通过，属 C 类环境毛刺，与本 PR 无关）

## Checklist

- [x] 影响范围仅 §0 列出的路径
- [x] 未触碰 `tests/scripts/run-tests.ps1`
- [x] commit message 未含 `构建后端/前端/ai/cli` 字面量
- [x] 已阅读 CLA（AGPLv3）

🤖 Co-authored-by: Codex <noreply@openai.com>

Nightly watch run 2026-07-29
