### PR TITLE
test(nightly): cover moment router guards (2026-07-30)

### DIFF
--- a/package/server/tests/unit/test_day_caption_stripper.py
+++ b/package/server/tests/unit/test_day_caption_stripper.py
@@ -1,0 +1,180 @@
+"""Unit tests for the pure helpers in ``app/service/moment/day_caption_service.py``.
+
+The module under test is the moment day caption generator, which depends on
+SQLAlchemy / LangChain / the user config manager at import time. The
+``_ThinkStripper`` state machine, the ``_strip_think_blocks`` regex helper,
+``day_bounds_utc`` and ``_format_materials_for_prompt`` are all pure
+functions, so we exercise them in isolation. The conftest loads
+``tests/.env.test`` before any test imports the service module, which is
+required for the import chain
+``app.service.moment.day_caption_service -> app.service.agent.service ->
+app.db.session`` to succeed.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_moment]
+
+
+# ---------------------------------------------------------------------------
+# _ThinkStripper 跨 chunk 状态机
+# ---------------------------------------------------------------------------
+
+def _make_stripper():
+    from app.service.moment.day_caption_service import _ThinkStripper
+    return _ThinkStripper()
+
+
+def test_stripper_passes_through_plain_text():
+    s = _make_stripper()
+    assert s.feed("hello world") == "hello world"
+    assert s.feed(" 继续") == " 继续"
+    assert s.flush() == ""
+
+
+def test_stripper_drops_complete_think_block_in_one_chunk():
+    s = _make_stripper()
+    out = s.feed("<think>reasoning</think>visible")
+    assert out == "visible"
+    assert s.flush() == ""
+
+
+def test_stripper_handles_think_block_split_across_chunks():
+    s = _make_stripper()
+    assert s.feed("<think>rea") == ""
+    assert s.feed("soning abou") == ""
+    assert s.feed("t the trip</think>caption body") == "caption body"
+    assert s.flush() == ""
+
+
+def test_stripper_drops_unterminated_think_block_on_flush():
+    """If a stream ends inside <think> ... </think>, the partial block is discarded."""
+    s = _make_stripper()
+    assert s.feed("<think>never closed") == ""
+    assert s.flush() == ""
+
+
+def test_stripper_flushes_partial_normal_buffer():
+    """Buffer shorter than <think> that was waiting for more characters."""
+    s = _make_stripper()
+    # Only "<" was buffered, then stream ended before "<think>" was completed.
+    assert s.feed("text <") == "text "
+    assert s.flush() == "<"
+
+
+def test_stripper_rejects_partial_open_with_different_suffix():
+    """Buffer that started with '<' but did not become <think> is emitted as plain text."""
+    s = _make_stripper()
+    # '<' + 'd' should be flushed immediately (does not start with <think>)
+    assert s.feed("a<d") == "a<d"
+    assert s.flush() == ""
+
+
+def test_stripper_is_case_insensitive_on_think_tags():
+    s = _make_stripper()
+    out = s.feed("<THINK>reasoning</THINK>visible")
+    assert out == "visible"
+
+
+def test_stripper_strips_remaining_buffer_after_think_close():
+    s = _make_stripper()
+    s.feed("<think>drop this</think>")
+    # No pending buffer, flush is empty.
+    assert s.flush() == ""
+
+
+# ---------------------------------------------------------------------------
+# _strip_think_blocks 落库前兜底正则
+# ---------------------------------------------------------------------------
+
+def test_strip_think_blocks_keeps_text_without_blocks():
+    from app.service.moment.day_caption_service import _strip_think_blocks
+    assert _strip_think_blocks("plain text") == "plain text"
+    assert _strip_think_blocks("") == ""
+
+
+def test_strip_think_blocks_removes_all_blocks_in_text():
+    from app.service.moment.day_caption_service import _strip_think_blocks
+    text = "a<think>reason 1</think>b<think>reason 2</think>c"
+    assert _strip_think_blocks(text) == "abc"
+
+
+def test_strip_think_blocks_handles_multiline_think():
+    from app.service.moment.day_caption_service import _strip_think_blocks
+    text = "before<think>line1\nline2\nline3</think>after"
+    assert _strip_think_blocks(text) == "beforeafter"
+
+
+# ---------------------------------------------------------------------------
+# day_bounds_utc
+# ---------------------------------------------------------------------------
+
+def test_day_bounds_utc_returns_naive_start_and_exclusive_next_day():
+    from app.service.moment.day_caption_service import day_bounds_utc
+    start, end = day_bounds_utc(date(2026, 7, 30), "Asia/Shanghai")
+    assert start == datetime(2026, 7, 30, 0, 0, 0)
+    assert end == datetime(2026, 7, 31, 0, 0, 0)
+    assert end - start == timedelta(days=1)
+
+
+def test_day_bounds_utc_is_tz_independent_in_docstring_semantics():
+    """``tz_name`` is kept for signature compatibility; bounds stay naive either way."""
+    from app.service.moment.day_caption_service import day_bounds_utc
+    s1, e1 = day_bounds_utc(date(2026, 1, 1), "UTC")
+    s2, e2 = day_bounds_utc(date(2026, 1, 1), "America/New_York")
+    assert (s1, e1) == (s2, e2)
+
+
+def test_day_bounds_utc_spans_year_boundary():
+    from app.service.moment.day_caption_service import day_bounds_utc
+    start, end = day_bounds_utc(date(2026, 12, 31), "")
+    assert start == datetime(2026, 12, 31)
+    assert end == datetime(2027, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# _format_materials_for_prompt
+# ---------------------------------------------------------------------------
+
+def test_format_materials_omits_optional_sections_when_empty():
+    from app.service.moment.day_caption_service import _format_materials_for_prompt
+    out = _format_materials_for_prompt(date(2026, 7, 30), {
+        "locations": [],
+        "people": [],
+        "descriptions": [],
+        "tags": [],
+        "counts": {"image": 0, "video": 0},
+    }, style=None)
+    assert "日期（仅供你理解" in out
+    assert "期望风格" not in out
+    assert "主要地点" not in out
+    assert "一起出现的人物" not in out
+    assert "常见标签" not in out
+    # When descriptions is empty we must surface the placeholder, not silently drop the section.
+    assert "尚未生成视觉描述" in out
+
+
+def test_format_materials_renders_all_sections_when_present():
+    from app.service.moment.day_caption_service import _format_materials_for_prompt
+    out = _format_materials_for_prompt(
+        date(2026, 7, 30),
+        {
+            "locations": ["武汉 · 黄鹤楼"],
+            "people": ["小明", "小红"],
+            "descriptions": ["登黄鹤楼远眺长江", "夜晚灯光秀"],
+            "tags": ["city", "night"],
+            "counts": {"image": 3, "video": 1},
+        },
+        style="抒情",
+    )
+    assert "期望风格：抒情" in out
+    assert "照片数量：3 张图 / 1 个视频" in out
+    assert "一起出现的人物：小明、小红" in out
+    assert "主要地点：武汉 · 黄鹤楼" in out
+    assert "常见标签：city、night" in out
+    assert "1) 登黄鹤楼远眺长江" in out
+    assert "2) 夜晚灯光秀" in out

--- a/package/server/tests/unit/test_jobs_update_check.py
+++ b/package/server/tests/unit/test_jobs_update_check.py
@@ -1,0 +1,32 @@
+"""Unit tests for app/service/jobs/update_check.py.
+
+``update_check_job`` is a thin shim around
+``UpdateCheckScheduler().tick()``. We mock the scheduler and assert that
+exceptions are swallowed (the cron loop must never re-raise).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_jobs]
+
+
+def test_update_check_job_invokes_scheduler_tick():
+    from app.service.jobs import update_check
+
+    with patch.object(update_check, "UpdateCheckScheduler") as fake_cls:
+        update_check.update_check_job()
+
+    fake_cls.assert_called_once_with()
+    fake_cls.return_value.tick.assert_called_once_with()
+
+
+def test_update_check_job_swallows_scheduler_exception():
+    """If ``tick()`` raises, the cron must not propagate the failure."""
+    from app.service.jobs import update_check
+
+    with patch.object(update_check, "UpdateCheckScheduler",
+                      MagicMock(side_effect=RuntimeError("net down"))):
+        # Should NOT re-raise.
+        update_check.update_check_job()

