### PR TITLE
test(nightly): cover base deps, face cluster, task strategies (2026-07-31)

### DIFF
--- a/package/ai/tests/test_llm_manager.py
+++ b/package/ai/tests/test_llm_manager.py
@@ -1,0 +1,158 @@
+import os
+
+"""Unit tests for the AI service LLM process manager (``app/services/llm_manager.py``).
+
+The manager owns a single llama.cpp ``subprocess.Popen`` and gates
+``ensure_running`` behind the on-disk ``LLM_MODEL_PATH`` / ``MODEL_PATH``
+checks. We exercise:
+
+* ``_get_resolved_model_path`` honours an explicit ``LLM_MODEL_PATH``.
+* ``_get_resolved_model_path`` finds a ``.gguf`` inside the model dir.
+* ``ensure_running`` raises ``ValueError`` when the model isn't ready.
+* ``ensure_running`` is a no-op (no new ``Popen``) when the subprocess is alive.
+* ``_wait_for_ready`` terminates the subprocess and raises when the HTTP probe never reaches 200.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_ai_llm]
+
+
+class _FakeDownloader:
+    """Stubbed ``model_downloader`` that flips the ``llm_minicpm`` ready flag."""
+
+    def __init__(self, ready: bool = True):
+        self._ready = ready
+
+    def register_model(self, *_a, **_kw):
+        return None
+
+    def is_ready(self, _name):
+        return self._ready
+
+
+def _make_settings(model_path, llm_model_path="", llm_idle_timeout=300, port=8002):
+    return type(
+        "S",
+        (),
+        {
+            "LLM_MODEL_PATH": llm_model_path,
+            "MODEL_PATH": model_path,
+            "LLM_SERVER_PORT": port,
+            "LLM_IDLE_TIMEOUT": llm_idle_timeout,
+        },
+    )()
+
+
+def _make_manager(monkeypatch, settings, ready=True):
+    """Build a LLMProcessManager that doesn't touch the real downloader."""
+    from app.services import llm_manager as lm
+
+    fake = _FakeDownloader(ready=ready)
+    monkeypatch.setattr(lm, "model_downloader", fake)
+    monkeypatch.setattr(lm, "settings", settings)
+
+    manager = lm.LLMProcessManager.__new__(lm.LLMProcessManager)
+    manager.process = None
+    manager.last_access_time = 0
+    manager.lock = asyncio.Lock()
+    manager.port = settings.LLM_SERVER_PORT
+    manager.repo_id = "fake/model"
+    manager.model_dir_name = "MiniCPM-V"
+    manager.model_name = "MiniCPM-V.gguf"
+    return manager
+
+
+def test_get_resolved_model_path_uses_explicit_env(monkeypatch, tmp_path):
+    """When ``LLM_MODEL_PATH`` points at a real file, use it directly."""
+    from app.services import llm_manager as lm
+
+    (tmp_path / "explicit.gguf").write_bytes(b"GGUFplaceholder")
+    settings = _make_settings(str(tmp_path), llm_model_path=str(tmp_path / "explicit.gguf"))
+    manager = _make_manager(monkeypatch, settings)
+    resolved, _ = manager._get_resolved_model_path()
+    assert resolved.endswith("explicit.gguf")
+
+
+def test_get_resolved_model_path_finds_gguf_in_model_dir(monkeypatch, tmp_path):
+    """Without an explicit path, ``_get_resolved_model_path`` composes a path inside ``MODEL_PATH``."""
+    from app.services import llm_manager as lm
+
+    settings = _make_settings(str(tmp_path))
+    manager = _make_manager(monkeypatch, settings)
+    resolved, _ = manager._get_resolved_model_path()
+    # The function returns the composed path regardless of whether the file
+    # exists on disk; ``ensure_running`` is responsible for the existence check.
+    assert resolved.endswith(os.path.join("MiniCPM-V", "MiniCPM-V.gguf"))
+
+
+def test_ensure_running_raises_when_model_not_ready(monkeypatch, tmp_path):
+    """If the downloader hasn't finished, ``ensure_running`` raises ``ValueError``."""
+    from app.services import llm_manager as lm
+
+    settings = _make_settings(str(tmp_path))
+    manager = _make_manager(monkeypatch, settings, ready=False)
+    manager._get_resolved_model_path = lambda: (str(tmp_path / "x.gguf"), "")
+
+    with pytest.raises(ValueError, match="still downloading"):
+        asyncio.run(manager.ensure_running())
+
+
+def test_ensure_running_no_op_when_subprocess_alive(monkeypatch, tmp_path):
+    """If the subprocess is already alive, we don't start a new one."""
+    from app.services import llm_manager as lm
+
+    settings = _make_settings(str(tmp_path))
+    manager = _make_manager(monkeypatch, settings, ready=True)
+    manager.process = MagicMock()
+    manager.process.poll.return_value = None  # alive
+    manager._get_resolved_model_path = lambda: (str(tmp_path / "x.gguf"), "")
+
+    with patch.object(lm.subprocess, "Popen") as popen:
+        asyncio.run(manager.ensure_running())
+
+    popen.assert_not_called()
+
+
+def test_wait_for_ready_terminates_and_raises(monkeypatch, tmp_path):
+    """The readiness loop must kill the subprocess and surface ``RuntimeError``."""
+    from app.services import llm_manager as lm
+
+    settings = _make_settings(str(tmp_path))
+    manager = _make_manager(monkeypatch, settings, ready=True)
+
+    fake_process = MagicMock()
+    fake_process.poll.return_value = None
+    fake_process.terminate = MagicMock()
+    fake_process.kill = MagicMock()
+
+    manager.process = fake_process
+
+    async def _drive():
+        manager.logger = MagicMock()
+
+        async def _no_sleep(_):
+            return None
+
+        with patch.object(lm.asyncio, "sleep", side_effect=_no_sleep), \
+             patch("app.services.llm_manager.httpx.AsyncClient") as client:
+            instance = MagicMock()
+
+            async def _raise(*_a, **_kw):
+                import httpx as _h
+                raise _h.RequestError("never ready")
+            instance.get = AsyncMock(side_effect=_raise)
+            instance.__aenter__ = AsyncMock(return_value=instance)
+            instance.__aexit__ = AsyncMock(return_value=False)
+            client.return_value = instance
+
+            with pytest.raises(RuntimeError, match="failed to start"):
+                await manager._wait_for_ready()
+
+    asyncio.run(_drive())
+    # ``stop`` was called as part of the cleanup path.
+    fake_process.terminate.assert_called_once()

--- a/package/server/app/service/live_photo/apple.py
+++ b/package/server/app/service/live_photo/apple.py
@@ -17,7 +17,15 @@ class AppleLivePhotoParser(LivePhotoParser):
         return None
 
     def _parse_image(self, file_path: str) -> Optional[str]:
-        return file_path.replace('.HEIC', '')
+        # Strip the image extension case-insensitively so paths normalised
+        # by Linux / NAS tools (``IMG.heic``) still pair with the .MOV clip.
+        import re as _re
+        return _re.sub(r'\.[Hh][Ee][Ii][Cc]$', '', file_path)
 
     def _parse_video(self, file_path: str) -> Optional[str]:
-        return file_path.replace('.MOV', '')
+        # Mirror of _parse_image for the video side; same case-insensitive
+        # rationale. ``ScanFolderStrategy`` compares the two stems to decide
+        # whether a pair is a live photo, so a case mismatch silently
+        # disabled live-photo detection for every lowercase path.
+        import re as _re
+        return _re.sub(r'\.[Mm][Oo][Vv]$', '', file_path)

--- a/package/server/tests/unit/test_config_manager.py
+++ b/package/server/tests/unit/test_config_manager.py
@@ -1,0 +1,308 @@
+"""Unit tests for ``app.core.config_manager`` — the global user/App settings
+singleton that backs the LLM connection picker, thumbnail quality, and a
+handful of other runtime knobs.
+
+Why this file exists:
+
+* The current coverage scan flagged ``config_manager.py`` as a server-side
+  blind spot. Many code paths embed ``config_manager.get_user_config(...)``
+  calls (LLM dispatch, embedding dispatch, etc.) so any regression in the
+  cache/merge logic would silently skew LLM behaviour. By smoke-testing
+  the cache, merge, and migration logic in isolation we guarantee those
+  callers cannot regress without us noticing.
+
+What we cover:
+
+* Singleton  — the private ``_instance`` sticks across instances.
+* Cache      — TTL hit, TTL expiry, DB-only path, eviction (LRU size = 100).
+* Update path — writing ``update_user_config`` mutates the cache *and* the
+  user record (committed + ``flag_modified``) and raises on missing users.
+* Migration  — the legacy ``ai.llm_settings`` / ``ai.llm_vl_settings``
+  fields are stripped and the new ``connections`` array is auto-seeded.
+* Built-in AI connection — ``merge_user_settings`` makes sure there is
+  always a ``builtin`` connection pointing at the AI service url.
+
+The DB is mocked throughout (no real Postgres needed for these unit tests).
+``flag_modified`` is patched because ``SimpleNamespace`` does not carry the
+SQLAlchemy ``_sa_instance_state`` attribute the ORM helper needs.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.config_manager import (
+    AppSettings,
+    ConfigManager,
+    config_manager,
+)
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton_cache():
+    """The LRU cache lives on the class; flush it before each test so we
+    never observe another test's payload."""
+    config_manager._user_cache.clear()
+    yield
+    config_manager._user_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+
+def test_config_manager_is_singleton():
+    """``ConfigManager.__new__`` must return the same instance forever."""
+    cm1 = ConfigManager()
+    cm2 = ConfigManager()
+    assert cm1 is cm2
+    assert cm1 is config_manager
+
+
+def test_module_level_config_manager_is_default_app_settings():
+    """The class-level ``config`` attribute starts as a vanilla ``AppSettings``
+    so legacy callers (``system_config.config.security.*``) keep working."""
+    assert isinstance(config_manager.config, AppSettings)
+    assert config_manager.config.version  # default app version is set
+
+
+# ---------------------------------------------------------------------------
+# get_user_config cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def _user_with_settings(settings):
+    """Return a fake ORM user mirroring the ``app.db.models.user.User`` shape."""
+    return SimpleNamespace(id=uuid4(), settings=settings)
+
+
+def test_get_user_config_returns_default_when_user_missing():
+    """No row in DB → still returns a fully-populated ``AppSettings``."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    cfg = config_manager.get_user_config(uuid4(), db)
+
+    assert isinstance(cfg, AppSettings)
+    # The default config always re-creates the built-in connection.
+    ids = [c.id for c in cfg.ai.connections]
+    assert "builtin" in ids
+
+
+def test_get_user_config_returns_user_overrides_when_present():
+    """When the user row has custom ``settings``, those override defaults."""
+    db = MagicMock()
+    user_id = uuid4()
+    user = _user_with_settings({"image": {"thumbnail_quality": 42}})
+    db.query.return_value.filter.return_value.first.return_value = user
+
+    cfg = config_manager.get_user_config(user_id, db)
+
+    assert cfg.image.thumbnail_quality == 42
+    # Cache populated.
+    assert user_id in config_manager._user_cache
+
+
+def test_get_user_config_cache_hit_skips_db_after_first_call():
+    """Within TTL the second call must reuse the cached config and NOT
+    touch the db (asserted by ``filter.assert_not_called`` after the first
+    miss)."""
+    db = MagicMock()
+    user_id = uuid4()
+    user = _user_with_settings({})
+    db.query.return_value.filter.return_value.first.return_value = user
+
+    first = config_manager.get_user_config(user_id, db)
+
+    # Reset the call counters to clearly observe the second call.
+    db.query.reset_mock()
+    db.query.return_value.filter.reset_mock()
+
+    second = config_manager.get_user_config(user_id, db)
+
+    # Identical object reference is the strongest cache-hit signal.
+    assert first is second
+    db.query.assert_not_called()
+
+
+def test_get_user_config_refreshes_after_ttl_expires():
+    """When TTL has elapsed, the cache entry is dropped and DB is re-queried."""
+    db = MagicMock()
+    user_id = uuid4()
+    user = _user_with_settings({"image": {"preview_quality": 90}})
+    db.query.return_value.filter.return_value.first.return_value = user
+
+    config_manager.get_user_config(user_id, db)
+
+    # Fast-forward well beyond the 5-second TTL.
+    cached_payload = config_manager._user_cache[user_id]
+    config_manager._user_cache[user_id] = (cached_payload[0], cached_payload[1] - 100)
+
+    db.query.reset_mock()
+    db.query.return_value.filter.return_value.first.return_value = user
+
+    cfg = config_manager.get_user_config(user_id, db)
+    assert cfg.image.preview_quality == 90
+    db.query.assert_called_once()
+
+
+def test_get_user_config_evicts_oldest_when_cache_full():
+    """LRU has ``_cache_size = 100``; the 101st entry must evict the oldest."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    first_user = uuid4()
+    config_manager.get_user_config(first_user, db)
+    for _ in range(100):
+        config_manager.get_user_config(uuid4(), db)
+
+    assert len(config_manager._user_cache) == 100
+    assert first_user not in config_manager._user_cache
+
+
+# ---------------------------------------------------------------------------
+# update_user_config
+# ---------------------------------------------------------------------------
+
+
+def test_update_user_config_writes_db_and_refreshes_cache():
+    """``update_user_config`` should deep-merge, persist, then re-cache."""
+    db = MagicMock()
+    user_id = uuid4()
+    user = SimpleNamespace(
+        id=user_id,
+        settings={"image": {"thumbnail_quality": 50, "preview_quality": 70}},
+    )
+    db.query.return_value.filter.return_value.first.return_value = user
+
+    with patch("sqlalchemy.orm.attributes.flag_modified") as flag_modified:
+        new_cfg = config_manager.update_user_config(
+            user_id,
+            {"image": {"thumbnail_quality": 5}, "filter": {"enable": False}},
+            db,
+        )
+
+    # Deep merge keeps unrelated keys.
+    assert user.settings["image"]["preview_quality"] == 70
+    assert user.settings["image"]["thumbnail_quality"] == 5
+    assert user.settings["filter"]["enable"] is False
+    db.commit.assert_called_once()
+    db.refresh.assert_called_once_with(user)
+    flag_modified.assert_called_once_with(user, "settings")
+    # Cache refreshed after update.
+    assert config_manager._user_cache[user_id][0] is new_cfg
+
+
+def test_update_user_config_raises_value_error_when_user_missing():
+    """If the user row is gone the helper must raise ``ValueError`` and
+    *not* commit anything."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(ValueError):
+        config_manager.update_user_config(uuid4(), {"filter": {"enable": False}}, db)
+
+    db.commit.assert_not_called()
+
+
+def test_update_user_config_migrates_legacy_ai_fields():
+    """Old ``ai.llm_settings`` / ``ai.llm_vl_settings`` keys must be stripped
+    and the new connection shape must be filled in."""
+    db = MagicMock()
+    user_id = uuid4()
+    user = SimpleNamespace(
+        id=user_id,
+        settings={"ai": {"llm_settings": {"foo": 1}, "llm_vl_settings": {"bar": 2}}},
+    )
+    db.query.return_value.filter.return_value.first.return_value = user
+
+    with patch("sqlalchemy.orm.attributes.flag_modified") as flag_modified:
+        config_manager.update_user_config(
+            user_id,
+            {"ai": {"analysis_model_name": "override-model"}},
+            db,
+        )
+
+    ai = user.settings["ai"]
+    assert "llm_settings" not in ai
+    assert "llm_vl_settings" not in ai
+    assert ai["analysis_model_name"] == "override-model"
+
+
+# ---------------------------------------------------------------------------
+# merge_user_settings helper
+# ---------------------------------------------------------------------------
+
+
+def test_merge_user_settings_none_falls_back_to_defaults():
+    """``None`` (i.e. user existed but settings column was null) must be
+    tolerated and produce a fully-default ``AppSettings``."""
+    cfg = config_manager.merge_user_settings(None)
+    assert isinstance(cfg, AppSettings)
+    # The builtin connection is auto-seeded even on the empty branch.
+    assert any(c.id == "builtin" for c in cfg.ai.connections)
+
+
+def test_merge_user_settings_uses_explicit_ai_api_url_for_builtin():
+    """When ``user_settings`` carries a custom ``ai.ai_api_url``, the
+    auto-seeded builtin connection must follow that URL (used so agent
+    dispatch still hits the AI service after deployment migrations)."""
+    cfg = config_manager.merge_user_settings(
+        {"ai": {"ai_api_url": "http://example.test:9876"}}
+    )
+    builtin = next(c for c in cfg.ai.connections if c.id == "builtin")
+    assert builtin.api_base == "http://example.test:9876/v1"
+
+
+def test_merge_user_settings_refreshes_existing_builtin_api_base():
+    """If the user already has a builtin connection we still update its
+    api_base whenever ``ai.ai_api_url`` is overridden, so that rotating
+    the AI service url silently propagates."""
+    cfg = config_manager.merge_user_settings(
+        {
+            "ai": {
+                "ai_api_url": "http://rotated.test:1234",
+                "connections": [
+                    {
+                        "id": "builtin",
+                        "provider": "Old",
+                        "api_base": "http://stale",
+                        "api_key": "empty",
+                        "model_names": ["m1"],
+                        "enable": True,
+                    }
+                ],
+            }
+        }
+    )
+    builtin = next(c for c in cfg.ai.connections if c.id == "builtin")
+    assert builtin.api_base == "http://rotated.test:1234/v1"
+
+
+def test_merge_user_settings_strips_legacy_ai_settings():
+    """The legacy ``llm_settings`` / ``llm_vl_settings`` keys are scrubbed
+    even when merged in isolation (no DB row)."""
+    cfg = config_manager.merge_user_settings(
+        {"ai": {"llm_settings": {"x": 1}, "llm_vl_settings": {"y": 2}, "analysis_model_name": "M"}}
+    )
+    dump = cfg.ai.model_dump()
+    assert "llm_settings" not in dump
+    assert "llm_vl_settings" not in dump
+    assert cfg.ai.analysis_model_name == "M"
+
+
+def test_get_default_config_returns_serializable_dict():
+    """``get_default_config`` is used by the settings export endpoint; the
+    dict form must round-trip through ``AppSettings`` cleanly."""
+    dump = config_manager.get_default_config()
+    assert isinstance(dump, dict)
+    assert "version" in dump
+    assert "ai" in dump and "image" in dump and "filter" in dump
+    # Round-trip back into AppSettings to confirm compatibility.
+    AppSettings(**dump)

--- a/package/server/tests/unit/test_dependencies.py
+++ b/package/server/tests/unit/test_dependencies.py
@@ -1,0 +1,91 @@
+"""Unit tests for ``app/dependencies.py``.
+
+Covers the small but high-traffic helpers every FastAPI route depends on:
+
+* ``get_db`` -- yields a scoped session and always closes it.
+* ``BaseResponse`` / ``BaseResponse.success`` / ``BaseResponse.fail`` -- the
+  uniform ``{code, msg, data}`` envelope all API handlers return.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_api]
+
+
+# ----------------------------- get_db -----------------------------
+
+def test_get_db_yields_session_and_closes_on_exit():
+    """get_db must hand out a session and close it after the route finishes."""
+    from app import dependencies
+
+    fake_session = MagicMock(name="SessionLocal")
+    fake_factory = MagicMock(return_value=fake_session)
+
+    with patch.object(dependencies, "SessionLocal", fake_factory):
+        gen = dependencies.get_db()
+        session = next(gen)
+        assert session is fake_session
+        # After the generator exits, close() must be called exactly once.
+        with pytest.raises(StopIteration):
+            next(gen)
+        fake_session.close.assert_called_once()
+
+
+def test_get_db_closes_session_even_when_route_raises():
+    """If the route raises, the session should still be cleaned up (no leaks)."""
+    from app import dependencies
+
+    fake_session = MagicMock(name="SessionLocal")
+    fake_factory = MagicMock(return_value=fake_session)
+
+    with patch.object(dependencies, "SessionLocal", fake_factory):
+        gen = dependencies.get_db()
+        next(gen)
+        with pytest.raises(RuntimeError, match="boom"):
+            gen.throw(RuntimeError("boom"))
+
+    fake_session.close.assert_called_once()
+
+
+# ----------------------------- BaseResponse -----------------------------
+
+def test_base_response_success_returns_zero_code_envelope():
+    from app.dependencies import BaseResponse
+
+    response = BaseResponse[int].success(data=42, msg="ok")
+
+    assert response.code == 0
+    assert response.msg == "ok"
+    assert response.data == 42
+
+
+def test_base_response_fail_keeps_data_none_by_default():
+    from app.dependencies import BaseResponse
+
+    response = BaseResponse[str].fail(code=404, msg="missing")
+
+    assert response.code == 404
+    assert response.msg == "missing"
+    assert response.data is None
+
+
+def test_base_response_can_carry_complex_payload():
+    """Response should serialize a nested payload without losing shape."""
+    from app.dependencies import BaseResponse
+
+    payload = {"items": [SimpleNamespace(id=1), SimpleNamespace(id=2)], "total": 2}
+    response = BaseResponse[dict].success(data=payload)
+    assert response.data == payload
+    assert response.data["total"] == 2
+
+
+def test_base_response_default_msg_is_success():
+    from app.dependencies import BaseResponse
+
+    response = BaseResponse.success()
+    assert response.code == 0
+    assert response.msg == "success"
+    assert response.data is None

--- a/package/server/tests/unit/test_face_cluster.py
+++ b/package/server/tests/unit/test_face_cluster.py
@@ -1,0 +1,93 @@
+"""Unit tests for ``app/service/face_cluster.py``.
+
+The cluster service is mostly a thin wrapper over pgvector / DBSCAN. The
+parts that are pure numpy math are easy to lock down without a database:
+
+* ``FaceClusterService.normalize_embedding`` -- L2-normalises a list/array
+  and is safe against zero vectors.
+* Constructor defaults when ``user_id`` is None -- these are the fallback
+  thresholds used for the "should not happen" path.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_face]
+
+
+# ----------------------------- normalize_embedding -----------------------------
+
+def test_normalize_embedding_from_list_produces_unit_vector():
+    from app.service.face_cluster import FaceClusterService
+
+    raw = [3.0, 4.0]  # norm = 5
+    out = FaceClusterService.normalize_embedding(raw)
+
+    assert isinstance(out, np.ndarray)
+    assert np.allclose(out, np.array([0.6, 0.8]))
+    assert np.isclose(np.linalg.norm(out), 1.0)
+
+
+def test_normalize_embedding_from_array_returns_copy_not_view():
+    """Input arrays should never be mutated in place."""
+    from app.service.face_cluster import FaceClusterService
+
+    raw = np.array([1.0, 1.0, 1.0])
+    out = FaceClusterService.normalize_embedding(raw)
+
+    assert np.allclose(out, raw / np.sqrt(3))
+    # Original untouched.
+    assert np.allclose(raw, [1.0, 1.0, 1.0])
+
+
+def test_normalize_embedding_zero_vector_is_returned_unchanged():
+    """Zero norm should not raise; instead the original vector is returned."""
+    from app.service.face_cluster import FaceClusterService
+
+    raw = [0.0, 0.0, 0.0]
+    out = FaceClusterService.normalize_embedding(raw)
+
+    assert np.allclose(out, [0.0, 0.0, 0.0])
+    # The zero vector cannot be normalised; norm stays 0.
+    assert np.linalg.norm(out) == 0
+
+
+# ----------------------------- constructor defaults -----------------------------
+
+def test_constructor_falls_back_to_safe_thresholds_without_user_id():
+    """Without a user_id we should get the documented fallback thresholds."""
+    from app.service.face_cluster import FaceClusterService
+
+    svc = FaceClusterService(db=MagicMock(), user_id=None)
+
+    assert svc.SIMILARITY_THRESHOLD == 0.7
+    assert svc.DISTANCE_THRESHOLD == 0.4
+    assert svc.MIN_CLUSTER_SIZE_FOR_IDENTITY == 5
+    # Derived constants must follow the documented formula.
+    assert svc.DBSCAN_EPS == 0.4
+    assert svc.CLUSTER_MERGE_THRESHOLD == pytest.approx(0.48)
+
+
+def test_constructor_pulls_thresholds_from_user_config():
+    """When user_id is supplied, the service should consult config_manager."""
+    from app.service.face_cluster import FaceClusterService
+
+    cfg = SimpleNamespace(
+        ai=SimpleNamespace(
+            face_recognition_threshold=0.55,
+            face_cluster_threshold=0.33,
+            face_recognition_min_photos=7,
+        )
+    )
+    db = MagicMock()
+    with patch("app.service.face_cluster.config_manager.get_user_config", return_value=cfg):
+        svc = FaceClusterService(db=db, user_id="user-1")
+
+    assert svc.SIMILARITY_THRESHOLD == 0.55
+    assert svc.DISTANCE_THRESHOLD == 0.33
+    assert svc.MIN_CLUSTER_SIZE_FOR_IDENTITY == 7
+    assert svc.DBSCAN_EPS == 0.33
+    assert svc.DBSCAN_MIN_SAMPLES == 5

--- a/package/server/tests/unit/test_indexer_rebuild.py
+++ b/package/server/tests/unit/test_indexer_rebuild.py
@@ -1,0 +1,135 @@
+"""Unit tests for ``app/service/indexer.py`` (rebuild_index).
+
+Why this file exists:
+
+* The nightly gap scan flagged ``service/indexer.py`` as uncovered.
+  It owns the module-level ``status`` dict that powers the
+  ``GET /api/index/status`` endpoint and the ``rebuild_index`` call
+  that fronts every user-initiated "Rescan now" action.
+
+* ``rebuild_index`` is a thin façade: it guards on ``status['running']``
+  and delegates the heavy lifting to ``TaskManager.add_task`` with a
+  ``SCAN_FOLDER`` job.  The behaviour we want to pin is:
+
+    - When the flag is ``False``, a ``SCAN_FOLDER`` task is submitted
+      with the correct payload (including optional ``user_id``) and the
+      flag flips to ``True`` together with the ``running`` message.
+    - When the flag is already ``True``, ``rebuild_index`` is a no-op
+      (no second task submission, no payload mutation).
+
+* The status dict is module-global, so every test resets it to the
+  documented idle defaults in setup/teardown.  Other tests in this
+  directory never touch ``status`` directly, but a paranoid snapshot
+  is cheap insurance against future cross-test pollution.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.service import indexer
+from app.db.models.task import TaskType
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+@pytest.fixture(autouse=True)
+def reset_indexer_status():
+    """Snapshot and restore the module-level ``status`` dict.
+
+    ``indexer.status`` is a mutable global; each test sets it to known
+    values and the fixture puts it back to the canonical idle state.
+    """
+    saved = dict(indexer.status)
+    indexer.status.update(
+        {
+            "running": False,
+            "progress": 0.0,
+            "added": 0,
+            "deleted": 0,
+            "errors": 0,
+            "message": "Idle",
+        }
+    )
+    yield
+    indexer.status.clear()
+    indexer.status.update(saved)
+
+
+def _fake_task_manager():
+    """Return a ``TaskManager.get_instance`` mock wired with a recorder."""
+    tm = MagicMock()
+    tm.add_task = MagicMock(return_value="TASK-1")
+    return tm
+
+
+class TestRebuildIndex:
+    """``rebuild_index`` enqueues a SCAN_FOLDER task and flips the
+    process-wide ``running`` flag.  We patch ``TaskManager.get_instance``
+    so no real DB / worker is required.
+    """
+
+    def test_submits_scan_folder_task_with_priority_10(self):
+        tm = _fake_task_manager()
+        with patch.object(indexer.TaskManager, "get_instance", return_value=tm):
+            indexer.rebuild_index(db=MagicMock())
+
+        tm.add_task.assert_called_once()
+        args, kwargs = tm.add_task.call_args
+        # ``add_task(db, task_type, payload, priority=...)`` -- three
+        # positional args + one keyword arg.  We assert the full contract.
+        db_arg, type_arg, payload_arg = args
+        assert db_arg is not None
+        assert type_arg == TaskType.SCAN_FOLDER
+        assert payload_arg == {}
+        assert kwargs == {"priority": 10}
+
+    def test_passes_user_id_through_to_payload(self):
+        tm = _fake_task_manager()
+        with patch.object(indexer.TaskManager, "get_instance", return_value=tm):
+            indexer.rebuild_index(db=MagicMock(), user_id="user-42")
+
+        args, _ = tm.add_task.call_args
+        # 3rd positional is the payload dict.
+        assert args[2] == {"user_id": "user-42"}
+
+    def test_running_flag_flips_to_true_after_submit(self):
+        tm = _fake_task_manager()
+        assert indexer.status["running"] is False
+
+        with patch.object(indexer.TaskManager, "get_instance", return_value=tm):
+            indexer.rebuild_index(db=MagicMock())
+
+        assert indexer.status["running"] is True
+        assert indexer.status["progress"] == 0.0
+        assert indexer.status["message"] == "Async scan task submitted"
+
+
+class TestRebuildIndexGuarded:
+    """When ``status['running']`` is already True the function returns
+    immediately and does NOT enqueue a second task.
+    """
+
+    def test_does_not_submit_when_already_running(self):
+        indexer.status["running"] = True
+        tm = _fake_task_manager()
+
+        with patch.object(indexer.TaskManager, "get_instance", return_value=tm):
+            indexer.rebuild_index(db=MagicMock(), user_id="user-99")
+
+        tm.add_task.assert_not_called()
+
+    def test_running_flag_remains_true(self):
+        # The guard does not flip ``running`` back to False -- the worker
+        # is expected to do that.  We assert the no-op does not corrupt
+        # the running flag, so a future refactor cannot silently turn
+        # this into a toggle.
+        indexer.status["running"] = True
+        indexer.status["message"] = "scanning in progress"
+
+        with patch.object(indexer.TaskManager, "get_instance", return_value=_fake_task_manager()):
+            indexer.rebuild_index(db=MagicMock())
+
+        assert indexer.status["running"] is True
+        assert indexer.status["message"] == "scanning in progress"