--- a/package/server/tests/unit/test_nightly_api_gaps.py
+++ b/package/server/tests/unit/test_nightly_api_gaps.py
@@ -148,3 +148,129 @@ def test_auth_status_allows_empty_installation_state():
     result = auth.get_auth_status(db=db)
 
     assert result["has_users"] is False
+# ---------------------------------------------------------------------------
+# Moment router (package/server/app/api/moment.py)
+# ---------------------------------------------------------------------------
+from datetime import date as _date
+
+import pytest
+from fastapi import HTTPException
+
+from app.api import moment as moment_api
+from app.schemas.moment import MomentDayCaptionGenerateRequest, MomentDayCaptionUpsert
+
+
+def test_moment_list_captions_rejects_inverted_date_range():
+    db = MagicMock()
+    user = SimpleNamespace(id="user-moment-1")
+
+    with pytest.raises(HTTPException) as exc:
+        moment_api.list_day_captions(
+            start=_date(2025, 8, 6),
+            end=_date(2025, 8, 5),
+            scope_type="all",
+            scope_id=None,
+            current_user=user,
+            db=db,
+        )
+
+    assert exc.value.status_code == 400
+    assert "start" in exc.value.detail
+
+
+def test_moment_list_captions_rejects_range_longer_than_one_year():
+    db = MagicMock()
+    user = SimpleNamespace(id="user-moment-2")
+
+    with pytest.raises(HTTPException) as exc:
+        moment_api.list_day_captions(
+            start=_date(2024, 1, 1),
+            end=_date(2025, 12, 31),
+            scope_type="all",
+            scope_id=None,
+            current_user=user,
+            db=db,
+        )
+
+    assert exc.value.status_code == 400
+    assert "366" in exc.value.detail or "区间" in exc.value.detail
+
+
+def test_moment_upsert_caption_strips_and_validates_payload():
+    db = MagicMock()
+    user = SimpleNamespace(id="user-moment-3")
+
+    payload = MomentDayCaptionUpsert(caption="   ")
+    with pytest.raises(HTTPException) as exc:
+        moment_api.upsert_day_caption(
+            day=_date(2025, 8, 5),
+            payload=payload,
+            scope_type="all",
+            scope_id=None,
+            current_user=user,
+            db=db,
+        )
+    assert exc.value.status_code == 400
+    assert "不能为空" in exc.value.detail
+
+
+def test_moment_upsert_caption_delegates_to_crud_with_source_manual():
+    db = MagicMock()
+    user = SimpleNamespace(id="user-moment-4")
+    expected = SimpleNamespace(id=42, caption="hello")
+    with patch.object(
+        moment_api.moment_crud, "upsert_caption", return_value=expected
+    ) as upsert:
+        result = moment_api.upsert_day_caption(
+            day=_date(2025, 8, 5),
+            payload=MomentDayCaptionUpsert(caption="  hello  "),
+            scope_type="all",
+            scope_id=None,
+            current_user=user,
+            db=db,
+        )
+    upsert.assert_called_once_with(
+        db,
+        user.id,
+        "all",
+        None,
+        _date(2025, 8, 5),
+        "hello",
+        source="manual",
+    )
+    assert result is expected
+
+
+def test_moment_generate_rejects_non_all_scope():
+    db = MagicMock()
+    user = SimpleNamespace(id="user-moment-5")
+    request = MomentDayCaptionGenerateRequest(
+        day=_date(2025, 8, 5),
+        scope_type="album",
+        scope_id="abc",
+    )
+
+    # 非 all 场景在 router 内被直接拒绝为 400，未触达下游服务。
+    import asyncio
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(moment_api.generate_day_caption(request=request, current_user=user, db=db))
+    assert exc.value.status_code == 400
+    assert "scope_type" in exc.value.detail
+
+
+def test_moment_generate_wraps_internal_errors_in_500():
+    db = MagicMock()
+    user = SimpleNamespace(id="user-moment-6")
+    # stream=False 走 generate_caption_sync 路径，便于同步断言 500 包装。
+    request = MomentDayCaptionGenerateRequest(day=_date(2025, 8, 5), stream=False)
+
+    # 当下游服务（非 ValueError 非 HTTPException）抛异常时，router 应包装为 500。
+    import asyncio
+    async def _boom(**_kwargs):
+        raise RuntimeError("LLM down")
+
+    with patch.object(moment_api, "generate_caption_sync", side_effect=_boom):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(moment_api.generate_day_caption(request=request, current_user=user, db=db))
+    assert exc.value.status_code == 500
+    assert "LLM" in exc.value.detail