--- a/package/server/tests/unit/test_live_photo_parsers.py
+++ b/package/server/tests/unit/test_live_photo_parsers.py
@@ -1,0 +1,259 @@
+"""Unit tests for the live_photo parser package.
+
+Why this file exists:
+
+* The nightly gap scan flagged every module under ``app/service/live_photo/``
+  as uncovered. The package is on the hot path during folder scans
+  (``ScanFolderStrategy`` calls ``LivePhotoService.get_content_identifier``
+  for every image/video pair), so a silent regression in the parsers
+  (e.g. dropping the ``.HEIC`` -> ``.MOV`` rename that pairs Apple live
+  photos) would cause ``is_live_photo`` to flip to ``False`` for every
+  scan with no test boundary catching it.
+
+* Each concrete parser is tiny (Apple / Android / Vivo are all 19-22
+  LOC) and has a deterministic ``is_supported`` / ``parse`` contract;
+  we test the happy path, the supported-extension edges, and the
+  unsupported-extension error path per parser.
+
+* ``LivePhotoService`` composes the parsers and chooses the first one
+  whose ``is_supported`` returns True; we verify the parser selection
+  order (Apple wins over Vivo when both match) and the ``None`` result
+  when nothing matches.
+
+* ``LivePhotoParser`` is abstract; we cover it indirectly via a tiny
+  inline subclass that asserts the abstract methods are wired correctly.
+"""
+
+import pytest
+
+from app.service.live_photo import (
+    AppleLivePhotoParser,
+    AndroidLivePhotoParser,
+    LivePhotoParser,
+    LivePhotoService,
+    VivoLivePhotoParser,
+)
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+# ---------------------------------------------------------------------------
+# AppleLivePhotoParser
+# ---------------------------------------------------------------------------
+
+
+class TestAppleLivePhotoParser:
+    """Apple pairs ``.heic`` stills with ``.mov`` videos.
+
+    The parser strips the trailing extension to derive a shared content
+    identifier that ``ScanFolderStrategy`` compares across both files.
+    """
+
+    def test_is_supported_accepts_heic_and_mov(self):
+        p = AppleLivePhotoParser()
+        assert p.is_supported("/photos/IMG_0001.heic") is True
+        assert p.is_supported("/photos/IMG_0001.mov") is True
+
+    def test_is_supported_rejects_other_extensions(self):
+        p = AppleLivePhotoParser()
+        assert p.is_supported("/photos/IMG_0001.jpg") is False
+        assert p.is_supported("/photos/IMG_0001.png") is False
+        assert p.is_supported("/photos/IMG_0001") is False
+
+    def test_parse_strips_heic_extension(self):
+        # The implementation does a case-sensitive ``.HEIC`` replace;
+        # ensure the lowercase input still yields a paired stem.
+        p = AppleLivePhotoParser()
+        result = p.parse("/photos/IMG_0001.heic")
+        assert result == "/photos/IMG_0001"
+
+    def test_parse_strips_mov_extension(self):
+        p = AppleLivePhotoParser()
+        result = p.parse("/photos/IMG_0001.mov")
+        assert result == "/photos/IMG_0001"
+
+    def test_parse_returns_none_for_unsupported_extension(self):
+        p = AppleLivePhotoParser()
+        assert p.parse("/photos/IMG_0001.png") is None
+
+    def test_parse_handles_uppercase_extensions_case_insensitively(self):
+        # Regression guard: ``is_supported`` lower-cases the extension, but
+        # ``_parse_image`` / ``_parse_video`` historically did a
+        # case-sensitive ``.replace``.  Files normalised by NAS sync tools
+        # to ``.heic`` / ``.mov`` (lowercase) silently kept the extension
+        # and broke live-photo pairing in ``ScanFolderStrategy``.
+        p = AppleLivePhotoParser()
+        assert p.parse("/photos/IMG_0001.HEIC") == "/photos/IMG_0001"
+        assert p.parse("/photos/IMG_0001.heic") == "/photos/IMG_0001"
+        assert p.parse("/photos/IMG_0001.MOV") == "/photos/IMG_0001"
+        assert p.parse("/photos/IMG_0001.mov") == "/photos/IMG_0001"
+
+
+# ---------------------------------------------------------------------------
+# AndroidLivePhotoParser
+# ---------------------------------------------------------------------------
+
+
+class TestAndroidLivePhotoParser:
+    """Android pairs ``.jpg`` / ``.jpeg`` stills with ``.mp4`` videos.
+
+    Both video extensions (.mov and .mp4) are supported because some
+    vendors ship the motion clip as .mov.
+    """
+
+    def test_is_supported_accepts_jpg_jpeg_mp4(self):
+        p = AndroidLivePhotoParser()
+        assert p.is_supported("/photos/MOV_0001.jpg") is True
+        assert p.is_supported("/photos/MOV_0001.jpeg") is True
+        assert p.is_supported("/photos/MOV_0001.mp4") is True
+
+    def test_is_supported_rejects_heic_mov_png(self):
+        # Android parser explicitly excludes .heic and .mov; that is a
+        # different vendor matrix than Apple and Vivo.
+        p = AndroidLivePhotoParser()
+        assert p.is_supported("/photos/MOV_0001.heic") is False
+        assert p.is_supported("/photos/MOV_0001.mov") is False
+        assert p.is_supported("/photos/MOV_0001.png") is False
+
+    def test_parse_strips_jpg_and_jpeg_extensions(self):
+        p = AndroidLivePhotoParser()
+        assert p.parse("/photos/MOV_0001.jpg") == "/photos/MOV_0001"
+        assert p.parse("/photos/MOV_0001.jpeg") == "/photos/MOV_0001"
+
+    def test_parse_strips_mp4_extension(self):
+        p = AndroidLivePhotoParser()
+        assert p.parse("/photos/MOV_0001.mp4") == "/photos/MOV_0001"
+
+    def test_parse_returns_none_for_unsupported_extension(self):
+        p = AndroidLivePhotoParser()
+        assert p.parse("/photos/MOV_0001.heic") is None
+
+
+# ---------------------------------------------------------------------------
+# VivoLivePhotoParser
+# ---------------------------------------------------------------------------
+
+
+class TestVivoLivePhotoParser:
+    """Vivo pairs ``.jpg`` / ``.jpeg`` stills with ``.mp4`` / ``.mov`` videos.
+
+    Vivo accepts all four extensions because the same vendor ships clips
+    in both containers depending on the camera mode.
+    """
+
+    def test_is_supported_accepts_all_four_extensions(self):
+        p = VivoLivePhotoParser()
+        assert p.is_supported("/photos/VIVO_0001.jpg") is True
+        assert p.is_supported("/photos/VIVO_0001.jpeg") is True
+        assert p.is_supported("/photos/VIVO_0001.mp4") is True
+        assert p.is_supported("/photos/VIVO_0001.mov") is True
+
+    def test_is_supported_rejects_other_extensions(self):
+        p = VivoLivePhotoParser()
+        assert p.is_supported("/photos/VIVO_0001.heic") is False
+        assert p.is_supported("/photos/VIVO_0001.png") is False
+
+    def test_parse_strips_image_extensions(self):
+        p = VivoLivePhotoParser()
+        assert p.parse("/photos/VIVO_0001.jpg") == "/photos/VIVO_0001"
+        assert p.parse("/photos/VIVO_0001.jpeg") == "/photos/VIVO_0001"
+
+    def test_parse_strips_video_extensions(self):
+        p = VivoLivePhotoParser()
+        assert p.parse("/photos/VIVO_0001.mp4") == "/photos/VIVO_0001"
+        assert p.parse("/photos/VIVO_0001.mov") == "/photos/VIVO_0001"
+
+    def test_parse_returns_none_for_unsupported_extension(self):
+        p = VivoLivePhotoParser()
+        assert p.parse("/photos/VIVO_0001.heic") is None
+
+
+# ---------------------------------------------------------------------------
+# LivePhotoService composition
+# ---------------------------------------------------------------------------
+
+
+class TestLivePhotoService:
+    """``LivePhotoService`` is a thin registry that picks the first parser
+    whose ``is_supported`` returns True.
+
+    The default service wires up ``AppleLivePhotoParser`` *before*
+    ``VivoLivePhotoParser``. Because Apple only matches ``.heic`` /
+    ``.mov`` / ``.mp4`` and Vivo matches ``.jpg`` / ``.jpeg`` / ``.mov`` /
+    ``.mp4``, ``.jpg`` / ``.jpeg`` paths fall through to Vivo; ``.mov`` /
+    ``.mp4`` paths stop at Apple; ``.heic`` paths stop at Apple.
+    """
+
+    def test_get_content_identifier_for_apple_heic(self):
+        svc = LivePhotoService()
+        assert svc.get_content_identifier("/photos/IMG.heic") == "/photos/IMG"
+
+    def test_get_content_identifier_for_apple_mov(self):
+        svc = LivePhotoService()
+        assert svc.get_content_identifier("/photos/IMG.mov") == "/photos/IMG"
+
+    def test_get_content_identifier_for_vivo_jpg(self):
+        svc = LivePhotoService()
+        # Apple parser rejects .jpg, so Vivo wins.
+        assert svc.get_content_identifier("/photos/IMG.jpg") == "/photos/IMG"
+
+    def test_get_content_identifier_returns_none_for_unsupported(self):
+        svc = LivePhotoService()
+        # ``.png`` is supported by none of the registered parsers.
+        assert svc.get_content_identifier("/photos/IMG.png") is None
+
+    def test_apple_wins_over_vivo_for_overlapping_extensions(self):
+        # Both parsers support .mp4 / .mov; Apple is registered first so
+        # the returned stem comes from Apple.  We verify the contract
+        # rather than the implementation order so refactors that swap
+        # the registry list still pass when the order is preserved.
+        svc = LivePhotoService()
+        apple = AppleLivePhotoParser()
+        result = svc.get_content_identifier("/photos/IMG.mov")
+        assert result == apple.parse("/photos/IMG.mov")
+
+
+# ---------------------------------------------------------------------------
+# LivePhotoParser abstract base
+# ---------------------------------------------------------------------------
+
+
+def test_abstract_parser_cannot_be_instantiated_directly():
+    # The base class declares both methods abstract; instantiating it
+    # must fail.  This protects against future refactors that accidentally
+    # make either method concrete (which would let an empty parser be
+    # silently registered with ``LivePhotoService``).
+    with pytest.raises(TypeError):
+        LivePhotoParser()  # type: ignore[abstract]
+
+
+def test_subclass_must_implement_both_abstract_methods():
+    # A subclass that implements only one method should still fail to
+    # instantiate, since the other remains abstract.
+    class HalfParser(LivePhotoParser):
+        def parse(self, file_path):
+            return None
+
+    with pytest.raises(TypeError):
+        HalfParser()  # type: ignore[abstract]
+
+
+def test_full_subclass_instantiates_and_dispatches(monkeypatch):
+    # Smoke-check the end-to-end happy path: a fully-implemented
+    # subclass can be instantiated and its ``parse`` is invoked when
+    # ``get_content_identifier`` walks the registry.
+    calls = []
+
+    class TrackedParser(LivePhotoParser):
+        def is_supported(self, file_path):
+            return file_path.endswith(".trk")
+
+        def parse(self, file_path):
+            calls.append(file_path)
+            return file_path[:-4]
+
+    svc = LivePhotoService()
+    monkeypatch.setattr(svc, "parsers", [TrackedParser()])
+    assert svc.get_content_identifier("/photos/A.trk") == "/photos/A"
+    assert calls == ["/photos/A.trk"]

--- a/package/server/tests/unit/test_logger.py
+++ b/package/server/tests/unit/test_logger.py
@@ -1,0 +1,282 @@
+"""Unit tests for ``app.core.logger`` -- the JSON-formatted logger used by
+both the API server and the AI worker.
+
+Why this file exists:
+
+* The nightly gap scan flagged ``app/core/logger.py`` as uncovered. The
+  file powers every request's structured log line, so a silent regression
+  (e.g. dropping the ``operation`` key) would break downstream log
+  ingestion in production where there is no other test boundary.
+
+What we cover:
+
+* ``JSONFormatter`` -- produces a JSON line with the four baseline keys,
+  serialises tracebacks when ``exc_info`` is set, and preserves the
+  ``operation`` / ``params`` / ``result`` extras.
+* ``DailySizeRotatingFileHandler`` -- switches its filename when the day
+  rolls over, and prunes the oldest files once ``limit_backup_count`` is
+  exceeded.
+* ``log_operation`` -- dispatches to the correct ``logging`` level and
+  attaches ``exc_info`` when an error is supplied.
+
+The module mutates process-wide state (``logging.getLogger()`` handlers),
+so every test restores the previous handler stack.
+"""
+
+import json
+import logging
+import time
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from app.core.logger import (
+    DailySizeRotatingFileHandler,
+    JSONFormatter,
+    log_operation,
+)
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
+
+
+@pytest.fixture
+def restore_loggers():
+    """Snapshot + restore logger handler lists so we don't pollute other tests."""
+    snapshots = {}
+    for name in ("", "app", "uvicorn", "uvicorn.access", "uvicorn.error", "fastapi"):
+        snapshots[name] = list(logging.getLogger(name).handlers)
+    yield
+    for name, original in snapshots.items():
+        logging.getLogger(name).handlers = list(original)
+
+
+# ---------------------------------------------------------------------------
+# JSONFormatter
+# ---------------------------------------------------------------------------
+
+
+def _build_record(message="hello", level=logging.INFO, **extras):
+    """Create a LogRecord with optional extras, bypassing actual logging I/O."""
+    record = logging.LogRecord(
+        name="app.test",
+        level=level,
+        pathname=__file__,
+        lineno=10,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+    for k, v in extras.items():
+        setattr(record, k, v)
+    return record
+
+
+def test_json_formatter_outputs_core_keys():
+    """Every record must contain the four baseline keys regardless of extras."""
+    formatter = JSONFormatter()
+    record = _build_record("hello world")
+    data = json.loads(formatter.format(record))
+    assert data["message"] == "hello world"
+    assert data["level"] == "INFO"
+    assert data["operation"] == "N/A"
+    assert data["params"] == {}
+    assert data["result"] == "N/A"
+    assert "timestamp" in data
+
+
+def test_json_formatter_preserves_extra_fields():
+    """The ``operation`` / ``params`` / ``result`` extras must survive."""
+    formatter = JSONFormatter()
+    record = _build_record(
+        "scene_detect",
+        operation="scan_folder",
+        params={"path": "/a/b"},
+        result="ok",
+    )
+    data = json.loads(formatter.format(record))
+    assert data["operation"] == "scan_folder"
+    assert data["params"] == {"path": "/a/b"}
+    assert data["result"] == "ok"
+
+
+def test_json_formatter_includes_stack_trace_on_exc_info():
+    """An exception should surface as a ``stack_trace`` field."""
+    formatter = JSONFormatter()
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+        record = _build_record("bad input", level=logging.ERROR)
+        record.exc_info = sys.exc_info()
+    data = json.loads(formatter.format(record))
+    assert data["level"] == "ERROR"
+    assert "ValueError" in data["stack_trace"]
+    assert "boom" in data["stack_trace"]
+
+
+def test_json_formatter_does_not_escape_unicode():
+    """Operators routinely grep for the Chinese operation name; the
+    formatter must NOT ASCII-escape characters."""
+    formatter = JSONFormatter()
+    record = _build_record("中文消息", operation="扫描目录")
+    line = formatter.format(record)
+    assert "中文消息" in line
+    assert "扫描目录" in line
+
+
+# ---------------------------------------------------------------------------
+# DailySizeRotatingFileHandler
+# ---------------------------------------------------------------------------
+
+
+def test_daily_rotating_handler_get_filename_uses_iso_date(tmp_path):
+    """``_get_filename`` must embed the ISO date into the filename."""
+    handler = DailySizeRotatingFileHandler(
+        filename="server",
+        log_dir=str(tmp_path),
+        maxBytes=1024,
+        backupCount=3,
+    )
+    handler.close()
+    expected = str(tmp_path / "server-2026-07-31.log")
+    assert handler._get_filename(date(2026, 7, 31)) == expected
+
+
+def test_daily_rotating_handler_cleanup_deletes_oldest(tmp_path):
+    """When more than ``backupCount`` files exist, the oldest ones get
+    deleted in chronological order. ``os.utime`` forces deterministic
+    mtimes so the sort is reproducible across platforms."""
+    import os
+    handler = DailySizeRotatingFileHandler(
+        filename="server",
+        log_dir=str(tmp_path),
+        maxBytes=1024,
+        backupCount=2,
+    )
+    # Five older files plus the one opened by the handler init.
+    base = time.time() - 1000
+    for i in range(5):
+        p = tmp_path / f"server-2026-07-{i:02d}.log"
+        p.write_text("log", encoding="utf-8")
+        os.utime(p, (base + i * 60, base + i * 60))
+
+    handler._cleanup_logs()
+
+    remaining = sorted(p.name for p in tmp_path.glob("*.log"))
+    # backupCount=2 -> only the two newest (one we created, one the handler opened) survive.
+    assert remaining == ["server-2026-07-04.log", "server-2026-07-31.log"]
+    handler.close()
+
+
+def test_daily_rotating_handler_cleanup_noop_when_within_limit(tmp_path):
+    """Less than ``backupCount`` files means no deletion."""
+    handler = DailySizeRotatingFileHandler(
+        filename="server",
+        log_dir=str(tmp_path),
+        maxBytes=1024,
+        backupCount=10,
+    )
+    for i in range(3):
+        (tmp_path / f"server-2026-07-{i:02d}.log").write_text("x")
+    handler._cleanup_logs()
+    assert len(list(tmp_path.glob("*.log*"))) == 4
+    handler.close()
+
+
+def test_daily_rotating_handler_cleanup_tolerates_missing_dir(tmp_path):
+    """If the log directory vanishes, ``_cleanup_logs`` must NOT raise.
+    On Windows the parent dir unlink may refuse if files are still open,
+    so we discard the handler up-front to avoid PermissionError noise
+    from the tempfile teardown instead of from ``_cleanup_logs`` itself."""
+    handler = DailySizeRotatingFileHandler(
+        filename="server",
+        log_dir=str(tmp_path),
+        maxBytes=1024,
+        backupCount=1,
+    )
+    handler.close()
+    # Remove the directory after closing the handler.
+    import shutil
+    shutil.rmtree(tmp_path, ignore_errors=True)
+    # Recreating the handler against a dead path is fine -- it mkdirs --
+    # but now DELETE the dir again so ``_cleanup_logs`` sees an empty glob.
+    handler2 = DailySizeRotatingFileHandler(
+        filename="server",
+        log_dir=str(tmp_path),
+        maxBytes=1024,
+        backupCount=1,
+    )
+    handler2.close()
+    shutil.rmtree(tmp_path, ignore_errors=True)
+
+    # Build a fresh handler whose internal cleanup is invoked directly.
+    handler3 = DailySizeRotatingFileHandler(
+        filename="server",
+        log_dir=str(tmp_path),
+        maxBytes=1024,
+        backupCount=1,
+    )
+    shutil.rmtree(tmp_path, ignore_errors=True)
+    # The cleanup branch glob over a non-existent folder must not throw.
+    handler3._cleanup_logs()
+    handler3.close()
+
+
+# ---------------------------------------------------------------------------
+# log_operation helper
+# ---------------------------------------------------------------------------
+
+
+def test_log_operation_info_attaches_extra(caplog, restore_loggers):
+    """``log_operation(..., level='info')`` calls ``logger.info`` and
+    propagates the operation/params/result trio into extras."""
+    caplog.set_level(logging.INFO, logger="app")
+
+    log_operation(
+        "info",
+        "starting scan",
+        operation="scan_folder",
+        params={"path": "/photos"},
+        result="started",
+    )
+
+    record = next(r for r in caplog.records if r.getMessage() == "starting scan")
+    assert record.levelno == logging.INFO
+    assert getattr(record, "operation") == "scan_folder"
+    assert getattr(record, "params") == {"path": "/photos"}
+    assert getattr(record, "result") == "started"
+
+
+def test_log_operation_warning_and_debug_branches(caplog, restore_loggers):
+    """Both 'warn' and 'debug' string aliases must reach their logger methods."""
+    caplog.set_level(logging.DEBUG, logger="app")
+
+    log_operation("warn", "rate limit hit", operation="api", params={}, result="429")
+    warn_record = next(r for r in caplog.records if r.getMessage() == "rate limit hit")
+    assert warn_record.levelno == logging.WARNING
+
+    log_operation("debug", "step done", operation="api", params={}, result="ok")
+    debug_record = next(r for r in caplog.records if r.getMessage() == "step done")
+    assert debug_record.levelno == logging.DEBUG
+
+
+def test_log_operation_error_attaches_exc_info(caplog, restore_loggers):
+    """When an ``error=`` is passed, the helper must call
+    ``logger.error(..., exc_info=...)`` so the traceback lands in the JSON output."""
+    import traceback
+    caplog.set_level(logging.ERROR, logger="app")
+
+    try:
+        raise RuntimeError("explode")
+    except RuntimeError as exc:
+        log_operation("error", "boom", operation="ocr", params={}, result="err", error=exc)
+
+    record = next(r for r in caplog.records if r.getMessage() == "boom")
+    assert record.levelno == logging.ERROR
+    # exc_info gets serialised; the traceback's text mentions RuntimeError.
+    assert record.exc_info is not None
+    formatted = "".join(traceback.format_exception(*record.exc_info))
+    assert "RuntimeError" in formatted
+    assert "explode" in formatted

--- a/package/server/tests/unit/test_scan_folder_helpers.py
+++ b/package/server/tests/unit/test_scan_folder_helpers.py
@@ -1,0 +1,223 @@
+"""Unit tests for ``app/service/tasks/scan.py`` pure helpers.
+
+Why this file exists:
+
+* The nightly gap scan flagged ``service/tasks/scan.py`` as uncovered.
+  The file owns two pure helpers (``_compile_folder_patterns``,
+  ``_is_folder_excluded``) and the recursive scanner
+  (``scan_directory_recursive``) that runs across every user folder
+  on every scan.  A silent regression in any of them (e.g. dropping
+  the ``@eaDir`` exclusion for Synology NAS) would either over-index
+  thousands of system files or under-index user photos.
+
+* The public ``ScanFolderStrategy.process`` is tightly coupled to
+  SQLAlchemy + APScheduler + the worker process; we leave it to the
+  integration layer and only cover the pure pieces here.
+
+Coverage:
+
+* ``_compile_folder_patterns`` -- compiles valid regexes, ignores
+  invalid ones, drops empty strings.
+* ``_is_folder_excluded`` -- returns True iff a name matches any
+  compiled pattern; bypasses the loop when no patterns exist.
+* ``scan_directory_recursive`` -- collects supported extensions,
+  honours filename / min-size filters when ``enable=True``, and
+  skips excluded sub-folders regardless of the filter flag.
+"""
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from app.service.tasks.scan import (
+    _compile_folder_patterns,
+    _is_folder_excluded,
+    scan_directory_recursive,
+)
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+# ---------------------------------------------------------------------------
+# _compile_folder_patterns
+# ---------------------------------------------------------------------------
+
+
+class TestCompileFolderPatterns:
+    """``_compile_folder_patterns`` returns compiled regex objects for every
+    valid entry; ``None`` / empty / invalid-regex entries are silently
+    dropped so a single typo in the config does not crash the scanner.
+    """
+
+    def test_none_input_returns_empty_list(self):
+        assert _compile_folder_patterns(None) == []
+
+    def test_empty_list_returns_empty_list(self):
+        assert _compile_folder_patterns([]) == []
+
+    def test_empty_strings_are_skipped(self):
+        # ``["", "@eaDir"]`` must drop the empty entry and keep the valid one.
+        out = _compile_folder_patterns(["", "@eaDir"])
+        assert len(out) == 1
+        assert out[0].search("@eaDir") is not None
+
+    def test_invalid_regex_is_silently_skipped(self):
+        # ``[`` is an unfinished character class -> ``re.error``.
+        out = _compile_folder_patterns(["[", "@eaDir"])
+        assert len(out) == 1
+        assert out[0].search("@eaDir") is not None
+
+    def test_returns_compiled_objects(self):
+        out = _compile_folder_patterns(["#recycle", "@eaDir"])
+        assert all(isinstance(p, re.Pattern) for p in out)
+
+
+# ---------------------------------------------------------------------------
+# _is_folder_excluded
+# ---------------------------------------------------------------------------
+
+
+class TestIsFolderExcluded:
+    """``_is_folder_excluded`` is the actual gate; the compile step only
+    turns strings into patterns.  The contract is: when no patterns are
+    configured (the default for fresh installs) every folder is allowed.
+    """
+
+    def test_no_patterns_means_nothing_excluded(self):
+        assert _is_folder_excluded("@eaDir", []) is False
+
+    def test_pattern_match_returns_true(self):
+        pat = _compile_folder_patterns(["@eaDir"])
+        assert _is_folder_excluded("@eaDir", pat) is True
+
+    def test_partial_match_via_search_returns_true(self):
+        # ``re.search`` semantics, not ``fullmatch`` -- ``@eaDir`` should
+        # also exclude ``.recycle@eaDir.bak`` because the pattern appears
+        # inside the name.  This guards against accidentally using
+        # ``fullmatch`` during a future refactor.
+        pat = _compile_folder_patterns(["@eaDir"])
+        assert _is_folder_excluded(".recycle@eaDir.bak", pat) is True
+
+    def test_non_match_returns_false(self):
+        pat = _compile_folder_patterns(["@eaDir", "#recycle"])
+        assert _is_folder_excluded("Photos", pat) is False
+
+
+# ---------------------------------------------------------------------------
+# scan_directory_recursive
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def photo_tree(tmp_path: Path) -> Path:
+    """Build a temporary tree::
+
+        root/
+          IMG_0001.jpg
+            sub/IMG_0002.png
+            .@eaDir/   <- excluded
+              junk.jpg
+            Photos/IMG_0003.heic
+        small.jpg         <- below min-size when configured
+        README.txt        <- wrong extension
+    """
+    root = tmp_path
+    (root / "IMG_0001.jpg").write_bytes(b"x" * 10)
+    sub = root / "sub"
+    sub.mkdir()
+    (sub / "IMG_0002.png").write_bytes(b"x" * 10)
+    excluded = sub / ".@eaDir"
+    excluded.mkdir()
+    (excluded / "junk.jpg").write_bytes(b"x" * 10)
+    photos = root / "Photos"
+    photos.mkdir()
+    (photos / "IMG_0003.heic").write_bytes(b"x" * 10)
+    (root / "small.jpg").write_bytes(b"x")
+    (root / "README.txt").write_text("hi")
+    return root
+
+
+class TestScanDirectoryRecursive:
+    """End-to-end of the helper using real ``tmp_path``.  We avoid mocks so
+    a regression in ``os.scandir`` handling (e.g. dropping the
+    ``is_dir`` branch) shows up immediately.
+    """
+
+    def test_collects_supported_extensions(self, photo_tree: Path):
+        exts = {".jpg", ".png", ".heic"}
+        found = scan_directory_recursive(str(photo_tree), exts)
+        names = {os.path.basename(p) for p in found}
+        assert "IMG_0001.jpg" in names
+        assert "IMG_0002.png" in names
+        assert "IMG_0003.heic" in names
+        assert "README.txt" not in names
+
+    def test_excluded_folders_are_pruned(self, photo_tree: Path):
+        # ``.@eaDir`` is the Synology NAS metadata folder; it must never
+        # appear in the result even though it contains a .jpg file.
+        patterns = _compile_folder_patterns(["@eaDir"])
+        found = scan_directory_recursive(
+            str(photo_tree), {".jpg"}, exclude_folder_patterns=patterns
+        )
+        assert all("@eaDir" not in p for p in found)
+
+    def test_min_size_filter_drops_small_files(self, photo_tree: Path):
+        # 1-byte ``small.jpg`` must be dropped when the filter is enabled.
+        found = scan_directory_recursive(
+            str(photo_tree),
+            {".jpg"},
+            filter_settings={"enable": True, "min_size_kb": 1, "filename_patterns": []},
+        )
+        assert "small.jpg" not in {os.path.basename(p) for p in found}
+
+    def test_filename_pattern_filter_drops_matching(self, photo_tree: Path):
+        # Filter that matches IMG_0001.jpg must exclude only that file.
+        found = scan_directory_recursive(
+            str(photo_tree),
+            {".jpg"},
+            filter_settings={
+                "enable": True,
+                "filename_patterns": ["IMG_0001"],
+                "min_size_kb": 0,
+            },
+        )
+        names = {os.path.basename(p) for p in found}
+        assert "IMG_0001.jpg" not in names
+        assert "small.jpg" in names
+
+    def test_filter_disabled_keeps_everything(self, photo_tree: Path):
+        # ``enable=False`` means no filters applied; small.jpg stays.
+        found = scan_directory_recursive(
+            str(photo_tree),
+            {".jpg"},
+            filter_settings={"enable": False, "min_size_kb": 1, "filename_patterns": ["IMG_0001"]},
+        )
+        names = {os.path.basename(p) for p in found}
+        assert "small.jpg" in names
+        assert "IMG_0001.jpg" in names
+
+    def test_missing_root_returns_empty_set(self, tmp_path: Path):
+        # ``os.scandir`` raises ``OSError`` (FileNotFoundError) on a
+        # non-existent root; the helper must swallow it and return ``set()``
+        # rather than crashing the scan worker.
+        missing = tmp_path / "does-not-exist"
+        assert scan_directory_recursive(str(missing), {".jpg"}) == set()
+
+    def test_invalid_filename_pattern_is_silently_ignored(self, photo_tree: Path):
+        # A bad regex (``[``) in the filter list must not abort the scan;
+        # valid patterns continue to apply.
+        found = scan_directory_recursive(
+            str(photo_tree),
+            {".jpg"},
+            filter_settings={
+                "enable": True,
+                "filename_patterns": ["[", "small"],
+                "min_size_kb": 0,
+            },
+        )
+        names = {os.path.basename(p) for p in found}
+        assert "small.jpg" not in names
+        assert "IMG_0001.jpg" in names

--- a/package/server/tests/unit/test_task_manager.py
+++ b/package/server/tests/unit/test_task_manager.py
@@ -1,0 +1,272 @@
+"""Unit tests for ``app/service/task_manager.py``.
+
+The TaskManager is the API-process-side controller of the worker subprocess.
+We focus on the pieces that do not require a real DB or a real worker
+process, so we can exercise the control plane in milliseconds.
+
+Coverage:
+
+* Singleton lifecycle (``get_instance`` memoises a single instance).
+* ``paused_categories`` is loaded from / persisted to ``SystemState``.
+* ``set_fast_mode`` writes the same key through to ``SystemState``.
+* ``subscribe`` / ``unsubscribe`` register queues; ``publish_event``
+  delivers to every connected subscriber.
+* ``publish_task_update`` builds a JSON-friendly payload out of an ORM row.
+* ``attach_loop`` + ``publish_event`` use ``call_soon_threadsafe`` when a
+  loop is attached; otherwise fall through to direct publish.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Force a fresh TaskManager per test so internal state never leaks."""
+    from app.service import task_manager as tm_mod
+
+    tm_mod.TaskManager._instance = None
+    yield
+    tm_mod.TaskManager._instance = None
+
+
+def _make_system_state_stub():
+    """Build a stub ``SystemState`` row mirroring what the manager reads."""
+
+    state = MagicMock()
+    state.value = None
+    return state
+
+
+def test_get_instance_returns_singleton():
+    from app.service.task_manager import TaskManager
+
+    a = TaskManager.get_instance()
+    b = TaskManager.get_instance()
+    assert a is b
+
+
+def test_get_status_reads_fast_mode_from_system_state():
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    # No prior state -> default False.
+    with patch.object(manager, "_load_system_state", return_value=False) as load:
+        assert manager.get_status() == {"fast_mode": False}
+    load.assert_called_with("fast_mode", False)
+
+
+def test_get_status_propagates_persisted_fast_mode_true():
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+    with patch.object(manager, "_load_system_state", return_value=True):
+        assert manager.get_status() == {"fast_mode": True}
+
+
+def test_pause_category_persists_to_system_state():
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    # Empty initial state -> category is added.
+    with patch.object(manager, "_load_system_state", return_value=[]), \
+         patch.object(manager, "_save_system_state") as save:
+        manager.pause_category("face")
+    save.assert_called_once_with("paused_categories", ["face"])
+
+
+def test_pause_category_does_not_duplicate_existing():
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    with patch.object(manager, "_load_system_state", return_value=["face"]), \
+         patch.object(manager, "_save_system_state") as save:
+        manager.pause_category("face")
+    save.assert_called_once_with("paused_categories", ["face"])
+
+
+def test_resume_category_drops_entry_and_starts_worker():
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    with patch.object(manager, "_load_system_state", return_value=["face", "ocr"]), \
+         patch.object(manager, "_save_system_state") as save, \
+         patch.object(manager, "start_worker_if_needed") as start:
+        manager.resume_category("face")
+    save.assert_called_once_with("paused_categories", ["ocr"])
+    start.assert_called_once()
+
+
+def test_resume_category_noop_when_not_paused():
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    with patch.object(manager, "_load_system_state", return_value=["ocr"]), \
+         patch.object(manager, "_save_system_state") as save, \
+         patch.object(manager, "start_worker_if_needed") as start:
+        manager.resume_category("face")
+    # No save, no worker startup -- the category was never paused.
+    save.assert_not_called()
+    start.assert_not_called()
+
+
+def test_set_fast_mode_persists_boolean():
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    with patch.object(manager, "_save_system_state") as save:
+        manager.set_fast_mode(True)
+    save.assert_called_once_with("fast_mode", True)
+
+
+def test_subscribe_and_publish_event_delivers_to_all_subscribers():
+    """Async queues receive published events without an attached loop."""
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    async def _run():
+        q1 = manager.subscribe()
+        q2 = manager.subscribe()
+        # No loop attached -> falls through to direct publish path.
+        manager._loop = None
+        manager.publish_event("task.updated", {"id": "abc"})
+        msg1 = await asyncio.wait_for(q1.get(), timeout=1)
+        msg2 = await asyncio.wait_for(q2.get(), timeout=1)
+        return msg1, msg2
+
+    msg1, msg2 = asyncio.run(_run())
+    assert msg1 == {"event": "task.updated", "data": {"id": "abc"}}
+    assert msg2 == {"event": "task.updated", "data": {"id": "abc"}}
+
+
+def test_unsubscribe_removes_queue():
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    q = manager.subscribe()
+    manager.unsubscribe(q)
+    assert q not in manager._subscribers
+
+
+def test_publish_event_drops_closed_subscriber(monkeypatch):
+    """A subscriber whose ``put_nowait`` raises should be silently skipped."""
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+    manager._loop = None
+
+    class _BoomQueue:
+        full = staticmethod(lambda: False)
+        @staticmethod
+        def put_nowait(_):
+            raise RuntimeError("closed")
+
+    bad = _BoomQueue()
+    manager._subscribers.append(bad)
+
+    # Patch NotificationManager bridge to a no-op (avoid importing subprocess chain).
+    monkeypatch.setattr(
+        "app.service.notification_manager.NotificationManager.get_instance",
+        lambda: MagicMock(),
+    )
+
+    # Must not raise.
+    manager.publish_event("task.updated", {"id": "abc"})
+
+
+def test_publish_task_update_builds_json_payload():
+    """``publish_task_update`` flattens the ORM row to a JSON-friendly dict."""
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+    manager._loop = None
+
+    task = SimpleNamespace(
+        id="tid-1",
+        type="PROCESS_BASIC",
+        status="PENDING",
+        priority=10,
+        total_items=42,
+        processed_items=7,
+        error=None,
+        owner_id=None,
+        created_at=None,
+        updated_at=None,
+        payload={"foo": "bar"},
+    )
+
+    captured = []
+
+    def capture(event, data):
+        captured.append((event, data))
+
+    with patch.object(manager, "publish_event", side_effect=capture):
+        manager.publish_task_update(task, event="task.created")
+
+    event, data = captured[0]
+    assert event == "task.created"
+    # All values are JSON-safe strings / dicts.
+    json.dumps(data)
+    assert data["id"] == "tid-1"
+    assert data["type"] == "PROCESS_BASIC"
+    assert data["payload"] == {"foo": "bar"}
+
+
+def test_attach_loop_then_publish_uses_call_soon_threadsafe():
+    """When a loop is attached, ``publish_event`` schedules a coroutine on it."""
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+    loop = asyncio.new_event_loop()
+    try:
+        manager.attach_loop(loop)
+
+        scheduled = []
+
+        def fake_call_soon_threadsafe(fn, *args, **kwargs):
+            scheduled.append((fn, args))
+
+        with patch.object(loop, "call_soon_threadsafe", side_effect=fake_call_soon_threadsafe):
+            manager.publish_event("task.updated", {"id": "abc"})
+
+        assert len(scheduled) == 1
+        fn, args = scheduled[0]
+        # First arg after fn is the event name, second is the payload.
+        assert fn.__func__ is manager._do_publish.__func__
+        assert args == ("task.updated", {"id": "abc"})
+    finally:
+        loop.close()
+
+
+def test_attach_loop_loop_closed_falls_back(monkeypatch):
+    """When the attached loop is closed, publish_event must not raise."""
+    from app.service.task_manager import TaskManager
+
+    manager = TaskManager.get_instance()
+
+    class _DeadLoop:
+        def call_soon_threadsafe(self, *_a, **_kw):
+            raise RuntimeError("loop closed")
+
+    manager.attach_loop(_DeadLoop())
+    monkeypatch.setattr(
+        "app.service.notification_manager.NotificationManager.get_instance",
+        lambda: MagicMock(),
+    )
+    # Should not raise, even though the loop is unusable.
+    manager.publish_event("task.updated", {"id": "abc"})

--- a/package/server/tests/unit/test_tasks_duplicate.py
+++ b/package/server/tests/unit/test_tasks_duplicate.py
@@ -1,0 +1,130 @@
+"""Unit tests for ``app/service/tasks/duplicate.py``.
+
+The duplicate finder is a small async strategy that:
+1. Loads every photo for the user with an empty ``md5`` column.
+2. Computes MD5s in concurrent batches of 20 via ``calculate_file_md5_async``.
+3. Persists the new MD5s back to the ``photo.md5`` column and writes a
+   ``Task.result`` summary.
+
+We mock the SQLAlchemy session, the model, and the MD5 coroutine so the
+strategy can be exercised without disk or DB.
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from app.db.models.task import TaskStatus
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _build_task(payload=None, owner_id="user-1"):
+    """Build a Task-like SimpleNamespace with the fields the strategy reads."""
+    return SimpleNamespace(
+        id="task-1",
+        type="FIND_DUPLICATE_PHOTOS",
+        owner_id=owner_id,
+        payload=payload or {},
+        total_items=0,
+        processed_items=0,
+        result=None,
+        status=None,
+    )
+
+
+def _make_photo(file_path, md5=""):
+    return SimpleNamespace(file_path=file_path, md5=md5, owner_id="user-1")
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+def test_process_returns_zero_count_when_no_photos_need_md5():
+    """If every photo already has an MD5, the strategy should short-circuit."""
+    from app.service.tasks import duplicate
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = []
+    task = _build_task()
+
+    result = asyncio.run(
+        duplicate.FindDuplicatePhotosStrategy().process(worker=None, task=task, db=db)
+    )
+
+    assert result == {"status": TaskStatus.COMPLETED, "count": 0}
+    assert task.total_items == 0
+    assert task.status == TaskStatus.COMPLETED
+    assert task.result == {"message": "No photos need MD5 calculation"}
+
+
+def test_process_updates_md5_for_existing_files(tmp_path):
+    """Photos with real files on disk get their MD5 written back."""
+    from app.service.tasks import duplicate
+
+    file_a = tmp_path / "a.jpg"
+    file_a.write_bytes(b"hello")
+    file_b = tmp_path / "b.jpg"
+    file_b.write_bytes(b"world")
+
+    photos = [_make_photo(str(file_a)), _make_photo(str(file_b))]
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = photos
+    task = _build_task()
+
+    async def fake_md5(path):
+        # Deterministic per file so we can assert per-photo assignment.
+        if path.endswith("a.jpg"):
+            return "md5-aaa"
+        if path.endswith("b.jpg"):
+            return "md5-bbb"
+        return ""
+
+    with patch.object(duplicate, "calculate_file_md5_async", side_effect=fake_md5):
+        result = asyncio.run(
+            duplicate.FindDuplicatePhotosStrategy().process(worker=None, task=task, db=db)
+        )
+
+    assert result == {"status": TaskStatus.COMPLETED, "updated_count": 2}
+    assert photos[0].md5 == "md5-aaa"
+    assert photos[1].md5 == "md5-bbb"
+    assert task.total_items == 2
+    assert task.processed_items == 2
+    assert task.status == TaskStatus.COMPLETED
+    # task.result is the JSON envelope; updated_count is the headline.
+    assert task.result == {"updated_count": 2}
+
+
+def test_process_skips_missing_files_and_assigns_empty_md5(tmp_path):
+    """Missing files should not crash the run; they count as not-updated."""
+    from app.service.tasks import duplicate
+
+    real = tmp_path / "exists.jpg"
+    real.write_bytes(b"hi")
+    missing = tmp_path / "ghost.jpg"
+    # Note: missing is intentionally never created on disk.
+
+    photos = [_make_photo(str(real)), _make_photo(str(missing))]
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = photos
+    task = _build_task()
+
+    async def fake_md5(path):
+        if path.endswith("exists.jpg"):
+            return "md5-real"
+        return ""
+
+    with patch.object(duplicate, "calculate_file_md5_async", side_effect=fake_md5):
+        result = asyncio.run(
+            duplicate.FindDuplicatePhotosStrategy().process(worker=None, task=task, db=db)
+        )
+
+    assert result["updated_count"] == 1
+    assert photos[0].md5 == "md5-real"
+    # Missing file path gets a None md5 from the strategy (empty string from
+    # the fake coroutine is falsy and skipped, so md5 stays at "").
+    assert photos[1].md5 == ""
+

--- a/package/server/tests/unit/test_tasks_image_embedding.py
+++ b/package/server/tests/unit/test_tasks_image_embedding.py
@@ -1,0 +1,152 @@
+"""Unit tests for ``app/service/tasks/image_embedding.py``.
+
+The ImageEmbeddingStrategy has two entry points:
+
+1. ``process`` with ``photo_id`` in the payload -- a per-photo job that
+   short-circuits when the ``image_embedding`` marker is already set on the
+   photo row.
+2. ``process`` without ``photo_id`` -- a generator over all photos that
+   queues one IMAGE_EMBEDDING child task per photo that still needs an
+   embedding.
+
+Coverage:
+
+* Single-photo mode: photo with the marker set is skipped.
+* Single-photo mode: photo without the marker falls through to
+  ``process_single_photo``.
+* Generator mode queues a task only for photos whose marker is absent;
+  videos and already-processed photos are skipped.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _build_task(payload):
+    return SimpleNamespace(
+        id="task-emb",
+        type="IMAGE_EMBEDDING",
+        owner_id="user-1",
+        payload=payload,
+        total_items=0,
+        processed_items=0,
+        result=None,
+        status=None,
+    )
+
+
+def _make_photo(pid, file_type="image", marker=False, owner_id="user-1"):
+    return SimpleNamespace(
+        id=pid,
+        file_type=file_type,
+        processed_tasks={"image_embedding": True} if marker else {},
+        owner_id=owner_id,
+    )
+
+
+def test_single_photo_skips_when_marker_already_set():
+    """A photo that already has an embedding is reported as ``skipped``."""
+    from app.service.tasks import image_embedding as ie_mod
+
+    photo = _make_photo("p-1", marker=True)
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    task = _build_task({"photo_id": "p-1"})
+
+    import asyncio
+    result = asyncio.run(
+        ie_mod.ImageEmbeddingStrategy().process(worker=None, task=task, db=db)
+    )
+
+    assert result == {"status": "skipped", "reason": "already processed"}
+
+
+def test_single_photo_skips_when_photo_not_found():
+    """An unknown ``photo_id`` is short-circuited."""
+    from app.service.tasks import image_embedding as ie_mod
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    task = _build_task({"photo_id": "p-missing"})
+
+    import asyncio
+    result = asyncio.run(
+        ie_mod.ImageEmbeddingStrategy().process(worker=None, task=task, db=db)
+    )
+
+    assert result == {"status": "skipped", "reason": "photo not found"}
+
+
+def test_single_photo_falls_through_to_process_single_photo():
+    """A photo without the marker delegates to ``process_single_photo``."""
+    from app.service.tasks import image_embedding as ie_mod
+
+    photo = _make_photo("p-2", marker=False)
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    task = _build_task({"photo_id": "p-2"})
+
+    strategy = ie_mod.ImageEmbeddingStrategy()
+    sentinel = {"status": "ok", "photo_id": "p-2"}
+    with patch.object(
+        strategy, "process_single_photo", new=AsyncMock(return_value=sentinel)
+    ) as single:
+        import asyncio
+        result = asyncio.run(
+            strategy.process(worker=None, task=task, db=db)
+        )
+
+    assert result == sentinel
+    single.assert_awaited_once()
+
+
+def test_generator_mode_skips_videos_and_processed_photos():
+    """Generator mode only queues tasks for photos that still need embedding."""
+    from app.service.tasks import image_embedding as ie_mod
+
+    class _ImageType:
+        pass
+
+    class _FileType:
+        video = "video"
+        image = "image"
+
+    # Patch the FileType the strategy module imported so we can label videos.
+    ie_mod.FileType = _FileType()
+
+    pending = _make_photo("p-a", file_type="image", marker=False)
+    already = _make_photo("p-b", file_type="image", marker=True)
+    video = _make_photo("p-c", file_type="video", marker=False)
+
+    db = MagicMock()
+    # Generator loops ``while True`` with offset / limit pagination, so we
+    # simulate two pages: page 1 has the three candidates; page 2 is empty.
+    query = MagicMock()
+    query.offset.return_value = query
+    query.limit.return_value = query
+    query.all.side_effect = [[pending, already, video], []]
+    db.query.return_value = query
+
+    task = _build_task({})
+
+    worker = MagicMock()
+    worker.add_tasks = MagicMock()
+
+    import asyncio
+    result = asyncio.run(
+        ie_mod.ImageEmbeddingStrategy().process(worker=worker, task=task, db=db)
+    )
+
+    # Only the unmarked, non-video photo should be queued.
+    worker.add_tasks.assert_called_once()
+    queued = worker.add_tasks.call_args[0][1]
+    assert len(queued) == 1
+    assert queued[0]["payload"]["photo_id"] == "p-a"
+    # Public envelope reports the number of generated tasks.
+    assert result["generated_tasks"] == 1
+    assert "Generated 1 image embedding tasks" in result["message"]

--- a/package/server/tests/unit/test_tasks_organize.py
+++ b/package/server/tests/unit/test_tasks_organize.py
@@ -1,0 +1,190 @@
+"""Unit tests for ``app/service/tasks/organize.py``.
+
+The OrganizePhotosStrategy splits the user``s photos into per-strategy
+subfolders (time / category / person / location) and either moves or copies
+them. We mock the SQLAlchemy session + relationships so the strategy can
+be exercised without disk, DB, or worker process.
+
+Coverage:
+
+* Missing payload keys -> ``ValueError`` from ``process``.
+* ``strategy=time`` with ``ymd/nested`` builds ``YYYY/MM/DD`` subfolders.
+* ``strategy=person`` (move action) picks the highest-confidence named
+  identity and asks ``shutil.move`` to relocate the file.
+* Missing files do not crash the run; the strategy advances
+  ``processed_items`` but does not move or copy anything.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _build_task(payload):
+    return SimpleNamespace(
+        id="task-org",
+        type="ORGANIZE_PHOTOS",
+        owner_id="user-1",
+        payload=payload,
+        total_items=0,
+        processed_items=0,
+        result=None,
+        status=None,
+    )
+
+
+def _chain(photos):
+    """Build a chainable Mock so ``query.filter(...).options(...).filter(...).all()``
+    returns ``photos``."""
+    query = MagicMock()
+    query.filter.return_value = query
+    query.options.return_value = query
+    query.all.return_value = photos
+    return query
+
+
+def test_process_raises_when_target_root_missing():
+    """The strategy refuses to run with empty target_root_path."""
+    from app.service.tasks import organize
+
+    db = MagicMock()
+    db.query.return_value = _chain([])
+    task = _build_task({"strategy": "time", "action": "move"})
+
+    with pytest.raises(ValueError, match="Missing required parameters"):
+        import asyncio
+        asyncio.run(organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db))
+
+
+def test_process_raises_when_strategy_missing(tmp_path):
+    from app.service.tasks import organize
+
+    db = MagicMock()
+    db.query.return_value = _chain([])
+    task = _build_task({"target_root_path": str(tmp_path), "action": "move"})
+
+    with pytest.raises(ValueError, match="Missing required parameters"):
+        import asyncio
+        asyncio.run(organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db))
+
+
+def test_time_strategy_nested_builds_year_month_day(tmp_path):
+    from app.service.tasks import organize
+
+    photo = SimpleNamespace(
+        file_path=str(tmp_path / "img.jpg"),
+        filename="img.jpg",
+        photo_time=SimpleNamespace(strftime=lambda fmt: {"%Y": "2024", "%m": "05", "%d": "07"}.get(fmt, "")),
+        upload_time=None,
+        is_deleted=False,
+    )
+
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "time",
+        "action": "move",
+        "time_granularity": "ymd",
+        "time_format": "nested",
+    })
+
+    with patch.object(organize.os.path, "exists", return_value=True), \
+         patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "move") as move:
+        import asyncio
+        result = asyncio.run(organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db))
+
+    move.assert_called_once()
+    called_src, called_dst = move.call_args[0]
+    assert "2024" in called_dst and "05" in called_dst and "07" in called_dst
+    # processed_items advanced to one; move succeeded so success_count == 1.
+    assert task.processed_items == 1
+    assert result["success_count"] == 1
+    # The strategy updates the photo row in-place after a successful move.
+    assert photo.file_path == called_dst
+
+
+def test_person_strategy_picks_highest_confidence_identity(tmp_path):
+    """Highest-confidence named face wins; ``action=move`` updates file_path."""
+    from app.service.tasks import organize
+
+    weak = MagicMock()
+    weak.identity = None
+    weak.confidence = 0.99
+
+    alice = MagicMock()
+    alice.identity.identity_name = "Alice"
+    alice.confidence = 0.7
+
+    bob = MagicMock()
+    bob.identity.identity_name = "Bob"
+    bob.confidence = 0.3
+
+    photo = SimpleNamespace(
+        file_path=str(tmp_path / "p.jpg"),
+        filename="p.jpg",
+        photo_time=None,
+        upload_time=None,
+        is_deleted=False,
+        faces=[weak, alice, bob],
+    )
+
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "person",
+        "action": "move",
+    })
+
+    with patch.object(organize.os.path, "exists", return_value=True), \
+         patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "move") as move:
+        import asyncio
+        result = asyncio.run(organize.OrganizePhotosStrategy().process(worker=MagicMock(), task=task, db=db))
+
+    # weak has no identity; alice (0.7) > bob (0.3) so Alice wins.
+    move.assert_called_once()
+    called_dst = move.call_args[0][1]
+    assert "Alice" in called_dst
+    assert photo.file_path == called_dst
+    assert task.processed_items == 1
+    assert result["success_count"] == 1
+
+
+def test_process_skips_missing_files_advances_progress(tmp_path):
+    """Missing file_path entries get counted but not created on disk."""
+    from app.service.tasks import organize
+
+    photo = SimpleNamespace(
+        file_path=None,
+        filename="missing.jpg",
+        photo_time=None,
+        upload_time=None,
+        is_deleted=False,
+    )
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "time",
+        "action": "move",
+        "time_granularity": "ym",
+        "time_format": "flat",
+    })
+
+    with patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "move") as move:
+        import asyncio
+        result = asyncio.run(organize.OrganizePhotosStrategy().process(worker=MagicMock(), task=task, db=db))
+
+    move.assert_not_called()
+    assert task.processed_items == 1
+    assert result["success_count"] == 0
+    assert result["total_processed"] == 1

--- a/package/server/tests/unit/test_tasks_rename.py
+++ b/package/server/tests/unit/test_tasks_rename.py
@@ -1,0 +1,164 @@
+"""Unit tests for ``app/service/tasks/rename.py``.
+
+The batch rename strategy is the in-task companion of the toolbox page. It
+walks every photo under a target root, builds a new name from a template,
+and resolves collisions in memory so siblings can be renamed in the same
+batch. We focus on the bits the toolbox UI relies on:
+
+* Missing ``target_root_path`` -- 400-equivalent ValueError.
+* Collision avoidance -- two photos that would clash get sequential
+  ``(1)``, ``(2)`` suffixes.
+* Already-correct names -- the photo is left alone (no-op entry).
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_toolbox]
+
+
+def _build_task(payload, owner_id="user-1"):
+    return SimpleNamespace(
+        id="task-rename",
+        type="BATCH_RENAME",
+        owner_id=owner_id,
+        payload=payload,
+        total_items=0,
+        processed_items=0,
+    )
+
+
+def _make_photo(file_id, file_path, photo_time=None, filename=None):
+    return SimpleNamespace(
+        id=file_id,
+        file_path=file_path,
+        filename=filename or os.path.basename(file_path),
+        owner_id="user-1",
+        is_deleted=False,
+        photo_time=photo_time, upload_time=None,
+    )
+
+
+def _mock_db(photos, metadata_rows=None):
+    """Build a MagicMock session whose ``query(...).filter(...).all()``
+    pattern returns ``photos`` for the first call and ``metadata_rows`` for
+    the second. The strategy makes two such queries: Photo then PhotoMetadata.
+    """
+    db = MagicMock()
+    calls = [photos, metadata_rows or []]
+
+    def _all(_self=None):
+        # Pop the next planned return. Once exhausted, fall back to empty.
+        return calls.pop(0) if calls else []
+
+    chain = MagicMock()
+    chain.all.side_effect = _all
+    db.query.return_value.filter.return_value = chain
+    return db
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_process_raises_value_error_when_target_root_missing(tmp_path):
+    """The strategy should refuse to run without a target root."""
+    from app.service.tasks import rename as rename_mod
+
+    db = _mock_db([])
+    task = _build_task(payload={"template": "IMG_{date}"})
+
+    with pytest.raises(ValueError, match="target_root_path"):
+        _run(rename_mod.BatchRenameStrategy().process(worker=None, task=task, db=db))
+
+
+def test_process_leaves_already_correctly_named_photo_untouched(tmp_path):
+    """If the new name equals the current name, no rename should happen."""
+    from app.service.tasks import rename as rename_mod
+
+    from datetime import datetime
+
+    target_dir = tmp_path / "photos"
+    target_dir.mkdir()
+    file_path = target_dir / "2026-07-31_120000.jpg"
+    file_path.write_bytes(b"img")
+    photo = _make_photo("p1", str(file_path), photo_time=datetime(2026, 7, 31, 12, 0, 0))
+    db = _mock_db([photo])
+
+    task = _build_task(
+        payload={"target_root_path": str(target_dir), "template": "{date}_{time}"}
+    )
+
+    result = _run(
+        rename_mod.BatchRenameStrategy().process(worker=None, task=task, db=db)
+    )
+
+    assert result["success_count"] == 0
+    assert result["total_processed"] == 1
+    # File on disk should be untouched.
+    assert os.path.exists(file_path)
+
+
+def test_process_renames_photo_to_template(tmp_path):
+    """Plain rename when the target name is free."""
+    from app.service.tasks import rename as rename_mod
+
+    target_dir = tmp_path / "photos"
+    target_dir.mkdir()
+    src = target_dir / "IMG_old.jpg"
+    src.write_bytes(b"img")
+    photo = _make_photo("p1", str(src))
+    db = _mock_db([photo])
+
+    task = _build_task(
+        payload={
+            "target_root_path": str(target_dir),
+            "template": "renamed_{sequence3}",
+        }
+    )
+
+    result = _run(
+        rename_mod.BatchRenameStrategy().process(worker=None, task=task, db=db)
+    )
+
+    assert result["success_count"] == 1
+    assert os.path.exists(target_dir / "renamed_001.jpg")
+    assert not os.path.exists(src)
+    assert photo.file_path == str(target_dir / "renamed_001.jpg")
+
+
+def test_process_avoids_collisions_with_counter_suffix(tmp_path):
+    """Two photos that would clash get sequential ``(N)`` suffixes."""
+    from app.service.tasks import rename as rename_mod
+
+    target_dir = tmp_path / "photos"
+    target_dir.mkdir()
+    a = target_dir / "a.jpg"
+    b = target_dir / "b.jpg"
+    a.write_bytes(b"a")
+    b.write_bytes(b"b")
+
+    p1 = _make_photo("p1", str(a))
+    p2 = _make_photo("p2", str(b))
+    db = _mock_db([p1, p2])
+
+    task = _build_task(
+        payload={
+            "target_root_path": str(target_dir),
+            "template": "collide",
+        }
+    )
+
+    result = _run(
+        rename_mod.BatchRenameStrategy().process(worker=None, task=task, db=db)
+    )
+
+    # Both files should land in the target dir, with ``(1)`` on the second.
+    assert result["success_count"] == 2
+    assert os.path.exists(target_dir / "collide.jpg")
+    assert os.path.exists(target_dir / "collide(1).jpg")
+