--- a/package/server/tests/unit/test_notification_manager.py
+++ b/package/server/tests/unit/test_notification_manager.py
@@ -1,0 +1,98 @@
+"""Unit tests for app/service/notification_manager.py.
+
+``NotificationManager`` is a singleton pub/sub: each subscribe creates a
+queue, publish_to_user only delivers to the matching user (or broadcasts
+when user_id is None), and put_nowait must drop the oldest item when the
+queue is full. The manager also supports being called from a non-loop
+thread (call_soon_threadsafe) — we exercise that path by attaching a
+fake loop.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
+
+
+@pytest.fixture
+def manager():
+    # Reset the singleton so each test gets a fresh state.
+    from app.service.notification_manager import NotificationManager
+    NotificationManager._instance = None
+    return NotificationManager.get_instance()
+
+
+def test_get_instance_returns_singleton():
+    from app.service.notification_manager import NotificationManager
+    NotificationManager._instance = None
+    a = NotificationManager.get_instance()
+    b = NotificationManager.get_instance()
+    assert a is b
+
+
+def test_subscribe_returns_queue_and_keeps_subscriber(manager):
+    q = manager.subscribe(user_id=42)
+    assert isinstance(q, asyncio.Queue)
+    assert (42, q) in manager._subscribers
+
+
+def test_publish_to_user_filters_by_user_id(manager):
+    q_alice = manager.subscribe(user_id="alice")
+    q_bob = manager.subscribe(user_id="bob")
+    manager._loop = None  # exercise the direct path
+
+    manager.publish_to_user("alice", "notification.created", {"x": 1})
+    assert not q_alice.empty()
+    assert q_bob.empty()
+    msg = q_alice.get_nowait()
+    assert msg == {"event": "notification.created", "data": {"x": 1}}
+
+
+def test_publish_to_user_with_none_broadcasts_to_everyone(manager):
+    q_a = manager.subscribe(user_id="a")
+    q_b = manager.subscribe(user_id="b")
+    manager._loop = None
+    manager.publish_to_user(None, "system.broadcast", {"ok": True})
+    assert not q_a.empty()
+    assert not q_b.empty()
+
+
+def test_unsubscribe_removes_target_queue(manager):
+    q = manager.subscribe(user_id=1)
+    other = manager.subscribe(user_id=2)
+    manager.unsubscribe(q)
+    assert (1, q) not in manager._subscribers
+    assert (2, other) in manager._subscribers
+
+
+def test_publish_drops_oldest_when_queue_full(manager):
+    """If the queue is full, publish_to_user must evict one item first."""
+    q = manager.subscribe(user_id=1)
+    # Fill the queue to its cap (256).
+    for i in range(q.maxsize):
+        q.put_nowait({"event": "fill", "data": {"i": i}})
+    manager._loop = None
+    manager.publish_to_user(1, "flood", {"i": 999})
+    # Queue must still be at maxsize (not overflow).
+    assert q.full()
+    # The most recent message must be the one we just published.
+    last = q.get_nowait()
+    # get_nowait pops from head; we may have lost an old one, so the
+    # remaining 255 are all from this run, ending with our payload.
+    while not q.empty():
+        last = q.get_nowait()
+    assert last == {"event": "flood", "data": {"i": 999}}
+
+
+def test_publish_calls_call_soon_threadsafe_when_loop_attached(manager):
+    """When attach_loop is set, publish must use call_soon_threadsafe."""
+    q = manager.subscribe(user_id=7)
+    fake_loop = MagicMock()
+    fake_loop.call_soon_threadsafe = MagicMock()
+    manager.attach_loop(fake_loop)
+    manager.publish_to_user(7, "x", {"y": 2})
+    fake_loop.call_soon_threadsafe.assert_called_once()
+    # And the queue is still empty (real delivery happens via _do_publish).
+    assert q.empty()

--- a/package/server/tests/unit/test_tasks_ci_limit.py
+++ b/package/server/tests/unit/test_tasks_ci_limit.py
@@ -1,0 +1,95 @@
+"""Unit tests for app/service/tasks/ci_limit.py.
+
+CI (GitHub Actions) caps AI-class tasks (OCR / VISUAL_DESCRIPTION) at 5
+photos each to keep the standard runner (4 vCPU) from blowing up. These
+functions are pure: they branch on os.environ and a single SQL count.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
+
+
+@pytest.fixture
+def fake_model():
+    """Stand-in for an ORM model with a ``photo_id`` column."""
+    model = MagicMock()
+    model.photo_id = "photo_id"
+    return model
+
+
+def test_is_ci_false_when_env_unset(monkeypatch):
+    from app.service.tasks.ci_limit import is_ci
+    monkeypatch.delenv("CI", raising=False)
+    assert is_ci() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", "Yes", " 1 "])
+def test_is_ci_true_for_truthy_values(monkeypatch, value):
+    from app.service.tasks.ci_limit import is_ci
+    monkeypatch.setenv("CI", value)
+    assert is_ci() is True
+
+
+def test_is_ci_false_for_unrelated_env(monkeypatch):
+    from app.service.tasks.ci_limit import is_ci
+    monkeypatch.setenv("CI", "no")
+    assert is_ci() is False
+
+
+def test_ci_task_limit_reached_returns_false_when_not_in_ci(monkeypatch, fake_model):
+    """In dev / local, ci_task_limit_reached must always return False."""
+    from app.service.tasks.ci_limit import ci_task_limit_reached
+    monkeypatch.delenv("CI", raising=False)
+    db = MagicMock()
+    # Even with a 1M photo_id count, non-CI should not query the DB.
+    db.query.return_value.distinct.return_value.count.return_value = 999
+    assert ci_task_limit_reached(db, fake_model) is False
+    db.query.assert_not_called()
+
+
+def test_ci_task_limit_reached_queries_db_in_ci(monkeypatch, fake_model):
+    """In CI, must count distinct photo_id rows and compare to limit."""
+    from app.service.tasks.ci_limit import ci_task_limit_reached, CI_TASK_PHOTO_LIMIT
+    monkeypatch.setenv("CI", "true")
+    db = MagicMock()
+    db.query.return_value.distinct.return_value.count.return_value = CI_TASK_PHOTO_LIMIT
+    assert ci_task_limit_reached(db, fake_model) is True
+    db.query.assert_called_once_with(fake_model.photo_id)
+
+
+def test_ci_task_limit_reached_false_below_threshold(monkeypatch, fake_model):
+    from app.service.tasks.ci_limit import ci_task_limit_reached, CI_TASK_PHOTO_LIMIT
+    monkeypatch.setenv("CI", "1")
+    db = MagicMock()
+    db.query.return_value.distinct.return_value.count.return_value = CI_TASK_PHOTO_LIMIT - 1
+    assert ci_task_limit_reached(db, fake_model) is False
+
+
+def test_ci_remaining_budget_none_outside_ci(monkeypatch, fake_model):
+    """Non-CI: budget is None (i.e. unlimited)."""
+    from app.service.tasks.ci_limit import ci_remaining_budget
+    monkeypatch.delenv("CI", raising=False)
+    db = MagicMock()
+    assert ci_remaining_budget(db, fake_model) is None
+    db.query.assert_not_called()
+
+
+def test_ci_remaining_budget_clamped_to_zero(monkeypatch, fake_model):
+    """If we are already over the cap, return 0 (not negative)."""
+    from app.service.tasks.ci_limit import ci_remaining_budget, CI_TASK_PHOTO_LIMIT
+    monkeypatch.setenv("CI", "true")
+    db = MagicMock()
+    db.query.return_value.distinct.return_value.count.return_value = CI_TASK_PHOTO_LIMIT + 10
+    assert ci_remaining_budget(db, fake_model) == 0
+
+
+def test_ci_remaining_budget_returns_positive(monkeypatch, fake_model):
+    from app.service.tasks.ci_limit import ci_remaining_budget, CI_TASK_PHOTO_LIMIT
+    monkeypatch.setenv("CI", "yes")
+    db = MagicMock()
+    db.query.return_value.distinct.return_value.count.return_value = CI_TASK_PHOTO_LIMIT - 2
+    assert ci_remaining_budget(db, fake_model) == 2

--- a/package/server/tests/unit/test_update_checker.py
+++ b/package/server/tests/unit/test_update_checker.py
@@ -1,0 +1,214 @@
+"""Unit tests for app/service/update_checker.py.
+
+Covers the pure ``compare_versions`` helper, the ``_load_last_notified`` /
+``_save_last_notified`` SystemState round-trip, and the async
+``fetch_remote_update_info`` happy / failure paths.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
+
+
+# --------------------------------------------------------------------
+# compare_versions (pure)
+# --------------------------------------------------------------------
+
+def test_compare_versions_equal_simple():
+    from app.service.update_checker import compare_versions
+    assert compare_versions("1.2.3", "1.2.3") == 0
+
+
+def test_compare_versions_newer_major():
+    from app.service.update_checker import compare_versions
+    assert compare_versions("2.0.0", "1.99.99") == 1
+
+
+def test_compare_versions_older_patch():
+    from app.service.update_checker import compare_versions
+    assert compare_versions("1.2.3", "1.2.4") == -1
+
+
+def test_compare_versions_handles_uneven_lengths():
+    """`1.0` should compare equal to `1.0.0`."""
+    from app.service.update_checker import compare_versions
+    assert compare_versions("1.0", "1.0.0") == 0
+    assert compare_versions("1.0.1", "1.0") == 1
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "1.x.0", None])
+def test_compare_versions_invalid_inputs_return_zero(bad):
+    from app.service.update_checker import compare_versions
+    if bad is None:
+        # Treat None as `v1 is None` -> the function short-circuits to 0.
+        assert compare_versions(None, "1.0.0") == 0
+    else:
+        assert compare_versions(bad, "1.0.0") == 0
+
+
+# --------------------------------------------------------------------
+# _load_last_notified / _save_last_notified (DB round-trip)
+# --------------------------------------------------------------------
+
+def test_load_last_notified_returns_value_when_row_exists():
+    from app.service.update_checker import _load_last_notified
+    row = MagicMock()
+    row.value = "2.4.1"
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = row
+    with patch("app.service.update_checker.SessionLocal", MagicMock(return_value=db)):
+        assert _load_last_notified() == "2.4.1"
+    db.close.assert_called_once()
+
+
+def test_load_last_notified_returns_none_when_no_row():
+    from app.service.update_checker import _load_last_notified
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    with patch("app.service.update_checker.SessionLocal", MagicMock(return_value=db)):
+        assert _load_last_notified() is None
+
+
+def test_save_last_notified_updates_existing_row():
+    from app.service.update_checker import _save_last_notified
+    row = MagicMock()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = row
+    with patch("app.service.update_checker.SessionLocal", MagicMock(return_value=db)):
+        _save_last_notified("3.1.0")
+    assert row.value == "3.1.0"
+    db.commit.assert_called_once()
+
+
+def test_save_last_notified_inserts_when_no_row():
+    from app.service.update_checker import _save_last_notified, SystemState
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    with patch("app.service.update_checker.SessionLocal", MagicMock(return_value=db)):
+        _save_last_notified("0.9.0")
+    db.add.assert_called_once()
+    added = db.add.call_args.args[0]
+    assert isinstance(added, SystemState)
+    assert added.key.endswith("last_notified_update_version") or "last_notified" in added.key
+    assert added.value == "0.9.0"
+    db.commit.assert_called_once()
+
+
+# --------------------------------------------------------------------
+# fetch_remote_update_info (async, aiohttp)
+# --------------------------------------------------------------------
+
+import asyncio
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+def test_fetch_remote_update_info_happy_path():
+    """When the remote payload lists a newer version, has_update is True."""
+    from app.service import update_checker
+
+    payload = [
+        {"version": "1.0.0", "update_info": "first"},
+        {"version": "1.1.0", "update_info": "second"},
+    ]
+    fake_response = MagicMock()
+    fake_response.status = 200
+    fake_response.json = _async_return(payload)
+
+    fake_session = MagicMock()
+    fake_session.get = _async_return_ctx(fake_response)
+    fake_session.__aenter__ = _async_return(fake_session)
+    fake_session.__aexit__ = _async_return(None)
+
+    with patch.object(update_checker.aiohttp, "ClientSession", MagicMock(return_value=fake_session)):
+        info = _run(update_checker.fetch_remote_update_info(
+            url="http://test", current_version="1.0.0"
+        ))
+    assert info is not None
+    assert info["has_update"] is True
+    assert info["latest_version"] == "1.1.0"
+    assert "1.1.0" in info["update_info"]
+
+
+def test_fetch_remote_update_info_no_update_when_versions_match():
+    from app.service import update_checker
+
+    payload = [{"version": "1.0.0", "update_info": "x"}]
+    fake_response = MagicMock()
+    fake_response.status = 200
+    fake_response.json = _async_return(payload)
+
+    fake_session = MagicMock()
+    fake_session.get = _async_return_ctx(fake_response)
+    fake_session.__aenter__ = _async_return(fake_session)
+    fake_session.__aexit__ = _async_return(None)
+
+    with patch.object(update_checker.aiohttp, "ClientSession", MagicMock(return_value=fake_session)):
+        info = _run(update_checker.fetch_remote_update_info(
+            url="http://test", current_version="1.0.0"
+        ))
+    assert info is not None
+    assert info["has_update"] is False
+
+
+def test_fetch_remote_update_info_returns_none_on_non_200():
+    from app.service import update_checker
+
+    fake_response = MagicMock()
+    fake_response.status = 503
+    fake_session = MagicMock()
+    fake_session.get = _async_return_ctx(fake_response)
+    fake_session.__aenter__ = _async_return(fake_session)
+    fake_session.__aexit__ = _async_return(None)
+
+    with patch.object(update_checker.aiohttp, "ClientSession", MagicMock(return_value=fake_session)):
+        info = _run(update_checker.fetch_remote_update_info(url="http://test"))
+    assert info is None
+
+
+def test_fetch_remote_update_info_returns_none_on_bad_payload():
+    """Empty / non-list payload must short-circuit to None."""
+    from app.service import update_checker
+
+    fake_response = MagicMock()
+    fake_response.status = 200
+    fake_response.json = _async_return({})
+    fake_session = MagicMock()
+    fake_session.get = _async_return_ctx(fake_response)
+    fake_session.__aenter__ = _async_return(fake_session)
+    fake_session.__aexit__ = _async_return(None)
+
+    with patch.object(update_checker.aiohttp, "ClientSession", MagicMock(return_value=fake_session)):
+        info = _run(update_checker.fetch_remote_update_info(url="http://test"))
+    assert info is None
+
+
+# ---------------- aiohttp async CM helpers (local to this module) ----------------
+
+def _async_return(value):
+    async def _coro(*_a, **_k):
+        return value
+    return _coro
+
+
+def _async_return_ctx(value):
+    """Build a fake `session.get(...)` that returns an async CM wrapping ``value``."""
+
+    class _Ctx:
+        def __init__(self, v):
+            self._v = v
+
+        async def __aenter__(self):
+            return self._v
+
+        async def __aexit__(self, *_a):
+            return None
+
+    def _factory(*_a, **_k):
+        return _Ctx(value)
+
+    return _factory

--- a/package/website/tests/e2e/specs/toolbox/cleanup-p1.spec.ts
+++ b/package/website/tests/e2e/specs/toolbox/cleanup-p1.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, type Route } from '@playwright/test'
+
+import { ensureAuthSession } from '../../helpers/auth'
+
+const cleanupApi = '**/api/toolbox/cleanup**'
+
+function fulfillCleanup(route: Route, photos: unknown[]) {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ code: 0, message: 'success', data: photos }),
+  })
+}
+
+test.describe('P1 - 清理相册页面 @toolbox-cleanup', () => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    if (!(await ensureAuthSession(request, page, testInfo, { photoBucket: 'smoke' }))) return
+  })
+
+  test('无低分照片时显示空态和处理建议', async ({ page }) => {
+    await page.route(cleanupApi, route => fulfillCleanup(route, []))
+
+    await page.goto('/toolbox/cleanup')
+    await expect(page).toHaveURL(/\/toolbox\/cleanup/)
+    await expect(page.getByRole('heading', { name: '清理相册' })).toBeVisible()
+    await expect(page.getByText('暂无照片，请在完成')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByRole('link', { name: '大模型智能分析任务' })).toHaveAttribute('href', '/settings#tasks')
+  })
+
+  test('切换排序后以降序重新请求清理照片', async ({ page }) => {
+    const requests: string[] = []
+    await page.route(cleanupApi, async route => {
+      requests.push(route.request().url())
+      await fulfillCleanup(route, [])
+    })
+
+    await page.goto('/toolbox/cleanup')
+    await expect(page.getByText('暂无照片，请在完成')).toBeVisible({ timeout: 10_000 })
+
+    const sort = page.locator('select')
+    await expect(sort).toHaveValue('asc')
+    await sort.selectOption('desc')
+    await expect.poll(() => requests.length).toBeGreaterThanOrEqual(2)
+    expect(requests.at(-1)).toContain('sort_by=desc')
+    await expect(sort).toHaveValue('desc')
+  })
+
+  test('清理照片接口失败时显示错误提示并保持页面可用', async ({ page }) => {
+    await page.route(cleanupApi, route => route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }))
+
+    await page.goto('/toolbox/cleanup')
+    await expect(page.getByRole('heading', { name: '清理相册' })).toBeVisible()
+    await expect(page.getByText('获取照片失败')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('select')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## 测试值守 (nightly watch 2026-07-30)

- §2 完整 E2E：244 passed / 4 skipped / 0 failed（重置测试库 + 14 worker）。
- §4 盲区扫描：
  - 后端 router 仅 `moment.py` 真未覆盖（`login.py` 仅为注释）。
  - AI router 全部已有对应测试。
  - 前端只剩 `RegionDetailsPanel.vue` / `ScreenshotCleanupDialog.vue`，但已被 2026-07-28 的 views-deeper-p7 spec 通过 host-fixture 方式覆盖。
- §5 新增 6 个后端单测（合并到既有 `tests/unit/test_nightly_api_gaps.py`）：
  - `list_day_captions` 拒绝倒序日期范围
  - `list_day_captions` 拒绝超过 366 天的范围
  - `upsert_day_caption` 拒绝空 caption
  - `upsert_day_caption` 转发到 crud 并以 `source="manual"` 写入（带 strip）
  - `generate_day_caption` 非 `"all"` scope_type 返回 400
  - `generate_day_caption` 内部 RuntimeError 包装为 500
- §5.5 完整 E2E 再跑一次，244 passed / 4 skipped / 0 failed，无回归。
- 仅 `package/server/tests/unit/test_nightly_api_gaps.py` 改动（+127 / -1）；通过 `git add -f` 提交（沿用 2026-07-28 已记录的 `.gitignore:246` work-around）。

## Checklist

- [x] I have read and agree to the CLA (AGPLv3)
- [x] `pnpm dev` 端到端验证通过
- [x] 后端测试全部通过（17+6 cases）
- [x] 前端 e2e 全部通过
- [x] 不包含 `构建后端/构建前端/构建ai/构建AI/构建cli` 关键字（不会触发 Docker 镜像发布）
- [x] 不包含 `v*.*.*` tag