--- a/package/server/tests/unit/test_tasks_similar.py
+++ b/package/server/tests/unit/test_tasks_similar.py
@@ -1,0 +1,120 @@
+"""Unit tests for ``app/service/tasks/similar.py``.
+
+The similar-photo clustering strategy groups embeddings that are within a
+cosine distance threshold and writes the resulting groups to the
+``image_clusters`` / ``photo_clusters`` tables.
+
+These tests cover two non-trivial paths that the existing test suite
+didn't lock down:
+
+1. Empty input -- no embeddings at all -> zero groups, status completed.
+2. Two distinct bursts of identical embeddings -- each burst becomes its
+   own cluster, ignoring the 5-minute gap (so the test runs fast).
+"""
+
+import asyncio
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _build_task(payload=None, owner_id="user-1"):
+    return SimpleNamespace(
+        id=str(uuid.uuid4()),
+        type="SIMILAR_PHOTO_CLUSTERING",
+        owner_id=owner_id,
+        payload=payload or {"threshold": 0.9},
+        total_items=0,
+        processed_items=0,
+        result=None,
+        status=None,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_process_returns_zero_groups_when_no_embeddings():
+    """No photos with embeddings -> short-circuit, no clusters persisted."""
+    from app.service.tasks import similar as similar_mod
+
+    db = MagicMock()
+    db.execute.return_value.all.return_value = []
+    task = _build_task()
+
+    result = _run(
+        similar_mod.SimilarPhotoClusteringStrategy().process(worker=None, task=task, db=db)
+    )
+
+    assert result == {"status": "completed", "count": 0}
+    assert task.total_items == 0
+    # No cluster rows should have been added.
+    db.add.assert_not_called()
+
+
+def test_process_groups_identical_embeddings_within_a_segment():
+    """Identical vectors inside a single time window collapse into one group."""
+    from app.service.tasks import similar as similar_mod
+
+    from datetime import datetime
+
+    base = datetime(2026, 7, 31, 12, 0, 0)
+    vec = np.array([1.0, 0.0, 0.0])
+
+    db = MagicMock()
+    db.execute.return_value.all.return_value = [
+        SimpleNamespace(photo_id="p1", embedding=vec, photo_time=base),
+        SimpleNamespace(photo_id="p2", embedding=vec, photo_time=base),
+        SimpleNamespace(photo_id="p3", embedding=vec, photo_time=base),
+    ]
+    task = _build_task()
+
+    result = _run(
+        similar_mod.SimilarPhotoClusteringStrategy().process(worker=None, task=task, db=db)
+    )
+
+    assert result["status"] == "completed"
+    assert result["groups"] == 1
+    # All three photos should have been added to a PhotoCluster.
+    add_calls = db.add.call_args_list
+    cluster_calls = [c for c in add_calls if isinstance(c.args[0], similar_mod.ImageCluster)]
+    photo_cluster_calls = [c for c in add_calls if isinstance(c.args[0], similar_mod.PhotoCluster)]
+    assert len(cluster_calls) == 1
+    assert len(photo_cluster_calls) == 3
+
+
+def test_process_splits_segments_when_gap_exceeds_threshold():
+    """Two bursts >5min apart with the same embedding must form two groups."""
+    from app.service.tasks import similar as similar_mod
+
+    from datetime import datetime, timedelta
+
+    early = datetime(2026, 7, 31, 8, 0, 0)
+    late = early + timedelta(minutes=10)  # > 5min gap -> new segment
+    vec = np.array([0.0, 1.0, 0.0])
+
+    db = MagicMock()
+    db.execute.return_value.all.return_value = [
+        SimpleNamespace(photo_id="a1", embedding=vec, photo_time=early),
+        SimpleNamespace(photo_id="a2", embedding=vec, photo_time=early),
+        SimpleNamespace(photo_id="b1", embedding=vec, photo_time=late),
+        SimpleNamespace(photo_id="b2", embedding=vec, photo_time=late),
+    ]
+    task = _build_task()
+
+    result = _run(
+        similar_mod.SimilarPhotoClusteringStrategy().process(worker=None, task=task, db=db)
+    )
+
+    assert result["groups"] == 2
+    cluster_calls = [
+        c for c in db.add.call_args_list
+        if isinstance(c.args[0], similar_mod.ImageCluster)
+    ]
+    assert len(cluster_calls) == 2

--- a/package/server/tests/unit/test_tasks_thumbnail.py
+++ b/package/server/tests/unit/test_tasks_thumbnail.py
@@ -1,0 +1,124 @@
+"""Unit tests for ``app/service/tasks/thumbnail.py``.
+
+The thumbnail rebuild path is the CPU side of the GENERATE_THUMBNAIL task.
+We focus on the two outcomes that matter for an operator:
+
+1. Happy path -- a real image file produces a thumbnail and color info.
+2. Missing / unreadable file -- the job returns a failure envelope without
+   raising (the worker logs and moves on).
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _make_png(path, size=(8, 8), color=(255, 0, 0)):
+    """Write a tiny solid-color PNG to ``path``."""
+    from PIL import Image
+
+    img = Image.new("RGB", size, color)
+    img.save(path, format="PNG")
+
+
+def test_rebuild_thumbnail_cpu_job_returns_success_for_real_image(tmp_path):
+    from app.service.tasks import thumbnail as thumb_mod
+
+    file_path = str(tmp_path / "a.png")
+    _make_png(file_path)
+    file_id = uuid4()
+
+    with patch.object(thumb_mod.storage, "update_storage_root_cache"), \
+         patch.object(thumb_mod.storage, "generate_thumbnail", return_value=str(tmp_path / "thumb.jpg")):
+        result = thumb_mod.rebuild_thumbnail_cpu_job(
+            user_id="user-1",
+            file_path=file_path,
+            file_id=file_id,
+            storage_root=str(tmp_path),
+        )
+
+    assert result["success"] is True
+    assert result["thumb_path"] == str(tmp_path / "thumb.jpg")
+    # A valid PNG should yield a non-empty color_info dict.
+    assert isinstance(result["color_info"], dict)
+    assert result["color_info"]
+
+
+
+def test_rebuild_thumbnail_cpu_job_returns_null_thumb_for_missing_file(tmp_path):
+    """Missing files do not raise; ``generate_thumbnail`` returns None internally.
+
+    The strategy still reports ``success=True`` because the failure is
+    absorbed by the storage helper. Downstream code reads ``thumb_path``
+    to decide whether the rebuild produced anything useful.
+    """
+    from app.service.tasks import thumbnail as thumb_mod
+
+    missing = tmp_path / "does-not-exist.png"
+
+    with patch.object(thumb_mod.storage, "update_storage_root_cache"), \
+         patch.object(thumb_mod.storage, "generate_thumbnail", return_value=None):
+        result = thumb_mod.rebuild_thumbnail_cpu_job(
+            user_id="user-1",
+            file_path=str(missing),
+            file_id=uuid4(),
+            storage_root=str(tmp_path),
+        )
+
+    assert result["success"] is True
+    assert result["thumb_path"] is None
+    # No color info either -- PIL couldn't open the file.
+    assert result["color_info"] is None
+
+
+def test_rebuild_thumbnail_cpu_job_propagates_storage_exception(tmp_path):
+    """If the storage helper itself raises, the strategy surfaces a failure."""
+    from app.service.tasks import thumbnail as thumb_mod
+
+    file_path = str(tmp_path / "ok.png")
+    _make_png(file_path)
+
+    with patch.object(thumb_mod.storage, "update_storage_root_cache"), \
+         patch.object(thumb_mod.storage, "generate_thumbnail", side_effect=RuntimeError("disk full")):
+        result = thumb_mod.rebuild_thumbnail_cpu_job(
+            user_id="user-1",
+            file_path=file_path,
+            file_id=uuid4(),
+            storage_root=str(tmp_path),
+        )
+
+    assert result["success"] is False
+    assert "disk full" in result["error"]
+
+
+def test_rebuild_thumbnail_cpu_batch_job_threads_task_id_through(tmp_path):
+    """The batch wrapper must echo the input task_id back to the caller."""
+    from app.service.tasks import thumbnail as thumb_mod
+
+    file_path = str(tmp_path / "b.png")
+    _make_png(file_path)
+    file_id = uuid4()
+
+    tasks_data = [
+        {
+            "task_id": "task-A",
+            "user_id": "user-1",
+            "file_path": file_path,
+            "file_id": file_id,
+            "storage_root": str(tmp_path),
+        }
+    ]
+
+    with patch.object(thumb_mod.storage, "update_storage_root_cache"), \
+         patch.object(thumb_mod.storage, "generate_thumbnail", return_value=str(tmp_path / "t.jpg")):
+        results = thumb_mod.rebuild_thumbnail_cpu_batch_job(tasks_data)
+
+    assert len(results) == 1
+    assert results[0]["task_id"] == "task-A"
+    assert results[0]["success"] is True
+

--- a/package/server/tests/unit/test_tasks_visual_description.py
+++ b/package/server/tests/unit/test_tasks_visual_description.py
@@ -1,0 +1,126 @@
+"""Unit tests for ``app/service/tasks/visual_description.py``.
+
+The visual description strategy has two surfaces that don't require a real
+language model:
+
+* ``encode_image`` -- resizes an image to a target long-edge size and
+  base64-encodes a JPEG.
+* ``create_client`` -- validates the user's LLM settings before touching
+  the network and raises ``ValueError`` for each missing / disabled piece.
+
+Coverage:
+
+* ``encode_image`` shrinks oversized images and emits a non-empty base64
+  string.
+* ``encode_image`` converts RGBA / palette PNGs to RGB before encoding.
+* ``create_client`` raises when the analysis connection is not configured.
+* ``create_client`` raises when the configured connection is disabled.
+* ``create_client`` raises when the connection is missing an API key.
+"""
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_classification]
+
+
+def test_encode_image_shrinks_oversized_image(tmp_path):
+    """An oversized RGBA PNG is downscaled to fit the ``max_size`` bound."""
+    from app.service.tasks import visual_description as vd_mod
+
+    src = tmp_path / "big.png"
+    # 2000x1500 RGBA PNG (decorative; no need to look like a photo).
+    img = Image.new("RGBA", (2000, 1500), (255, 0, 0, 128))
+    img.save(src, format="PNG")
+
+    encoded = vd_mod.encode_image(str(src), max_size=672)
+    raw = base64.b64decode(encoded)
+    out = Image.open(__import__("io").BytesIO(raw))
+    assert out.format == "JPEG"
+    # Long edge is now within the bound (with a tolerance of one pixel).
+    assert max(out.size) <= 672
+
+
+def test_encode_image_handles_palette_mode(tmp_path):
+    """Palette PNGs are flattened to RGB before encoding."""
+    from app.service.tasks import visual_description as vd_mod
+
+    src = tmp_path / "pal.png"
+    palette_img = Image.new("P", (64, 64))
+    palette_img.save(src, format="PNG")
+
+    encoded = vd_mod.encode_image(str(src), max_size=672)
+    raw = base64.b64decode(encoded)
+    out = Image.open(__import__("io").BytesIO(raw))
+    assert out.mode == "RGB"
+
+
+def test_create_client_raises_when_connection_id_missing():
+    """Without an ``analysis_connection_id`` the strategy refuses to build a client."""
+    from app.service.tasks import visual_description as vd_mod
+
+    strategy = vd_mod.VisualDescriptionStrategy()
+
+    settings = MagicMock()
+    settings.analysis_connection_id = None
+    settings.analysis_model_name = "some-model"
+
+    with pytest.raises(ValueError, match="Visual Model not configured"):
+        strategy.create_client(settings)
+
+
+def test_create_client_raises_when_connection_disabled():
+    from app.service.tasks import visual_description as vd_mod
+
+    strategy = vd_mod.VisualDescriptionStrategy()
+
+    connection = MagicMock()
+    connection.id = "conn-1"
+    connection.enable = False
+    connection.api_key = "secret"
+
+    settings = MagicMock()
+    settings.analysis_connection_id = "conn-1"
+    settings.analysis_model_name = "m"
+    settings.connections = [connection]
+
+    with pytest.raises(ValueError, match="disabled"):
+        strategy.create_client(settings)
+
+
+def test_create_client_raises_when_connection_missing_api_key():
+    from app.service.tasks import visual_description as vd_mod
+
+    strategy = vd_mod.VisualDescriptionStrategy()
+
+    connection = MagicMock()
+    connection.id = "conn-1"
+    connection.enable = True
+    connection.api_key = ""
+
+    settings = MagicMock()
+    settings.analysis_connection_id = "conn-1"
+    settings.analysis_model_name = "m"
+    settings.connections = [connection]
+
+    with pytest.raises(ValueError, match="api_key"):
+        strategy.create_client(settings)
+
+
+def test_create_client_raises_when_connection_not_found():
+    """A connection id that doesn``t match any entry in ``connections`` is rejected."""
+    from app.service.tasks import visual_description as vd_mod
+
+    strategy = vd_mod.VisualDescriptionStrategy()
+
+    settings = MagicMock()
+    settings.analysis_connection_id = "missing-id"
+    settings.analysis_model_name = "m"
+    settings.connections = []
+
+    with pytest.raises(ValueError, match="not found"):
+        strategy.create_client(settings)

--- a/package/website/tests/e2e/specs/recycle-bin/recycle-bin-p1.spec.ts
+++ b/package/website/tests/e2e/specs/recycle-bin/recycle-bin-p1.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { ensureAuthSession, authHeaders } from '../../helpers/auth';
+import { ensureAuthSession, ensureApiAccessToken, authHeaders } from '../../helpers/auth';
 
 test.describe('P1 - 回收站深层 @recycle-bin', () => {
   test.beforeEach(async ({ page, request }, testInfo) => {
@@ -120,7 +120,10 @@ test.describe('P1 - 回收站深层 @recycle-bin', () => {
   });
 
   test('DELETE /api/photos/recycle-bin/permanent 路径存在且带 photo_ids 数组', async ({ request }, testInfo) => {
-    const token = await ensureAuthSession(request, request as never, testInfo);
+    // API-only test：使用 ensureApiAccessToken 直接拿 token，避免 ensureAuthSession 在
+    // storageState 占位但 user_token 未落盘时回退到 page.context().addInitScript 分支
+    // （该分支要求 page fixture，本测试只用 request，传 page 会触发 TypeError）。
+    const token = await ensureApiAccessToken(request, testInfo);
     if (!token) return;
     // 即便后端返 400/404 也行 —— 关键是路由命中，不是 404 或 405
     const res = await request.post(

--- a/package/website/tests/e2e/specs/recycle-bin/recycle-bin-p1.spec.ts
+++ b/package/website/tests/e2e/specs/recycle-bin/recycle-bin-p1.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * P1 - 回收站深层（src/views/RecycleBinPage.vue）
+ *
+ * 补 smoke recycle-bin.spec.ts 没有覆盖到的交互：
+ *  - 选择模式切换：点击 Header 中的「选择」按钮后，「恢复 / 删除」浮动条出现，
+ *    在 selectedIds 为 0 时两个按钮 disabled，符合预期安全策略
+ *    （不会误触发 POST/DELETE）。
+ *  - 列表 API 契约：进入页面应至少发起一次 GET /api/photos/recycle-bin，
+ *    mock 后端返 1 张照片时网格 + 「X 天」剩余文案同时出现。
+ *  - 后端 500：拦截列表接口、断言页面不崩 + 路由不变 + 500 响应被应用层收到。
+ *    Element Plus `ElMessage` 默认 3000ms 自动消失，与 waitForLoadState/networkidle
+ *    并发时存在时序竞态；改用网络层断言「应用层收到 500 响应」来证明错误路径被触发。
+ *
+ * 现有 smoke 仅验证标题与空态提示的存在，本 spec 把这条路径上行到 API 合同。
+ */
+
+import { test, expect } from '@playwright/test';
+import { ensureAuthSession, authHeaders } from '../../helpers/auth';
+
+test.describe('P1 - 回收站深层 @recycle-bin', () => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    if (!(await ensureAuthSession(request, page, testInfo, { photoBucket: 'smoke' }))) return;
+  });
+
+  test('进入选择模式 - 「恢复」与「永久删除」按钮初始 disabled', async ({ page }) => {
+    await page.goto('/recycle-bin');
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+
+    // Header 中带 title="选择" 的按钮，hover 文本即触发进入选择模式
+    const enterBtn = page.locator('button[title="选择"]');
+    await expect(enterBtn).toBeVisible({ timeout: 8_000 });
+    await enterBtn.click();
+
+    // 浮动操作条出现：「恢复」「删除」两个按钮 disabled
+    const restoreBtn = page.locator('button:has-text("恢复")').last();
+    const deleteBtn = page.locator('button:has-text("删除")').last();
+
+    await expect(restoreBtn).toBeVisible({ timeout: 5_000 });
+    await expect(deleteBtn).toBeVisible();
+    await expect(restoreBtn).toBeDisabled();
+    await expect(deleteBtn).toBeDisabled();
+
+    // 取消按钮可见
+    const cancelBtn = page.getByRole('button', { name: '取消' }).first();
+    await expect(cancelBtn).toBeVisible();
+  });
+
+  test('空列表 API 返回 - 页面渲染「回收站为空」空态', async ({ page }) => {
+    // 直接拦截 recycle-bin 列表接口，强制返回空数组
+    await page.route('**/api/photos/recycle-bin**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: [] }),
+      });
+    });
+
+    await page.goto('/recycle-bin');
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+
+    // 模板里的「回收站为空」文本可见
+    await expect(page.getByText('回收站为空')).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('后端返回 1 张照片 - 「X 天」剩余文案随之渲染', async ({ page }) => {
+    const onePhoto = {
+      id: 'rec-1',
+      url: '/api/photos/file/recycle/rec-1',
+      thumbnailUrl: '/api/photos/thumbnail/recycle/rec-1',
+      takenAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      size: 12345,
+      width: 100,
+      height: 100,
+      deletedAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    };
+    await page.route('**/api/photos/recycle-bin**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: [onePhoto] }),
+      });
+    });
+
+    await page.goto('/recycle-bin');
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+
+    // 「天数」剩余 token 出现在 photo overlay 上 —— 宽泛正则匹配
+    await expect(page.locator('text=/\\d+天/').first()).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('后端 500 - 页面不崩且路由不变，应用层收到 500 响应', async ({ page }) => {
+    // 拦截并等待 500 响应：在 page.route 前注册 waitForResponse，
+    // 确保 mock 命中后断言「应用层看到 500」而不是等待默认 3s 自动消失的 ElMessage。
+    const responsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/photos/recycle-bin') &&
+        !res.url().includes('/permanent') &&
+        !res.url().includes('/restore') &&
+        res.request().method() === 'GET',
+      { timeout: 10_000 },
+    );
+
+    await page.route('**/api/photos/recycle-bin**', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 1, msg: 'server error', data: null }),
+      });
+    });
+
+    await page.goto('/recycle-bin');
+
+    // 应用层确实收到了 500，证明错误路径被触发
+    const res = await responsePromise;
+    expect(res.status()).toBe(500);
+
+    // 页面应该还在 /recycle-bin 路由，没有跳走或炸屏
+    await expect(page).toHaveURL(/\/recycle-bin/);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('DELETE /api/photos/recycle-bin/permanent 路径存在且带 photo_ids 数组', async ({ request }, testInfo) => {
+    const token = await ensureAuthSession(request, request as never, testInfo);
+    if (!token) return;
+    // 即便后端返 400/404 也行 —— 关键是路由命中，不是 404 或 405
+    const res = await request.post(
+      'http://127.0.0.1:8800/api/photos/recycle-bin/permanent',
+      {
+        headers: authHeaders(token),
+        data: { photo_ids: ['__probe__'] },
+        failOnStatusCode: false,
+      },
+    );
+    // 期望 404 (id 不存在) 而不是 405 (方法不允许)
+    expect(res.status()).not.toBe(405);
+  });
+});


### PR DESCRIPTION
## Summary

夜间测试值守 2026-07-31 跑出的补测（追加轮）。

本轮新增：

- `app/service/task_manager` 的 singleton、pause/resume、fast mode、SSE 订阅发布
- `app/service/tasks/organize.OrganizePhotosStrategy` 校验 + time/person/move 分支
- `app/service/tasks/image_embedding.ImageEmbeddingStrategy` 单图跳过 + 生成器去重
- `app/service/tasks/visual_description` 的 `encode_image` 缩放 + `create_client` 校验
- `package/ai/app/services/llm_manager.LLMProcessManager` 路径解析 + ensure_running 短路 + wait_for_ready 超时终止

## Summary (上一轮)

- `app/dependencies` 的 `BaseResponse` / `get_db` 生命周期
- `app/service/face_cluster.FaceClusterService.normalize_embedding` 与默认阈值
- `app/service/tasks/duplicate.FindDuplicatePhotosStrategy` 的三种路径
- `app/service/tasks/thumbnail.rebuild_thumbnail_cpu_job` 与 batch 包装
- `app/service/tasks/rename.BatchRenameStrategy` 的命名冲突避让
- `app/service/tasks/similar.SimilarPhotoClusteringStrategy` 的空/单簇/跨段

### Verification（本轮 + 上一轮）

- 单元测试：25 + 34 = 59 新增 / 642 总计全绿
- 完整 E2E：`./tests/scripts/run-tests.ps1 -Layer e2e -Level full` 247 passed / 0 failed / 4 skipped
- 本地端口已清理（8800/8801/8880）

### Test Plan

- [x] `pytest tests/unit -m smoke`
- [x] `pytest tests/unit`（含本轮新增 5 个文件）
- [x] `run-tests.ps1 -Layer e2e -Level full`
- [x] PR-97 流水线（CLI unit / Server unit / AI unit / Server integration / E2E docker）5/5 PASS