### PR TITLE
feat(website): 位置相册新增照片拼图视图

### DIFF
--- a/package/website/src/composables/useMapPuzzle.ts
+++ b/package/website/src/composables/useMapPuzzle.ts
@@ -1,0 +1,400 @@
+/**
+ * 地图拼图状态管理
+ *
+ * 负责：GeoJSON 加载 → 照片拉取（按评分优选）→ 网格计算 → 照片分配。
+ * 实际绘制交给 PuzzleCanvas 组件，本 composable 只产出「渲染所需的数据」。
+ */
+
+import { computed, ref, shallowRef } from 'vue'
+import request from '@/utils/request'
+import { albumService } from '@/api/album'
+import { locationService } from '@/api/location'
+import { buildRegionGeometry, filterRegionFeatures, shortenRegionName, type RegionGeometry } from '@/utils/mapPuzzle/geoPath'
+import { computeBBox, createProjector } from '@/utils/mapPuzzle/geoProjection'
+import { assignPhotos, buildGrid, shuffle, type PuzzleCell } from '@/utils/mapPuzzle/gridFill'
+
+/** 拼图层级：全国 / 单省 */
+export type PuzzleScope = 'nation' | 'province'
+
+/** 选片策略 */
+export type PhotoStrategy = 'memory_score' | 'quality_score' | 'photo_time' | 'random'
+
+export interface PuzzleConfig {
+  /** 目标格子数量 */
+  targetCount: number
+  /** 是否显示区域名 */
+  showLabel: boolean
+  /** 选片策略 */
+  strategy: PhotoStrategy
+}
+
+/** 全国图默认配置：格子密、不显示省名（太挤） */
+export const NATION_DEFAULTS: PuzzleConfig = {
+  targetCount: 600,
+  showLabel: false,
+  strategy: 'memory_score',
+}
+
+/** 单省默认配置：格子大、显示省名 */
+export const PROVINCE_DEFAULTS: PuzzleConfig = {
+  targetCount: 60,
+  showLabel: true,
+  strategy: 'memory_score',
+}
+
+/**
+ * 全国图下每省最多拉取的照片数。
+ *
+ * 该值同时决定了「照片少时自动增大格子」的触发点：拉得太少会让大省
+ * 明明有很多照片却被迫用大格子。实测新疆在 2000 格时需要约 354 格，
+ * 故取 400 以覆盖滑块上限；图片本身按需懒加载，不会一次性全部请求。
+ */
+const NATION_PER_PROVINCE_LIMIT = 400
+/** 单省图拉取上限，留出余量供用户手动换图 */
+const PROVINCE_FETCH_LIMIT = 500
+
+/**
+ * 碎小岛礁裁剪阈值（相对区域内最大面的面积比例）。
+ *
+ * 实测数据：广东 35 个面、浙江 75 个、海南 328 个（含南海诸岛）。
+ * 不裁剪时这些礁石会把包围盒撑大 —— 海南纬度跨度从 12.84° 变成 16.33°，
+ * 主体被压缩、拼图出现大片空白，且格子遍历量增加约 10 倍。
+ * 取 5% 时 34 个省的填充率全部 ≥25%，且不会误删任何省的主体。
+ */
+const ISLAND_RATIO = 0.05
+
+export function useMapPuzzle() {
+  /** 当前层级 */
+  const scope = ref<PuzzleScope>('nation')
+  /** 单省模式下的目标省份全称，如「河南省」 */
+  const activeProvince = ref<string | null>(null)
+
+  const config = ref<PuzzleConfig>({ ...NATION_DEFAULTS })
+
+  /** 画布尺寸（由容器 ResizeObserver driven） */
+  const canvasWidth = ref(800)
+  const canvasHeight = ref(600)
+
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  /** 投影后的行政区几何（shallowRef：数据量大且整体替换，无需深响应） */
+  const geometries = shallowRef<RegionGeometry[]>([])
+  /** 网格格子 */
+  const cells = shallowRef<PuzzleCell[]>([])
+  /** 格子 → 照片 id */
+  const assignments = shallowRef<(string | null)[]>([])
+
+  /** 省份全称 → 照片 id 池。拼图严格按省取图，不存在跨省的全局池。 */
+  const photosByRegion = shallowRef<Map<string, string[]>>(new Map())
+
+  /** 省份全称 → 照片数量，用于 hover 提示 */
+  const regionCounts = shallowRef<Map<string, number>>(new Map())
+
+  /** 原始 GeoJSON features 缓存，切换层级时避免重复请求 */
+  const geoCache = new Map<string, any[]>()
+
+  /** 有效照片数（去重后） */
+  const usedPhotoCount = computed(() => new Set(assignments.value.filter(Boolean)).size)
+
+  /**
+   * 拉取 GeoJSON features。
+   * 后端接口带一年强缓存，且无鉴权，这里再加一层内存缓存。
+   */
+  const fetchGeoFeatures = async (level: 'province' | 'city', parent?: string) => {
+    const key = `${level}:${parent ?? ''}`
+    const cached = geoCache.get(key)
+    if (cached) return cached
+
+    const params: Record<string, string> = { level, v: '2' }
+    if (parent) params.parent = parent
+    const res = await request.get('/api/medias/geojson', { params })
+    // request 封装对 BaseResponse 解包，但 geojson 接口直接返回裸对象，两种都兼容
+    const geoJson = (res as any)?.data ?? res
+    // 必须过滤：原始数据含 8 个「境界线」MultiLineString，会撑坏包围盒
+    const features = filterRegionFeatures(geoJson?.features ?? [])
+    geoCache.set(key, features)
+    return features
+  }
+
+  /**
+   * 按策略拉取某个省份的照片 id。
+   * 后端 order_by 已原生支持 memory_score / quality_score 且 nulls_last，
+   * 因此高分优先时不必担心未做 AI 分析的照片挤占前排。
+   */
+  const fetchProvincePhotos = async (
+    provinceName: string,
+    limit: number,
+    strategy: PhotoStrategy,
+    startDate?: string,
+    endDate?: string
+  ): Promise<string[]> => {
+    const filters: Record<string, any> = {
+      // 用单数 province（ilike 模糊匹配）以兼容「河南省」与「河南」两种写法
+      province: provinceName,
+      file_type: 'image',
+    }
+    if (startDate) filters.start_time = startDate
+    if (endDate) filters.end_time = endDate
+
+    if (strategy === 'memory_score' || strategy === 'quality_score') {
+      filters.order_by = strategy
+    } else if (strategy === 'photo_time') {
+      filters.order_by = 'photo_time'
+      filters.order_dir = 'desc'
+    }
+
+    try {
+      const photos = await albumService.getAllPhotos(0, limit, filters)
+      const ids = (photos ?? []).map((p: any) => p.id).filter(Boolean)
+      // 随机策略在前端打乱，避免后端不支持随机排序
+      return strategy === 'random' ? shuffle(ids) : ids
+    } catch (e) {
+      console.error(`[puzzle] 拉取 ${provinceName} 照片失败`, e)
+      return []
+    }
+  }
+
+  /** 重新计算网格与照片分配（几何或配置变化时调用，不重新请求数据） */
+  const recompute = () => {
+    if (!geometries.value.length) {
+      cells.value = []
+      assignments.value = []
+      return
+    }
+    // 各省实际可用照片数，驱动「照片少时自动增大格子」
+    const photoCounts = new Map<string, number>()
+    for (const [name, ids] of photosByRegion.value) {
+      photoCounts.set(name, ids.length)
+    }
+
+    const grid = buildGrid(geometries.value, {
+      targetCount: config.value.targetCount,
+      // 格子小于 9px 时照片内容已无法辨识，不如少铺几格
+      minCellSize: scope.value === 'nation' ? 9 : 12,
+      photoCounts,
+      // 没去过的省不生成格子，保持轮廓内干净空白
+      skipEmptyRegions: true,
+    })
+    cells.value = grid
+    assignments.value = assignPhotos(grid, photosByRegion.value)
+  }
+
+  /** 依据当前画布尺寸重新投影几何（尺寸变化时调用） */
+  const reproject = (features: any[]) => {
+    // ISLAND_RATIO 必须在 computeBBox 与 buildRegionGeometry 间保持一致，
+    // 否则包围盒与实际绘制的面不匹配，形状会偏移出画布。
+    const bbox = computeBBox(features, ISLAND_RATIO)
+    const projector = createProjector(bbox, canvasWidth.value, canvasHeight.value, 24)
+    geometries.value = features.map((f) => buildRegionGeometry(f, projector, ISLAND_RATIO))
+  }
+
+  /** 当前使用的 features，用于尺寸变化时重新投影 */
+  const activeFeatures = shallowRef<any[]>([])
+
+  /** 加载全国拼图 */
+  const loadNation = async (startDate?: string, endDate?: string) => {
+    loading.value = true
+    error.value = null
+    try {
+      const features = await fetchGeoFeatures('province')
+      activeFeatures.value = features
+      reproject(features)
+
+      // 用分布接口一次拿到各省照片数，避免对 34 个省逐个试探
+      const distribution = await locationService.getDistribution('province', startDate, endDate)
+      const counts = new Map<string, number>()
+      const nameToFull = new Map<string, string>()
+      for (const f of features) {
+        const full = f?.properties?.name
+        if (!full) continue
+        nameToFull.set(full, full)
+        nameToFull.set(shortenRegionName(full), full)
+      }
+      for (const item of distribution ?? []) {
+        const full = nameToFull.get(item.name) ?? nameToFull.get(shortenRegionName(item.name))
+        if (full) counts.set(full, (counts.get(full) ?? 0) + item.count)
+      }
+      regionCounts.value = counts
+
+      // 只对「有照片的省」发起请求，按照片数降序优先
+      const targets = [...counts.entries()]
+        .filter(([, count]) => count > 0)
+        .sort((a, b) => b[1] - a[1])
+
+      const poolMap = new Map<string, string[]>()
+      // 分批并发，避免 34 个省同时发请求
+      const BATCH = 6
+      for (let i = 0; i < targets.length; i += BATCH) {
+        const batch = targets.slice(i, i + BATCH)
+        const results = await Promise.all(
+          batch.map(([name]) =>
+            fetchProvincePhotos(
+              name,
+              NATION_PER_PROVINCE_LIMIT,
+              config.value.strategy,
+              startDate,
+              endDate
+            )
+          )
+        )
+        batch.forEach(([name], idx) => {
+          const ids = results[idx]
+          if (ids.length) poolMap.set(name, ids)
+        })
+      }
+      photosByRegion.value = poolMap
+
+      recompute()
+    } catch (e: any) {
+      console.error('[puzzle] 加载全国拼图失败', e)
+      error.value = e?.message ?? '加载失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /** 加载单省拼图 */
+  const loadProvince = async (provinceName: string, startDate?: string, endDate?: string) => {
+    loading.value = true
+    error.value = null
+    try {
+      // 从全国 features 里挑出目标省，避免为单省再请求一次 geojson
+      const allFeatures = await fetchGeoFeatures('province')
+      const short = shortenRegionName(provinceName)
+      const feature = allFeatures.find((f: any) => {
+        const full = f?.properties?.name ?? ''
+        return full === provinceName || shortenRegionName(full) === short
+      })
+      if (!feature) {
+        error.value = `未找到「${provinceName}」的边界数据`
+        geometries.value = []
+        cells.value = []
+        return
+      }
+
+      const fullName = feature.properties.name
+      activeProvince.value = fullName
+      activeFeatures.value = [feature]
+      reproject([feature])
+
+      const ids = await fetchProvincePhotos(
+        fullName,
+        PROVINCE_FETCH_LIMIT,
+        config.value.strategy,
+        startDate,
+        endDate
+      )
+      photosByRegion.value = new Map([[fullName, ids]])
+      regionCounts.value = new Map([[fullName, ids.length]])
+
+      recompute()
+    } catch (e: any) {
+      console.error('[puzzle] 加载单省拼图失败', e)
+      error.value = e?.message ?? '加载失败'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /** 画布尺寸变化：只重新投影 + 重算网格，不重新请求数据 */
+  const resize = (width: number, height: number) => {
+    if (width <= 0 || height <= 0) return
+    // 变化小于 2px 时忽略，避免 ResizeObserver 抖动导致频繁重算
+    if (Math.abs(width - canvasWidth.value) < 2 && Math.abs(height - canvasHeight.value) < 2) {
+      return
+    }
+    canvasWidth.value = width
+    canvasHeight.value = height
+    if (activeFeatures.value.length) {
+      reproject(activeFeatures.value)
+      recompute()
+    }
+  }
+
+  /** 进入单省视图 */
+  const drillDown = async (provinceName: string, startDate?: string, endDate?: string) => {
+    scope.value = 'province'
+    config.value = { ...PROVINCE_DEFAULTS, strategy: config.value.strategy }
+    await loadProvince(provinceName, startDate, endDate)
+  }
+
+  /** 返回全国视图 */
+  const drillUp = async (startDate?: string, endDate?: string) => {
+    scope.value = 'nation'
+    activeProvince.value = null
+    config.value = { ...NATION_DEFAULTS, strategy: config.value.strategy }
+    await loadNation(startDate, endDate)
+  }
+
+  /**
+   * 替换某个格子的照片。
+   *
+   * 候选照片**只从该格子所属省份的照片池里取**，不跨省借图，
+   * 与 assignPhotos 的严格归属规则保持一致。
+   * 优先取当前画面里尚未用到的照片，避免换图后出现重复。
+   */
+  const replaceCellPhoto = (cellIndex: number, photoId?: string) => {
+    const next = [...assignments.value]
+    if (photoId) {
+      next[cellIndex] = photoId
+      assignments.value = next
+      return
+    }
+
+    const cell = cells.value[cellIndex]
+    const pool = cell ? photosByRegion.value.get(cell.regionName) : undefined
+    if (!pool || !pool.length) return
+
+    const used = new Set(next.filter(Boolean) as string[])
+    const candidate = pool.find((id) => !used.has(id))
+    // 本省照片已全部用上时，在本省池内随机取一张（仍不跨省）
+    next[cellIndex] = candidate ?? pool[Math.floor(Math.random() * pool.length)] ?? null
+    assignments.value = next
+  }
+
+  /** 剔除某个格子的照片（留空为占位色） */
+  const removeCellPhoto = (cellIndex: number) => {
+    const next = [...assignments.value]
+    next[cellIndex] = null
+    assignments.value = next
+  }
+
+  /** 重新随机分配（换一批）。各省独立打乱，照片不会跨省流动。 */
+  const reshuffle = () => {
+    const seed = Date.now() & 0xffff
+    const shuffledMap = new Map<string, string[]>()
+    for (const [name, ids] of photosByRegion.value) {
+      shuffledMap.set(name, shuffle(ids, seed))
+    }
+    photosByRegion.value = shuffledMap
+    recompute()
+  }
+
+  return {
+    // 状态
+    scope,
+    activeProvince,
+    config,
+    loading,
+    error,
+    geometries,
+    cells,
+    assignments,
+    regionCounts,
+    photosByRegion,
+    canvasWidth,
+    canvasHeight,
+    usedPhotoCount,
+    // 动作
+    loadNation,
+    loadProvince,
+    drillDown,
+    drillUp,
+    resize,
+    recompute,
+    replaceCellPhoto,
+    removeCellPhoto,
+    reshuffle,
+  }
+}

--- a/package/website/src/composables/usePuzzleImageLoader.ts
+++ b/package/website/src/composables/usePuzzleImageLoader.ts
@@ -1,0 +1,144 @@
+/**
+ * 拼图图片加载器
+ *
+ * 全国拼图可能需要上千张缩略图，直接 new Image() 并发会打满浏览器连接池、
+ * 拖垮页面。这里做三件事：
+ *   1. 并发限流（默认 8 路）
+ *   2. 已解码图片缓存（同一张照片在多个格子复用时零成本）
+ *   3. 批量到货回调 —— 攒一批再触发重绘，避免每张图都重画一次画布
+ */
+
+import { onUnmounted, ref } from 'vue'
+
+export interface ImageLoaderOptions {
+  /** 并发上限 */
+  concurrency?: number
+  /** 重绘节流间隔（毫秒）：期间内到货的图片攒到一起触发一次回调 */
+  flushInterval?: number
+  /** 缩略图尺寸 */
+  size?: 'small' | 'medium' | 'large'
+}
+
+export function usePuzzleImageLoader(options: ImageLoaderOptions = {}) {
+  const { concurrency = 8, flushInterval = 120, size = 'small' } = options
+
+  /** photoId → 已解码图片 */
+  const cache = new Map<string, HTMLImageElement>()
+  /** 加载失败的 id，避免无限重试 */
+  const failed = new Set<string>()
+  /** 正在加载中的 id */
+  const pending = new Set<string>()
+
+  const queue: string[] = []
+  let active = 0
+  let destroyed = false
+
+  /** 已完成数量（含失败），用于进度展示 */
+  const loadedCount = ref(0)
+  /** 本轮请求总数 */
+  const totalCount = ref(0)
+
+  let flushTimer: number | null = null
+  let onBatchReady: (() => void) | null = null
+
+  const scheduleFlush = () => {
+    if (destroyed || flushTimer !== null) return
+    flushTimer = window.setTimeout(() => {
+      flushTimer = null
+      onBatchReady?.()
+    }, flushInterval)
+  }
+
+  const pump = () => {
+    if (destroyed) return
+    while (active < concurrency && queue.length > 0) {
+      const photoId = queue.shift()!
+      active++
+
+      const img = new Image()
+      // 同源请求（Vite /api 代理），无需 crossOrigin；
+      // 但显式声明可避免未来接入 CDN 时 canvas 被污染。
+      img.decoding = 'async'
+      img.src = `/api/medias/${photoId}/thumbnail?size=${size}`
+
+      const finalize = (ok: boolean) => {
+        active--
+        pending.delete(photoId)
+        loadedCount.value++
+        if (ok) {
+          cache.set(photoId, img)
+          scheduleFlush()
+        } else {
+          failed.add(photoId)
+        }
+        pump()
+      }
+
+      img.onload = () => finalize(true)
+      img.onerror = () => finalize(false)
+    }
+  }
+
+  /**
+   * 请求一批照片。已缓存/已在队列中的会自动跳过。
+   * @param photoIds 需要的照片 id（可含重复，内部去重）
+   * @param onReady  有新图片到货时的批量回调（用于触发重绘）
+   */
+  const request = (photoIds: (string | null)[], onReady: () => void) => {
+    onBatchReady = onReady
+    const unique = new Set<string>()
+    for (const id of photoIds) {
+      if (!id) continue
+      if (cache.has(id) || failed.has(id) || pending.has(id)) continue
+      unique.add(id)
+    }
+    if (!unique.size) return
+    for (const id of unique) {
+      pending.add(id)
+      queue.push(id)
+    }
+    totalCount.value += unique.size
+    pump()
+  }
+
+  /** 渲染器用的图片取用函数 */
+  const resolveImage = (photoId: string): HTMLImageElement | undefined => cache.get(photoId)
+
+  /** 放弃队列中尚未开始的任务（例如用户切换了省份） */
+  const cancelPending = () => {
+    queue.length = 0
+    pending.clear()
+  }
+
+  /** 重置进度计数（不清缓存，切换区域时照片可能复用） */
+  const resetProgress = () => {
+    loadedCount.value = 0
+    totalCount.value = 0
+  }
+
+  const dispose = () => {
+    destroyed = true
+    cancelPending()
+    cache.clear()
+    failed.clear()
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer)
+      flushTimer = null
+    }
+    onBatchReady = null
+  }
+
+  onUnmounted(dispose)
+
+  return {
+    request,
+    resolveImage,
+    cancelPending,
+    resetProgress,
+    dispose,
+    loadedCount,
+    totalCount,
+    /** 判断某张图是否已就绪，供换图预览使用 */
+    isReady: (id: string) => cache.has(id),
+  }
+}

--- a/package/website/src/stores/locationStore.ts
+++ b/package/website/src/stores/locationStore.ts
@@ -4,7 +4,7 @@ import { ref } from 'vue';
 
 export const useLocationStore = defineStore('location', () => {
   // Persistent State
-  const viewMode = useStorage<'grid' | 'map' | 'timeline' | 'trajectory' | 'statistics'>('trailsnap-location-view-mode', 'grid');
+  const viewMode = useStorage<'grid' | 'map' | 'timeline' | 'trajectory' | 'statistics' | 'puzzle'>('trailsnap-location-view-mode', 'grid');
   const level = useStorage<'city' | 'province' | 'district' | 'scene' | 'photo-map'>('trailsnap-location-level', 'city');
   const filterStatus = useStorage<'all' | 'checked' | 'unchecked'>('trailsnap-location-filter-status', 'checked')
   // State for Map Selection

--- a/package/website/src/utils/mapPuzzle/geoPath.ts
+++ b/package/website/src/utils/mapPuzzle/geoPath.ts
@@ -1,0 +1,336 @@
+/**
+ * GeoJSON → Path2D 转换与几何判定
+ *
+ * 拼图效果的核心是 ctx.clip(path)：先把行政区轮廓设为裁剪区域，
+ * 再往里铺照片，边缘照片就会被自动切成省界形状。
+ */
+
+import {
+  extractPolygons,
+  pruneSmallIslands,
+  type PolygonRings,
+  type Projector,
+} from './geoProjection'
+
+/** 一个行政区的几何信息 */
+export interface RegionGeometry {
+  /** 完整行政区名，如「河南省」 */
+  name: string
+  /** 国标编码（GeoJSON 字段名为 gb，形如 156410000，前 3 位是国家码 156） */
+  code: string
+  /** 已投影到画布坐标的多边形集合 */
+  polygons: PolygonRings[]
+  /** 该区域在画布中的像素包围盒 */
+  bounds: { x: number; y: number; width: number; height: number }
+}
+
+/**
+ * 把 GeoJSON feature 投影成画布坐标的几何对象。
+ * 注意：投影后坐标即为像素，后续判定/绘制都在像素空间进行。
+ *
+ * @param islandRatio 碎小岛礁裁剪阈值，需与 computeBBox 保持一致，
+ *                    否则包围盒与实际绘制的面不匹配会导致形状偏移。
+ */
+export function buildRegionGeometry(
+  feature: any,
+  projector: Projector,
+  islandRatio = 0.05
+): RegionGeometry {
+  const polygons: PolygonRings[] = []
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+
+  const source = pruneSmallIslands(extractPolygons(feature.geometry), islandRatio)
+  for (const polygon of source) {
+    const projectedRings: PolygonRings = []
+    for (const ring of polygon) {
+      const projectedRing: number[][] = []
+      for (const [lng, lat] of ring) {
+        const [x, y] = projector.project(lng, lat)
+        projectedRing.push([x, y])
+        if (x < minX) minX = x
+        if (x > maxX) maxX = x
+        if (y < minY) minY = y
+        if (y > maxY) maxY = y
+      }
+      projectedRings.push(projectedRing)
+    }
+    polygons.push(projectedRings)
+  }
+
+  if (!Number.isFinite(minX)) {
+    minX = minY = maxX = maxY = 0
+  }
+
+  return {
+    name: feature?.properties?.name ?? '',
+    code: feature?.properties?.gb ?? '',
+    polygons,
+    bounds: { x: minX, y: minY, width: maxX - minX, height: maxY - minY },
+  }
+}
+
+/**
+ * 构建 Path2D。
+ * 外环与内环（孔洞）都加入同一个 Path，配合 'evenodd' 填充规则，
+ * 内环会自动被挖空（例如被完全包围的飞地/湖泊）。
+ */
+export function buildPath2D(geometries: RegionGeometry[]): Path2D {
+  const path = new Path2D()
+  for (const geo of geometries) {
+    for (const rings of geo.polygons) {
+      for (const ring of rings) {
+        if (ring.length < 2) continue
+        path.moveTo(ring[0][0], ring[0][1])
+        for (let i = 1; i < ring.length; i++) {
+          path.lineTo(ring[i][0], ring[i][1])
+        }
+        path.closePath()
+      }
+    }
+  }
+  return path
+}
+
+/**
+ * 射线法判断点是否在多边形内（含孔洞处理）。
+ * 命中外环记 true，落在孔洞内则取反 → 最终等价于 even-odd 规则。
+ */
+function pointInRing(x: number, y: number, ring: number[][]): boolean {
+  let inside = false
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0]
+    const yi = ring[i][1]
+    const xj = ring[j][0]
+    const yj = ring[j][1]
+    // 判断水平射线是否穿过边 (i, j)
+    const intersect =
+      yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi
+    if (intersect) inside = !inside
+  }
+  return inside
+}
+
+// ---------------------------------------------------------------------------
+// 点在多边形内判定的加速索引
+//
+// 朴素射线法每次要遍历该省的所有边。实测新疆有 8556 个顶点、全国共 68519 个，
+// 在密集网格下（3000 格档位）会成为瓶颈（单次 buildGrid 耗时 2.6s）。
+//
+// 这里按 Y 轴把边分桶：水平扫描线只可能与「跨越该 Y 值」的边相交，
+// 因此只需检测落在对应桶内的边，把每次判定的边数从 O(全部边) 降到 O(局部边)。
+// ---------------------------------------------------------------------------
+
+/** 一条边的紧凑表示（避免对象属性访问开销） */
+interface EdgeIndex {
+  /** 每条边 4 个数：x0, y0, x1, y1 */
+  edges: Float64Array
+  /** 桶数组，每个桶存边在 edges 中的起始下标 */
+  buckets: Int32Array[]
+  minY: number
+  /** 1 / 桶高度，乘法比除法快 */
+  invBucketH: number
+  bucketCount: number
+  /** 该环是否为孔洞 */
+  isHole: boolean
+}
+
+/** 按 Y 轴分桶构建边索引 */
+function buildEdgeIndex(ring: number[][], isHole: boolean): EdgeIndex {
+  const n = ring.length
+  const edges = new Float64Array(n * 4)
+  let minY = Infinity
+  let maxY = -Infinity
+
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const o = i * 4
+    edges[o] = ring[j][0]
+    edges[o + 1] = ring[j][1]
+    edges[o + 2] = ring[i][0]
+    edges[o + 3] = ring[i][1]
+    const y0 = ring[j][1]
+    const y1 = ring[i][1]
+    if (y0 < minY) minY = y0
+    if (y0 > maxY) maxY = y0
+    if (y1 < minY) minY = y1
+    if (y1 > maxY) maxY = y1
+  }
+
+  // 桶数按边数开方量级选取，兼顾内存与命中率
+  const bucketCount = Math.max(1, Math.min(512, Math.ceil(Math.sqrt(n))))
+  const height = Math.max(1e-9, maxY - minY)
+  const bucketH = height / bucketCount
+  const invBucketH = 1 / bucketH
+
+  // 先统计每桶边数，再一次性分配（避免动态数组扩容）
+  const counts = new Int32Array(bucketCount)
+  for (let i = 0; i < n; i++) {
+    const o = i * 4
+    const ya = edges[o + 1]
+    const yb = edges[o + 3]
+    const lo = Math.min(ya, yb)
+    const hi = Math.max(ya, yb)
+    let b0 = Math.floor((lo - minY) * invBucketH)
+    let b1 = Math.floor((hi - minY) * invBucketH)
+    if (b0 < 0) b0 = 0
+    if (b1 >= bucketCount) b1 = bucketCount - 1
+    for (let b = b0; b <= b1; b++) counts[b]++
+  }
+
+  const buckets: Int32Array[] = new Array(bucketCount)
+  for (let b = 0; b < bucketCount; b++) buckets[b] = new Int32Array(counts[b])
+  const cursors = new Int32Array(bucketCount)
+
+  for (let i = 0; i < n; i++) {
+    const o = i * 4
+    const ya = edges[o + 1]
+    const yb = edges[o + 3]
+    const lo = Math.min(ya, yb)
+    const hi = Math.max(ya, yb)
+    let b0 = Math.floor((lo - minY) * invBucketH)
+    let b1 = Math.floor((hi - minY) * invBucketH)
+    if (b0 < 0) b0 = 0
+    if (b1 >= bucketCount) b1 = bucketCount - 1
+    for (let b = b0; b <= b1; b++) buckets[b][cursors[b]++] = o
+  }
+
+  return { edges, buckets, minY, invBucketH, bucketCount, isHole }
+}
+
+/** 借助边索引做射线法判定 */
+function pointInIndexedRing(x: number, y: number, idx: EdgeIndex): boolean {
+  let b = Math.floor((y - idx.minY) * idx.invBucketH)
+  if (b < 0 || b >= idx.bucketCount) return false
+  const bucket = idx.buckets[b]
+  const edges = idx.edges
+  let inside = false
+  for (let k = 0; k < bucket.length; k++) {
+    const o = bucket[k]
+    const xj = edges[o]
+    const yj = edges[o + 1]
+    const xi = edges[o + 2]
+    const yi = edges[o + 3]
+    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi) {
+      inside = !inside
+    }
+  }
+  return inside
+}
+
+/** 每个区域一组索引：外层数组对应 polygons，内层对应该 polygon 的环 */
+const indexCache = new WeakMap<RegionGeometry, EdgeIndex[][]>()
+
+function getIndex(geo: RegionGeometry): EdgeIndex[][] {
+  let cached = indexCache.get(geo)
+  if (cached) return cached
+  cached = geo.polygons.map((rings) => rings.map((ring, i) => buildEdgeIndex(ring, i > 0)))
+  indexCache.set(geo, cached)
+  return cached
+}
+
+/**
+ * 判断点是否落在某个行政区内部（考虑孔洞）。
+ * 首次调用会为该区域构建 Y 轴边索引并缓存（按几何对象弱引用，
+ * 几何随画布尺寸变化重建时旧索引会自动被回收）。
+ */
+export function pointInRegion(x: number, y: number, geo: RegionGeometry): boolean {
+  const index = getIndex(geo)
+  for (let p = 0; p < index.length; p++) {
+    const rings = index[p]
+    const outer = rings[0]
+    if (!outer || !pointInIndexedRing(x, y, outer)) continue
+    // 命中外环后，检查是否落在任一孔洞里
+    let inHole = false
+    for (let h = 1; h < rings.length; h++) {
+      if (pointInIndexedRing(x, y, rings[h])) {
+        inHole = true
+        break
+      }
+    }
+    if (!inHole) return true
+  }
+  return false
+}
+
+/** 判断点是否落在一组行政区中的任意一个内部，返回命中的区域 */
+export function findRegionAt(
+  x: number,
+  y: number,
+  geometries: RegionGeometry[]
+): RegionGeometry | null {
+  for (const geo of geometries) {
+    // 先用包围盒快速排除，避免对每个省都跑射线法
+    const b = geo.bounds
+    if (x < b.x || x > b.x + b.width || y < b.y || y > b.y + b.height) continue
+    if (pointInRegion(x, y, geo)) return geo
+  }
+  return null
+}
+
+/** 计算多边形面积（像素²，用于反解网格边长），带孔洞扣除 */
+export function computeArea(geometries: RegionGeometry[]): number {
+  let area = 0
+  for (const geo of geometries) {
+    for (const rings of geo.polygons) {
+      rings.forEach((ring, index) => {
+        // 鞋带公式求有向面积
+        let sum = 0
+        for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+          sum += ring[j][0] * ring[i][1] - ring[i][0] * ring[j][1]
+        }
+        const ringArea = Math.abs(sum / 2)
+        // 外环加，内环（孔洞）减
+        area += index === 0 ? ringArea : -ringArea
+      })
+    }
+  }
+  return Math.max(0, area)
+}
+
+/**
+ * 行政区名称归一化，用于把 GeoJSON 全称与数据库/接口返回的简称对齐。
+ * 与 MapContainer.vue / media.py 中的处理保持一致。
+ */
+const ADMIN_SUFFIX_REGEX =
+  /(省|市|自治区|特别行政区|回族自治区|壮族自治区|维吾尔自治区|自治州|地区|盟|县|区)$/
+
+export function shortenRegionName(name: string): string {
+  if (!name) return ''
+  return name.replace(ADMIN_SUFFIX_REGEX, '') || name
+}
+
+/**
+ * 过滤出可用于拼图的行政区 feature。
+ *
+ * 后端 geojson 里混有 8 个名为「境界线」的 MultiLineString（国界/未定国界绘制用），
+ * 它们没有 gb 编码、也不是面要素。若不剔除：
+ *   1. 会把包围盒撑大（境界线延伸到国境外），导致省份形状被压缩偏移；
+ *   2. extractPolygons 返回空数组，白占一个几何位。
+ * 因此这里只保留 Polygon / MultiPolygon 且带 gb 编码的要素。
+ */
+export function filterRegionFeatures(features: any[]): any[] {
+  return (features ?? []).filter((f) => {
+    const type = f?.geometry?.type
+    if (type !== 'Polygon' && type !== 'MultiPolygon') return false
+    const name = f?.properties?.name
+    if (!name || name === '境界线') return false
+    return true
+  })
+}
+
+/**
+ * 构建「简称 → 全称」映射表，便于用统计接口返回的名字反查 GeoJSON feature。
+ */
+export function buildNameMap(features: any[]): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const feature of features) {
+    const fullName: string = feature?.properties?.name
+    if (!fullName) continue
+    map[fullName] = fullName
+    const short = shortenRegionName(fullName)
+    if (short && short !== fullName) map[short] = fullName
+  }
+  return map
+}

--- a/package/website/src/utils/mapPuzzle/geoProjection.ts
+++ b/package/website/src/utils/mapPuzzle/geoProjection.ts
@@ -1,0 +1,152 @@
+/**
+ * GeoJSON 经纬度 → 画布坐标投影
+ *
+ * 拼图渲染只关心「形状在画布里好不好看」，不需要严格的地理投影精度，
+ * 因此这里采用简化的等距圆柱投影（Equirectangular）并对纬度做 cos 校正，
+ * 避免高纬度省份（如黑龙江、新疆）被横向拉伸得过宽。
+ */
+
+/** 经纬度包围盒 */
+export interface BBox {
+  minLng: number
+  minLat: number
+  maxLng: number
+  maxLat: number
+}
+
+/** 投影器：把 [lng, lat] 映射到画布像素坐标 */
+export interface Projector {
+  /** 投影单个坐标点 */
+  project: (lng: number, lat: number) => [number, number]
+  /** 形状实际占用的宽高（像素，已含 padding 外的绘制区域） */
+  width: number
+  height: number
+  /** 绘制区域左上角偏移（用于居中） */
+  offsetX: number
+  offsetY: number
+  /** 缩放比例（像素/度），供网格边长换算使用 */
+  scale: number
+}
+
+/** GeoJSON 的 Polygon / MultiPolygon 坐标环集合 */
+export type Ring = number[][]
+export type PolygonRings = Ring[]
+
+/**
+ * 从 GeoJSON geometry 中提取所有多边形（统一成 MultiPolygon 结构）。
+ * Polygon      → [ [outer, hole1, ...] ]
+ * MultiPolygon → [ [outer, hole...], [outer, hole...] ]
+ */
+export function extractPolygons(geometry: any): PolygonRings[] {
+  if (!geometry) return []
+  const { type, coordinates } = geometry
+  if (type === 'Polygon') return [coordinates as PolygonRings]
+  if (type === 'MultiPolygon') return coordinates as PolygonRings[]
+  return []
+}
+
+/** 计算环的面积（经纬度平方度，仅用于面之间的相对比较） */
+function ringAreaDeg(ring: Ring): number {
+  let sum = 0
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    sum += ring[j][0] * ring[i][1] - ring[i][0] * ring[j][1]
+  }
+  return Math.abs(sum / 2)
+}
+
+/**
+ * 剔除远离主体的碎小面（岛礁）。
+ *
+ * 为什么必须做：广东有 35 个面、浙江 75 个、海南多达 328 个（含南海诸岛）。
+ * 这些礁石面积极小却把包围盒撑得极大 —— 海南不裁剪时纬度跨度 16.33°，
+ * 导致海南岛主体被压缩成一小块、拼图出现大片空白；同时格子遍历量暴涨。
+ *
+ * 实测阈值取最大面积的 5%：34 个省的「有效面积/包围盒」填充率全部 ≥25%，
+ * 且每个省都至少保留主体面（不会误删整省）。海南主体填充率回到 60.6%。
+ *
+ * @param polygons  原始面集合
+ * @param ratio     保留阈值（相对最大面面积的比例）
+ */
+export function pruneSmallIslands(polygons: PolygonRings[], ratio = 0.05): PolygonRings[] {
+  if (ratio <= 0 || polygons.length <= 1) return polygons
+  const areas = polygons.map((p) => (p[0] ? ringAreaDeg(p[0]) : 0))
+  const max = Math.max(...areas)
+  if (max <= 0) return polygons
+  const kept = polygons.filter((_, i) => areas[i] >= max * ratio)
+  // 兜底：极端情况下全被过滤时保留最大面，避免整省消失
+  return kept.length ? kept : [polygons[areas.indexOf(max)]]
+}
+
+/**
+ * 计算一组 feature 的整体经纬度包围盒。
+ * @param islandRatio 传入 >0 时同步剔除碎小岛礁，避免包围盒被撑大
+ */
+export function computeBBox(features: any[], islandRatio = 0.05): BBox {
+  let minLng = Infinity
+  let minLat = Infinity
+  let maxLng = -Infinity
+  let maxLat = -Infinity
+
+  for (const feature of features) {
+    const polygons = pruneSmallIslands(extractPolygons(feature.geometry), islandRatio)
+    for (const polygon of polygons) {
+      // 只用外环即可确定包围盒（内环必然在外环内部）
+      const outer = polygon[0]
+      if (!outer) continue
+      for (const [lng, lat] of outer) {
+        if (lng < minLng) minLng = lng
+        if (lng > maxLng) maxLng = lng
+        if (lat < minLat) minLat = lat
+        if (lat > maxLat) maxLat = lat
+      }
+    }
+  }
+
+  // 退化保护：无有效坐标时给一个中国范围的兜底值
+  if (!Number.isFinite(minLng)) {
+    return { minLng: 73, minLat: 18, maxLng: 135, maxLat: 54 }
+  }
+  return { minLng, minLat, maxLng, maxLat }
+}
+
+/**
+ * 基于包围盒创建投影器，让形状在 (canvasWidth x canvasHeight) 内等比居中。
+ *
+ * @param bbox    目标区域经纬度范围
+ * @param width   画布宽度（CSS 像素）
+ * @param height  画布高度（CSS 像素）
+ * @param padding 四周留白（CSS 像素）
+ */
+export function createProjector(
+  bbox: BBox,
+  width: number,
+  height: number,
+  padding = 24
+): Projector {
+  const availW = Math.max(1, width - padding * 2)
+  const availH = Math.max(1, height - padding * 2)
+
+  // 纬度中心用于经度方向的 cos 校正，使形状接近真实观感
+  const centerLat = (bbox.minLat + bbox.maxLat) / 2
+  const lngCorrection = Math.cos((centerLat * Math.PI) / 180) || 1
+
+  const spanLng = Math.max(1e-6, (bbox.maxLng - bbox.minLng) * lngCorrection)
+  const spanLat = Math.max(1e-6, bbox.maxLat - bbox.minLat)
+
+  // 等比缩放，取较小者保证完整显示
+  const scale = Math.min(availW / spanLng, availH / spanLat)
+
+  const shapeW = spanLng * scale
+  const shapeH = spanLat * scale
+  const offsetX = padding + (availW - shapeW) / 2
+  const offsetY = padding + (availH - shapeH) / 2
+
+  const project = (lng: number, lat: number): [number, number] => {
+    const x = offsetX + (lng - bbox.minLng) * lngCorrection * scale
+    // 纬度向上增大，画布 y 向下增大，需翻转
+    const y = offsetY + (bbox.maxLat - lat) * scale
+    return [x, y]
+  }
+
+  return { project, width: shapeW, height: shapeH, offsetX, offsetY, scale }
+}

--- a/package/website/src/utils/mapPuzzle/gridFill.ts
+++ b/package/website/src/utils/mapPuzzle/gridFill.ts
@@ -1,0 +1,265 @@
+/**
+ * 网格切分与照片分配
+ *
+ * 基准格子边长由「全国总面积 / 目标张数」反解，因此各省分到的格子数
+ * 与其面积成正比（忠于真实地图形状）。
+ *
+ * 在此基础上做一层**按省自适应放大**：若某省的照片数少于它按基准尺寸
+ * 能容纳的格子数，就单独放大该省的格子，直到格子数不超过照片数 ——
+ * 这样照片少的省用大格子铺满，既不重复照片也不留空洞。
+ */
+
+import { computeArea, pointInRegion, type RegionGeometry } from './geoPath'
+
+/** 一个拼图格子 */
+export interface PuzzleCell {
+  /** 格子左上角坐标（画布像素） */
+  x: number
+  y: number
+  /** 格子边长（正方形） */
+  size: number
+  /** 所属行政区全称（全国图下用于按省分配照片） */
+  regionName: string
+  /** 格子与区域的重叠率 0~1，放大受限时用于优先保留覆盖度高的格子 */
+  coverage: number
+}
+
+export interface GridOptions {
+  /** 目标格子数量（实际数量会接近但不完全等于该值） */
+  targetCount: number
+  /** 格子最小边长限制（像素），防止张数过大导致格子碎成噪点 */
+  minCellSize?: number
+  /**
+   * 各区域可用照片数（区域全称 → 张数）。
+   * 提供后启用「照片少时自动增大格子尺寸」，减少同一张照片在省内重复。
+   */
+  photoCounts?: Map<string, number>
+  /**
+   * 是否跳过没有照片的区域（不为其生成任何格子）。
+   * 全国图开启后，没去过的省保持干净空白，只留轮廓。
+   */
+  skipEmptyRegions?: boolean
+  /** 格子自适应放大的上限倍数，防止极端情况下格子大到失去拼图感 */
+  maxCellScale?: number
+}
+
+/**
+ * 判断格子是否与区域有任何交集（用于「填满」模式）。
+ *
+ * 分三级递进，尽早短路以控制开销：
+ *   1. 包围盒排除
+ *   2. 稀疏 3x3 采样 —— 绝大多数格子（内部/远离边界）在此即可判定
+ *   3. 加密 5x5 采样 + 省界顶点检测 —— 仅对稀疏采样失败的格子执行
+ *
+ * 第 3 级必要性：细长的省界末梢（如陕西南部、甘肃河西走廊）可能让
+ * 稀疏采样点全部落在省外，却仍与省界相交，不补判会留下边缘空洞。
+ */
+function intersectsRegion(x: number, y: number, size: number, geo: RegionGeometry): boolean {
+  const b = geo.bounds
+  // ① 包围盒完全不相交
+  if (x + size < b.x || x > b.x + b.width || y + size < b.y || y > b.y + b.height) return false
+
+  // ② 稀疏 3x3 采样（含中心），命中即返回
+  for (let i = 0; i < 3; i++) {
+    for (let j = 0; j < 3; j++) {
+      const px = x + ((i + 0.5) / 3) * size
+      const py = y + ((j + 0.5) / 3) * size
+      if (pointInRegion(px, py, geo)) return true
+    }
+  }
+
+  // ③ 加密 5x5 采样，跳过已在 ② 中测过的位置
+  for (let i = 0; i < 5; i++) {
+    for (let j = 0; j < 5; j++) {
+      // 3x3 的采样点位于 1/6、3/6、5/6；5x5 位于 1/10、3/10…9/10，无重合
+      const px = x + ((i + 0.5) / 5) * size
+      const py = y + ((j + 0.5) / 5) * size
+      if (pointInRegion(px, py, geo)) return true
+    }
+  }
+
+  // ④ 采样全部落空时，检查是否有省界顶点落在格子内（细长末梢）
+  for (const rings of geo.polygons) {
+    for (const ring of rings) {
+      for (const [vx, vy] of ring) {
+        if (vx >= x && vx <= x + size && vy >= y && vy <= y + size) return true
+      }
+    }
+  }
+
+  return false
+}
+
+/**
+ * 单个区域内按给定边长铺格子。
+ *
+ * 采用「相交即保留」策略：只要格子与省界有任何交集就生成，
+ * 超出省界的部分会在渲染时被 ctx.clip() 裁掉，因此不会越界。
+ * 这样才能把省界内部完全填满 —— 实测省内像素填充率 91% → 99.97%。
+ */
+function fillRegion(
+  geo: RegionGeometry,
+  cell: number,
+  maxIterations = 200_000
+): PuzzleCell[] {
+  const b = geo.bounds
+  if (b.width <= 0 || b.height <= 0 || cell <= 0) return []
+
+  // 向外多铺一圈，确保省界最外缘也被格子覆盖
+  const cols = Math.ceil(b.width / cell) + 1
+  const rows = Math.ceil(b.height / cell) + 1
+  if (cols * rows > maxIterations) return []
+
+  // 让网格在区域包围盒内居中，使左右/上下边缘的溢出量均衡
+  const offsetX = b.x - (cols * cell - b.width) / 2
+  const offsetY = b.y - (rows * cell - b.height) / 2
+
+  const out: PuzzleCell[] = []
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const x = offsetX + c * cell
+      const y = offsetY + r * cell
+      if (!intersectsRegion(x, y, cell, geo)) continue
+      // coverage 目前不参与取舍（填满优先），置 1 以省去一次 9 点采样；
+      // 保留字段是为了渲染层/调试需要时可用
+      out.push({ x, y, size: cell, regionName: geo.name, coverage: 1 })
+    }
+  }
+  return out
+}
+
+/**
+ * 生成网格格子。
+ *
+ * @param geometries 目标行政区集合（单省时长度为 1；全国时为 34 个省）
+ * @param options    网格参数
+ */
+export function buildGrid(geometries: RegionGeometry[], options: GridOptions): PuzzleCell[] {
+  const {
+    targetCount,
+    minCellSize = 6,
+    photoCounts,
+    skipEmptyRegions = false,
+    maxCellScale = 14,
+  } = options
+  if (!geometries.length || targetCount <= 0) return []
+
+  const totalArea = computeArea(geometries)
+  if (totalArea <= 0) return []
+
+  // 基准边长。系数 1.03 是用真实 geojson 实测校准的结果，
+  // 使实际格子数与目标值的偏差保持在个位数百分比。
+  const baseCell = Math.max(minCellSize, Math.sqrt(totalArea / targetCount) * 1.03)
+
+  const cells: PuzzleCell[] = []
+
+  for (const geo of geometries) {
+    // 未出现在 photoCounts 里视为 0 张（该区域没去过）；
+    // 完全不传 photoCounts 时才视为不限张数，保持向后兼容。
+    const photos = photoCounts ? (photoCounts.get(geo.name) ?? 0) : Infinity
+
+    // 没有照片的区域：按需跳过，保持轮廓内干净空白
+    if (photos <= 0) {
+      if (skipEmptyRegions) continue
+      cells.push(...fillRegion(geo, baseCell))
+      continue
+    }
+
+    let regionCells = fillRegion(geo, baseCell)
+
+    // 照片不够铺满 → 逐步放大格子，直到格子数 <= 照片数。
+    // 放大而非删格，是为了在「不重复照片」的同时保持区域被完全填满。
+    if (Number.isFinite(photos) && regionCells.length > photos) {
+      let size = baseCell
+      const maxSize = baseCell * maxCellScale
+
+      for (let iter = 0; iter < 14 && regionCells.length > photos; iter++) {
+        // 格子数 ∝ 1/边长²，故边长按 sqrt(超出比例) 放大；
+        // 单次放大限制在 1.5 倍内，避免一步过冲导致格子远大于必要尺寸
+        const ratio = Math.min(Math.sqrt(regionCells.length / photos), 1.5)
+        const next = Math.min(size * ratio, maxSize)
+        if (next <= size) break
+        size = next
+        const grown = fillRegion(geo, size)
+        // 放大后一个格子都不剩时保留上一轮结果，避免该省整体消失
+        if (!grown.length) break
+        regionCells = grown
+        if (size >= maxSize) break
+      }
+
+      // 仍多于照片数时**不删格子**（删格会在地图上留下空洞），
+      // 改为让照片循环复用 —— 保持填满优先于绝对不重复。
+    }
+
+    // 面积过小拿不到任何格子的区域（北京/上海/港澳等），
+    // 只要它有照片就在中心补一格，保证「去过就被点亮」
+    if (!regionCells.length && photos > 0) {
+      const b = geo.bounds
+      if (b.width > 0 && b.height > 0) {
+        const size = Math.max(minCellSize, Math.min(baseCell, b.width, b.height))
+        regionCells = [
+          {
+            x: b.x + b.width / 2 - size / 2,
+            y: b.y + b.height / 2 - size / 2,
+            size,
+            regionName: geo.name,
+            coverage: 1,
+          },
+        ]
+      }
+    }
+
+    cells.push(...regionCells)
+  }
+
+  return cells
+}
+
+/**
+ * 把照片分配到格子上。
+ *
+ * **严格按行政区归属**：每个格子只会使用「它所在省份」的照片。
+ * 某省没有照片时该格子留空，绝不用其他省的照片填充 ——
+ * 否则拼图会失去「点亮地图」的意义：一个省份有照片才代表你去过那里。
+ *
+ * 配合 buildGrid 的自适应放大后，各省格子数通常已 ≤ 照片数，
+ * 因此同省内每格都能拿到不同照片；仅在放大受上限约束时才会循环复用。
+ *
+ * @param cells          有效格子
+ * @param photosByRegion 省份全称 → 该省照片 id 列表
+ * @returns 格子索引 → 照片 id（无照片的格子为 null）
+ */
+export function assignPhotos(
+  cells: PuzzleCell[],
+  photosByRegion: Map<string, string[]>
+): (string | null)[] {
+  // 每个省维护一个游标，顺序取用，保证同省照片在本省内均匀铺开
+  const cursors = new Map<string, number>()
+
+  return cells.map((cell) => {
+    const pool = photosByRegion.get(cell.regionName)
+    if (!pool || !pool.length) return null
+    const cursor = cursors.get(cell.regionName) ?? 0
+    cursors.set(cell.regionName, cursor + 1)
+    return pool[cursor % pool.length]
+  })
+}
+
+/**
+ * 打乱数组（Fisher-Yates），用于避免同一天拍的照片在拼图上扎堆。
+ * 返回新数组，不修改入参。
+ */
+export function shuffle<T>(items: T[], seed = 1): T[] {
+  const result = [...items]
+  // 简易可复现随机数（LCG），保证同一 seed 下重绘结果稳定，避免闪烁
+  let state = seed >>> 0 || 1
+  const random = () => {
+    state = (state * 1664525 + 1013904223) >>> 0
+    return state / 0xffffffff
+  }
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1))
+    ;[result[i], result[j]] = [result[j], result[i]]
+  }
+  return result
+}

--- a/package/website/src/utils/mapPuzzle/renderer.ts
+++ b/package/website/src/utils/mapPuzzle/renderer.ts
@@ -1,0 +1,301 @@
+/**
+ * 拼图 Canvas 渲染器
+ *
+ * 渲染顺序（顺序很关键）：
+ *   1. 清空 + 背景
+ *   2. save() → clip(轮廓 Path2D) → 铺照片格子 → restore()
+ *   3. 轮廓描边 / 外发光
+ *   4. 高亮区域（hover）
+ *   5. 区域名称文字
+ *
+ * 第 2 步先 clip 再画照片，边缘格子会被自动切成省界形状，
+ * 这正是「照片拼成地图」效果的来源。
+ */
+
+import { buildPath2D, type RegionGeometry } from './geoPath'
+import type { PuzzleCell } from './gridFill'
+
+export interface RenderTheme {
+  /** 画布背景色；传 null 表示透明背景 */
+  background: string | null
+  /** 已点亮区域的轮廓描边色 */
+  stroke: string
+  /** 描边宽度 */
+  strokeWidth: number
+  /** 未点亮（无照片）区域的轮廓色，应明显淡于 stroke */
+  unlitStroke: string
+  /** 外发光颜色，null 关闭 */
+  glow: string | null
+  /** 照片加载中的占位格子颜色 */
+  placeholder: string
+  /** 区域名称文字颜色 */
+  labelColor: string
+  /** 区域名称描边色（保证在照片上可读） */
+  labelStroke: string
+}
+
+export interface RenderOptions {
+  /** 是否显示区域名称 */
+  showLabel: boolean
+  /** 标签字号（像素）；不传则按区域尺寸自适应 */
+  labelSize?: number
+  /** hover 高亮的区域名称 */
+  hoverRegion?: string | null
+  /**
+   * 有照片（已点亮）的区域名集合。
+   * 提供后未点亮的区域只画淡描边、不显示名称，与已点亮区域形成对比。
+   */
+  litRegions?: Set<string>
+  theme: RenderTheme
+}
+
+/** 图片取用回调：返回已解码的图片，未加载完成时返回 undefined */
+export type ImageResolver = (photoId: string) => HTMLImageElement | ImageBitmap | undefined
+
+/** 默认亮色主题 */
+export const LIGHT_THEME: RenderTheme = {
+  background: null,
+  stroke: 'rgba(255,255,255,0.9)',
+  strokeWidth: 1.5,
+  unlitStroke: 'rgba(148,163,184,0.45)',
+  glow: null,
+  placeholder: 'rgba(148,163,184,0.25)',
+  labelColor: 'rgba(255,255,255,0.95)',
+  labelStroke: 'rgba(15,23,42,0.55)',
+}
+
+/** 默认暗色主题 */
+export const DARK_THEME: RenderTheme = {
+  background: null,
+  stroke: 'rgba(255,255,255,0.75)',
+  strokeWidth: 1.5,
+  unlitStroke: 'rgba(100,116,139,0.5)',
+  glow: null,
+  placeholder: 'rgba(71,85,105,0.35)',
+  labelColor: 'rgba(255,255,255,0.95)',
+  labelStroke: 'rgba(0,0,0,0.6)',
+}
+
+/**
+ * 以 object-fit: cover 的语义把图片绘制到目标矩形：
+ * 按短边填满并居中裁剪，避免照片被拉伸变形。
+ */
+function drawImageCover(
+  ctx: CanvasRenderingContext2D,
+  img: HTMLImageElement | ImageBitmap,
+  dx: number,
+  dy: number,
+  dw: number,
+  dh: number
+) {
+  const iw = (img as HTMLImageElement).naturalWidth ?? (img as ImageBitmap).width
+  const ih = (img as HTMLImageElement).naturalHeight ?? (img as ImageBitmap).height
+  if (!iw || !ih) return
+
+  const scale = Math.max(dw / iw, dh / ih)
+  const sw = dw / scale
+  const sh = dh / scale
+  const sx = (iw - sw) / 2
+  const sy = (ih - sh) / 2
+  ctx.drawImage(img as CanvasImageSource, sx, sy, sw, sh, dx, dy, dw, dh)
+}
+
+/**
+ * 描边区域轮廓。
+ *
+ * 已点亮（有照片）的区域用主题色实线 + 可选外发光；
+ * 未点亮的区域用更细更淡的线，只作为「中国版图」的参照存在，
+ * 这样视觉重心落在你真正去过的地方。
+ */
+function strokeRegions(
+  ctx: CanvasRenderingContext2D,
+  geometries: RegionGeometry[],
+  theme: RenderTheme,
+  litRegions?: Set<string>
+) {
+  if (theme.strokeWidth <= 0) return
+
+  const lit = litRegions ? geometries.filter((g) => litRegions.has(g.name)) : geometries
+  const unlit = litRegions ? geometries.filter((g) => !litRegions.has(g.name)) : []
+
+  // 未点亮区域：淡描边，不发光
+  if (unlit.length) {
+    const path = buildPath2D(unlit)
+    ctx.save()
+    ctx.strokeStyle = theme.unlitStroke
+    ctx.lineWidth = Math.max(0.5, theme.strokeWidth * 0.6)
+    ctx.lineJoin = 'round'
+    ctx.stroke(path)
+    ctx.restore()
+  }
+
+  if (!lit.length) return
+  const path = buildPath2D(lit)
+
+  if (theme.glow) {
+    ctx.save()
+    ctx.shadowColor = theme.glow
+    ctx.shadowBlur = 18
+    ctx.strokeStyle = theme.stroke
+    ctx.lineWidth = theme.strokeWidth
+    ctx.stroke(path)
+    ctx.restore()
+  }
+
+  ctx.save()
+  ctx.strokeStyle = theme.stroke
+  ctx.lineWidth = theme.strokeWidth
+  ctx.lineJoin = 'round'
+  ctx.stroke(path)
+  ctx.restore()
+}
+
+/** 绘制区域名称：粗体白字 + 深色描边，保证压在照片上仍可读 */
+function drawLabel(
+  ctx: CanvasRenderingContext2D,
+  geo: RegionGeometry,
+  options: RenderOptions
+) {
+  const { theme } = options
+  const b = geo.bounds
+  // 未指定字号时按区域短边自适应，并限制上下限
+  const size =
+    options.labelSize ?? Math.max(12, Math.min(72, Math.min(b.width, b.height) * 0.28))
+
+  ctx.save()
+  ctx.font = `700 ${size}px "PingFang SC", "Microsoft YaHei", system-ui, sans-serif`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.lineJoin = 'round'
+
+  const cx = b.x + b.width / 2
+  const cy = b.y + b.height / 2
+
+  ctx.lineWidth = Math.max(2, size * 0.14)
+  ctx.strokeStyle = theme.labelStroke
+  ctx.strokeText(geo.name, cx, cy)
+  ctx.fillStyle = theme.labelColor
+  ctx.fillText(geo.name, cx, cy)
+  ctx.restore()
+}
+
+export interface RenderContext {
+  ctx: CanvasRenderingContext2D
+  /** CSS 像素尺寸（非物理像素） */
+  width: number
+  height: number
+  geometries: RegionGeometry[]
+  cells: PuzzleCell[]
+  /** 格子索引 → 照片 id */
+  assignments: (string | null)[]
+  resolveImage: ImageResolver
+  options: RenderOptions
+}
+
+/**
+ * 执行一次完整渲染。
+ * 该函数为纯绘制、无副作用，可在任意时机重复调用（图片到货后重绘即可）。
+ */
+export function renderPuzzle(context: RenderContext): void {
+  const { ctx, width, height, geometries, cells, assignments, resolveImage, options } = context
+  const { theme } = options
+
+  ctx.clearRect(0, 0, width, height)
+
+  if (theme.background) {
+    ctx.fillStyle = theme.background
+    ctx.fillRect(0, 0, width, height)
+  }
+
+  if (!geometries.length) return
+
+  // ---- 照片层：按省分组，每个省用「自己的轮廓」裁剪 ----
+  //
+  // 关键点：裁剪路径必须是单个省的轮廓，不能是全部省合成的大路径。
+  // 若用合成路径，陕西的格子只要落在「任意一个省」范围内就不会被裁掉，
+  // 于是会溢出到邻省地盘上（全国图曾出现此问题；单省图因只有 1 个省而正常）。
+  const cellsByRegion = new Map<string, number[]>()
+  for (let i = 0; i < cells.length; i++) {
+    if (!assignments[i]) continue // 无照片的格子不画
+    const name = cells[i].regionName
+    const list = cellsByRegion.get(name)
+    if (list) list.push(i)
+    else cellsByRegion.set(name, [i])
+  }
+
+  for (const geo of geometries) {
+    const indices = cellsByRegion.get(geo.name)
+    if (!indices || !indices.length) continue
+
+    ctx.save()
+    // evenodd 让内环（孔洞）不被填充，与 buildPath2D 的环收集方式配套
+    ctx.clip(buildPath2D([geo]), 'evenodd')
+
+    for (const i of indices) {
+      const cell = cells[i]
+      const size = cell.size
+      if (size <= 0) continue
+
+      const img = resolveImage(assignments[i] as string)
+      if (img) {
+        drawImageCover(ctx, img, cell.x, cell.y, size, size)
+      } else {
+        // 图片尚在加载中：画占位色，到货后重绘替换
+        ctx.fillStyle = theme.placeholder
+        ctx.fillRect(cell.x, cell.y, size, size)
+      }
+    }
+
+    ctx.restore()
+  }
+
+  // ---- hover 高亮层 ----
+  if (options.hoverRegion) {
+    const target = geometries.find((g) => g.name === options.hoverRegion)
+    if (target) {
+      const hoverPath = buildPath2D([target])
+      ctx.save()
+      ctx.fillStyle = 'rgba(255,255,255,0.18)'
+      ctx.fill(hoverPath, 'evenodd')
+      ctx.strokeStyle = theme.stroke
+      ctx.lineWidth = theme.strokeWidth * 2
+      ctx.lineJoin = 'round'
+      ctx.stroke(hoverPath)
+      ctx.restore()
+    }
+  }
+
+  // ---- 轮廓描边层 ----
+  strokeRegions(ctx, geometries, theme, options.litRegions)
+
+  // ---- 文字层 ----
+  if (options.showLabel) {
+    for (const geo of geometries) {
+      // 太小的区域画字反而糊，跳过
+      if (geo.bounds.width < 28 || geo.bounds.height < 20) continue
+      // 未点亮的区域不标名称，避免空白省份的文字抢走视觉重心
+      if (options.litRegions && !options.litRegions.has(geo.name)) continue
+      drawLabel(ctx, geo, options)
+    }
+  }
+}
+
+/**
+ * 按设备像素比初始化画布，避免高分屏下模糊。
+ * 返回 CSS 像素下的绘制上下文（已 scale，绘制时无需关心 dpr）。
+ */
+export function setupCanvas(
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+  dpr = window.devicePixelRatio || 1
+): CanvasRenderingContext2D | null {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+  canvas.width = Math.round(width * dpr)
+  canvas.height = Math.round(height * dpr)
+  canvas.style.width = `${width}px`
+  canvas.style.height = `${height}px`
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  return ctx
+}

--- a/package/website/src/views/album/location/LocationList.vue
+++ b/package/website/src/views/album/location/LocationList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['location-list flex flex-col relative py-6 px-4', (viewMode === 'map' || viewMode === 'trajectory') ? 'h-screen' : 'container mx-auto']">
+  <div :class="['location-list flex flex-col relative py-6 px-4', (viewMode === 'map' || viewMode === 'trajectory' || viewMode === 'puzzle') ? 'h-screen' : 'container mx-auto']">
     <!-- Header -->
     <div class="container mx-auto flex sm:flex-row justify-between items-start sm:items-center gap-4 flex-shrink-0 z-50 transition-all duration-300 pb-2">
       <div class="flex flex-col gap-3">
@@ -304,6 +304,13 @@
               <BarChart3 class="w-4 h-4" />
               统计视图
             </button>
+            <button
+              @click="viewMode = 'puzzle'; showViewMenu = false"
+              :class="['w-full px-4 py-2 text-left text-sm dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2', viewMode === 'puzzle' ? 'text-primary-500 font-medium' : 'text-gray-700 dark:text-gray-200']"
+            >
+              <Shapes class="w-4 h-4" />
+              照片拼图
+            </button>
           </div>
 
           <!-- Desktop Buttons -->
@@ -342,6 +349,13 @@
               title="统计视图"
             >
               <BarChart3 class="w-4 h-4" />
+            </button>
+            <button
+              @click="viewMode = 'puzzle'"
+              :class="['p-1.5 rounded-md transition-all bg-white dark:bg-gray-700', viewMode === 'puzzle' ? 'shadow-sm text-primary-500' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200']"
+              title="照片拼图"
+            >
+              <Shapes class="w-4 h-4" />
             </button>
           </div>
         </div>
@@ -404,6 +418,13 @@
       @narrow-range="handleNarrowRange"
       @go-location="goToLocation"
     />
+    <!-- Puzzle View -->
+    <LocationPuzzleView
+      v-if="viewMode === 'puzzle'"
+      :start-date="dateRange?.[0]"
+      :end-date="dateRange?.[1]"
+      class="flex-1"
+    />
     <AddSceneDialog v-model="showAddScene" :edit-data="editingScene" @success="fetchLocations" />
   </div>
 </template>
@@ -416,7 +437,7 @@ import { useLocationStore } from '@/stores/locationStore'
 import { locationService } from '@/api/location'
 import type { Location, LocationStatistics, Scene } from '@/types/location'
 import type { Photo } from '@/types/album'
-import { ArrowLeft, LayoutGrid, Map, Images, Plus, ChevronDown, Calendar, Check, Clock, Route, BarChart3 } from 'lucide-vue-next'
+import { ArrowLeft, LayoutGrid, Map, Images, Plus, ChevronDown, Calendar, Check, Clock, Route, BarChart3, Shapes } from 'lucide-vue-next'
 import { onClickOutside } from '@vueuse/core'
 import { ElMessageBox, ElMessage } from 'element-plus'
 import LocationMap from './LocationMap.vue'
@@ -426,6 +447,7 @@ import LocationMapView from './LocationMapView.vue'
 import LocationTimelineView from './LocationTimelineView.vue'
 import LocationTrajectoryView from './LocationTrajectoryView.vue'
 import LocationStatsView from './LocationStatsView.vue'
+import LocationPuzzleView from './LocationPuzzleView.vue'
 import PhotoLightbox from '@/components/PhotoLightbox.vue'
 
 const router = useRouter()
@@ -550,6 +572,7 @@ const currentViewIcon = computed(() => {
     case 'timeline': return Clock
     case 'trajectory': return Route
     case 'statistics': return BarChart3
+    case 'puzzle': return Shapes
     default: return LayoutGrid
   }
 })

--- a/package/website/src/views/album/location/LocationPuzzleView.vue
+++ b/package/website/src/views/album/location/LocationPuzzleView.vue
@@ -1,0 +1,232 @@
+<template>
+  <div class="location-puzzle flex flex-col md:flex-row w-full h-full">
+    <!-- 左侧拼图画布 -->
+    <div class="flex-1 relative overflow-hidden bg-gray-50 dark:bg-gray-900 h-[50vh] md:h-full">
+      <!-- 加载遮罩 -->
+      <div
+        v-if="loading"
+        class="absolute inset-0 z-30 flex flex-col items-center justify-center gap-3 bg-gray-50/80 dark:bg-gray-900/80 backdrop-blur-sm"
+      >
+        <span
+          class="w-8 h-8 rounded-full border-[3px] border-primary-500 border-t-transparent animate-spin"
+        />
+        <p class="text-sm text-gray-500 dark:text-gray-400">正在生成拼图…</p>
+      </div>
+
+      <!-- 错误态 -->
+      <div
+        v-else-if="error"
+        class="absolute inset-0 z-30 flex flex-col items-center justify-center gap-3 px-6 text-center"
+      >
+        <ImageOff class="w-10 h-10 text-gray-300 dark:text-gray-600" />
+        <p class="text-sm text-gray-500 dark:text-gray-400">{{ error }}</p>
+        <button
+          class="px-4 py-2 rounded-lg bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+          @click="reload"
+        >
+          重新加载
+        </button>
+      </div>
+
+      <!-- 空态 -->
+      <div
+        v-else-if="!loading && !cells.length"
+        class="absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 px-6 text-center"
+      >
+        <MapPin class="w-10 h-10 text-gray-300 dark:text-gray-600" />
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          还没有带位置信息的照片，无法生成拼图
+        </p>
+      </div>
+
+      <PuzzleCanvas
+        ref="canvasRef"
+        :geometries="geometries"
+        :cells="cells"
+        :assignments="assignments"
+        :region-counts="regionCounts"
+        :show-label="config.showLabel"
+        :interactive="true"
+        :thumbnail-size="scope === 'nation' ? 'small' : 'medium'"
+        @select-region="handleSelectRegion"
+        @select-cell="handleSelectCell"
+        @resize="resize"
+      />
+
+      <!-- 返回全国按钮（单省模式，浮在画布左上） -->
+      <button
+        v-if="scope === 'province'"
+        class="absolute top-3 left-3 z-20 px-3 py-1.5 rounded-lg bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm shadow-md text-sm text-gray-700 dark:text-gray-200 hover:bg-white dark:hover:bg-gray-800 transition-colors flex items-center gap-1.5 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+        @click="handleDrillUp"
+      >
+        <ChevronLeft class="w-4 h-4" />
+        全国
+      </button>
+    </div>
+
+    <!-- 右侧配置面板 -->
+    <div
+      class="w-full md:w-80 lg:w-96 flex flex-col bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-t md:border-t-0 md:border-l border-gray-200 dark:border-gray-700 h-[50vh] md:h-full z-10"
+    >
+      <el-scrollbar class="flex-1">
+        <div class="p-4 md:p-6">
+          <PuzzlePanel
+            :scope="scope"
+            :active-province="activeProvince"
+            :config="config"
+            :cell-count="cells.length"
+            :used-photo-count="usedPhotoCount"
+            :region-counts="regionCounts"
+            :loading="loading"
+            @update-config="handleUpdateConfig"
+            @drill-down="handleSelectRegion"
+            @drill-up="handleDrillUp"
+            @reshuffle="reshuffle"
+          />
+        </div>
+      </el-scrollbar>
+    </div>
+
+    <!-- 格子换图操作弹层 -->
+    <el-dialog
+      v-model="cellDialogVisible"
+      title="调整这个位置"
+      width="320px"
+      align-center
+      append-to-body
+    >
+      <div class="flex flex-col gap-3">
+        <img
+          v-if="activeCellPhotoUrl"
+          :src="activeCellPhotoUrl"
+          alt="当前照片"
+          class="w-full aspect-square object-cover rounded-lg"
+        />
+        <div v-else class="w-full aspect-square rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center text-sm text-gray-400">
+          这个位置是空的
+        </div>
+        <div class="flex gap-2">
+          <button
+            class="flex-1 py-2 rounded-lg bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+            @click="handleReplaceCell"
+          >
+            换一张
+          </button>
+          <button
+            class="flex-1 py-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+            @click="handleRemoveCell"
+          >
+            留空
+          </button>
+        </div>
+      </div>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { ChevronLeft, ImageOff, MapPin } from 'lucide-vue-next'
+import PuzzleCanvas from './components/PuzzleCanvas.vue'
+import PuzzlePanel from './components/PuzzlePanel.vue'
+import { useMapPuzzle, type PuzzleConfig } from '@/composables/useMapPuzzle'
+
+const props = defineProps<{
+  startDate?: string
+  endDate?: string
+}>()
+
+const canvasRef = ref<InstanceType<typeof PuzzleCanvas> | null>(null)
+
+const {
+  scope,
+  activeProvince,
+  config,
+  loading,
+  error,
+  geometries,
+  cells,
+  assignments,
+  regionCounts,
+  usedPhotoCount,
+  loadNation,
+  drillDown,
+  drillUp,
+  resize,
+  recompute,
+  replaceCellPhoto,
+  removeCellPhoto,
+  reshuffle,
+} = useMapPuzzle()
+
+// --- 格子编辑 ---
+const cellDialogVisible = ref(false)
+const activeCellIndex = ref<number | null>(null)
+
+const activeCellPhotoUrl = computed(() => {
+  if (activeCellIndex.value === null) return null
+  const id = assignments.value[activeCellIndex.value]
+  return id ? `/api/medias/${id}/thumbnail?size=medium` : null
+})
+
+const handleSelectRegion = async (name: string) => {
+  // 全国图点省下钻；单省图点自身不做处理（交由格子命中逻辑）
+  if (scope.value !== 'nation') return
+  const count = regionCounts.value.get(name) ?? 0
+  if (count <= 0) return
+  await drillDown(name, props.startDate, props.endDate)
+}
+
+const handleSelectCell = (index: number) => {
+  // 仅单省模式允许编辑，全国图格子太小没有意义
+  if (scope.value !== 'province') return
+  activeCellIndex.value = index
+  cellDialogVisible.value = true
+}
+
+const handleReplaceCell = () => {
+  if (activeCellIndex.value === null) return
+  replaceCellPhoto(activeCellIndex.value)
+}
+
+const handleRemoveCell = () => {
+  if (activeCellIndex.value === null) return
+  removeCellPhoto(activeCellIndex.value)
+  cellDialogVisible.value = false
+}
+
+const handleDrillUp = async () => {
+  await drillUp(props.startDate, props.endDate)
+}
+
+const handleUpdateConfig = (patch: Partial<PuzzleConfig>) => {
+  const needRecompute = 'targetCount' in patch
+  const needReload = 'strategy' in patch
+  config.value = { ...config.value, ...patch }
+
+  if (needReload) {
+    reload()
+  } else if (needRecompute) {
+    recompute()
+  }
+  // showLabel 只影响绘制，由 PuzzleCanvas 内部 watch 自动重绘
+}
+
+const reload = async () => {
+  if (scope.value === 'province' && activeProvince.value) {
+    await drillDown(activeProvince.value, props.startDate, props.endDate)
+  } else {
+    await loadNation(props.startDate, props.endDate)
+  }
+}
+
+// 日期筛选变化时重新加载
+watch(
+  () => [props.startDate, props.endDate],
+  () => reload()
+)
+
+onMounted(() => {
+  loadNation(props.startDate, props.endDate)
+})
+</script>

--- a/package/website/src/views/album/location/components/PuzzleCanvas.vue
+++ b/package/website/src/views/album/location/components/PuzzleCanvas.vue
@@ -1,0 +1,262 @@
+<template>
+  <div ref="containerRef" class="relative w-full h-full overflow-hidden">
+    <canvas
+      ref="canvasRef"
+      :class="[
+        'block',
+        interactive ? (hoverRegion ? 'cursor-pointer' : 'cursor-default') : 'cursor-default',
+      ]"
+      @mousemove="handlePointerMove"
+      @mouseleave="handlePointerLeave"
+      @click="handleClick"
+    />
+
+    <!-- hover 提示浮层 -->
+    <div
+      v-if="hoverRegion && tooltip.visible"
+      class="pointer-events-none absolute z-20 px-2.5 py-1.5 rounded-lg bg-gray-900/90 dark:bg-gray-800/95 text-white text-xs font-medium shadow-lg whitespace-nowrap"
+      :style="{ left: `${tooltip.x}px`, top: `${tooltip.y}px`, transform: 'translate(-50%, -130%)' }"
+    >
+      {{ hoverRegion }}
+      <span class="text-gray-300 dark:text-gray-400">
+        · {{ regionCounts.get(hoverRegion) ?? 0 }} 张
+      </span>
+    </div>
+
+    <!-- 加载进度 -->
+    <div
+      v-if="showProgress"
+      class="absolute bottom-3 left-1/2 -translate-x-1/2 z-20 px-3 py-1.5 rounded-full bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm shadow-md text-xs text-gray-600 dark:text-gray-300 flex items-center gap-2"
+    >
+      <span class="w-3 h-3 rounded-full border-2 border-primary-500 border-t-transparent animate-spin" />
+      正在加载照片 {{ loader.loadedCount.value }} / {{ loader.totalCount.value }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { findRegionAt, type RegionGeometry } from '@/utils/mapPuzzle/geoPath'
+import type { PuzzleCell } from '@/utils/mapPuzzle/gridFill'
+import {
+  DARK_THEME,
+  LIGHT_THEME,
+  renderPuzzle,
+  setupCanvas,
+  type RenderTheme,
+} from '@/utils/mapPuzzle/renderer'
+import { usePuzzleImageLoader } from '@/composables/usePuzzleImageLoader'
+import { injectTheme } from '@/composables/useTheme'
+
+const props = defineProps<{
+  geometries: RegionGeometry[]
+  cells: PuzzleCell[]
+  assignments: (string | null)[]
+  regionCounts: Map<string, number>
+  showLabel: boolean
+  /** 是否响应 hover / 点击（全国图开启，单省图用于换图） */
+  interactive?: boolean
+  /** 缩略图尺寸：全国图用 small，单省用 medium */
+  thumbnailSize?: 'small' | 'medium'
+}>()
+
+const emit = defineEmits<{
+  (e: 'select-region', name: string): void
+  (e: 'select-cell', index: number): void
+  (e: 'resize', width: number, height: number): void
+}>()
+
+const containerRef = ref<HTMLDivElement | null>(null)
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+const ctxRef = ref<CanvasRenderingContext2D | null>(null)
+
+const hoverRegion = ref<string | null>(null)
+const tooltip = reactive({ visible: false, x: 0, y: 0 })
+
+const size = reactive({ width: 0, height: 0 })
+
+const loader = usePuzzleImageLoader({
+  concurrency: 8,
+  size: props.thumbnailSize ?? 'small',
+})
+
+const showProgress = computed(
+  () => loader.totalCount.value > 0 && loader.loadedCount.value < loader.totalCount.value
+)
+
+// 暗色模式跟随 html.dark，与项目其他地方保持一致
+const isDark = ref(document.documentElement.classList.contains('dark'))
+let darkObserver: MutationObserver | null = null
+
+// 主题色用于描边跟随用户选择的主题
+const { currentTheme } = injectTheme()
+
+const theme = computed<RenderTheme>(() => {
+  const base = isDark.value ? DARK_THEME : LIGHT_THEME
+  return {
+    ...base,
+    // 轮廓描边使用主题色，比纯白更有辨识度
+    stroke: currentTheme.value?.primary ?? base.stroke,
+    glow: `rgba(${currentTheme.value?.rgb ?? '56,189,248'},0.45)`,
+  }
+})
+
+/**
+ * 已点亮（有格子且分到照片）的区域集合。
+ * 由 cells + assignments 反推，无需父组件额外传参。
+ */
+const litRegions = computed(() => {
+  const set = new Set<string>()
+  for (let i = 0; i < props.cells.length; i++) {
+    if (props.assignments[i]) set.add(props.cells[i].regionName)
+  }
+  return set
+})
+
+/** 执行绘制 */
+const draw = () => {
+  const ctx = ctxRef.value
+  if (!ctx) return
+  renderPuzzle({
+    ctx,
+    width: size.width,
+    height: size.height,
+    geometries: props.geometries,
+    cells: props.cells,
+    assignments: props.assignments,
+    resolveImage: loader.resolveImage,
+    options: {
+      showLabel: props.showLabel,
+      hoverRegion: hoverRegion.value,
+      litRegions: litRegions.value,
+      theme: theme.value,
+    },
+  })
+}
+
+/** 初始化 / 重建画布（尺寸或 dpr 变化时） */
+const setup = () => {
+  const canvas = canvasRef.value
+  if (!canvas || size.width <= 0 || size.height <= 0) return
+  ctxRef.value = setupCanvas(canvas, size.width, size.height)
+  draw()
+}
+
+/** 请求当前分配用到的照片，到货后批量重绘 */
+const requestImages = () => {
+  if (!props.assignments.length) return
+  loader.request(props.assignments, draw)
+}
+
+const handlePointerMove = (e: MouseEvent) => {
+  if (!props.interactive) return
+  const canvas = canvasRef.value
+  if (!canvas) return
+  const rect = canvas.getBoundingClientRect()
+  const x = e.clientX - rect.left
+  const y = e.clientY - rect.top
+
+  const hit = findRegionAt(x, y, props.geometries)
+  // 只对已点亮的省份响应 hover —— 没去过的省点进去是空拼图，没有意义
+  const nextName = hit && litRegions.value.has(hit.name) ? hit.name : null
+
+  tooltip.x = x
+  tooltip.y = y
+  tooltip.visible = !!nextName
+
+  if (nextName !== hoverRegion.value) {
+    hoverRegion.value = nextName
+    draw()
+  }
+}
+
+const handlePointerLeave = () => {
+  tooltip.visible = false
+  if (hoverRegion.value !== null) {
+    hoverRegion.value = null
+    draw()
+  }
+}
+
+const handleClick = (e: MouseEvent) => {
+  if (!props.interactive) return
+  const canvas = canvasRef.value
+  if (!canvas) return
+  const rect = canvas.getBoundingClientRect()
+  const x = e.clientX - rect.left
+  const y = e.clientY - rect.top
+
+  const hit = findRegionAt(x, y, props.geometries)
+  // 未点亮的省份不允许下钻（进去必然是空拼图）
+  if (hit && litRegions.value.has(hit.name)) {
+    emit('select-region', hit.name)
+    return
+  }
+  // 未命中区域时，尝试命中格子（单省模式下用于换图）
+  const index = props.cells.findIndex(
+    (c) => x >= c.x && x <= c.x + c.size && y >= c.y && y <= c.y + c.size
+  )
+  if (index >= 0) emit('select-cell', index)
+}
+
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  const container = containerRef.value
+  if (!container) return
+
+  resizeObserver = new ResizeObserver((entries) => {
+    const entry = entries[0]
+    if (!entry) return
+    const { width, height } = entry.contentRect
+    if (width <= 0 || height <= 0) return
+    size.width = width
+    size.height = height
+    setup()
+    emit('resize', width, height)
+  })
+  resizeObserver.observe(container)
+
+  // 监听 html.dark 变化以切换主题
+  darkObserver = new MutationObserver(() => {
+    const next = document.documentElement.classList.contains('dark')
+    if (next !== isDark.value) {
+      isDark.value = next
+      draw()
+    }
+  })
+  darkObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class'],
+  })
+})
+
+onUnmounted(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  darkObserver?.disconnect()
+  darkObserver = null
+})
+
+// 几何/格子变化 → 重绘 + 拉图
+watch(
+  () => [props.geometries, props.cells, props.assignments],
+  () => {
+    draw()
+    requestImages()
+  },
+  { deep: false }
+)
+
+// 纯样式参数变化 → 只重绘，不重新拉图
+watch(() => props.showLabel, draw)
+
+// 主题色变化 → 重绘（JS 驱动的绘制不会自动响应主题类）
+watch(currentTheme, draw)
+
+defineExpose({
+  /** 供父组件导出图片时取用（后续导出功能预留） */
+  getCanvas: () => canvasRef.value,
+  redraw: draw,
+})
+</script>

--- a/package/website/src/views/album/location/components/PuzzlePanel.vue
+++ b/package/website/src/views/album/location/components/PuzzlePanel.vue
@@ -1,0 +1,185 @@
+<template>
+  <div class="space-y-6 animate-fade-in">
+    <!-- 标题 / 面包屑 -->
+    <div>
+      <div class="flex items-center gap-2 mb-1">
+        <button
+          v-if="scope === 'province'"
+          class="p-1 -ml-1 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+          title="返回全国"
+          @click="emit('drill-up')"
+        >
+          <ChevronLeft class="w-5 h-5" />
+        </button>
+        <h2 class="text-xl font-bold text-gray-800 dark:text-white">
+          {{ scope === 'nation' ? '全国照片拼图' : activeProvince }}
+        </h2>
+      </div>
+      <p class="text-xs text-gray-500 dark:text-gray-400">
+        {{
+          scope === 'nation'
+            ? '用照片拼出你走过的中国，点击任意省份查看单省拼图'
+            : '点击任意格子可替换或移除该位置的照片'
+        }}
+      </p>
+    </div>
+
+    <!-- 统计卡片 -->
+    <div class="grid grid-cols-2 gap-3">
+      <div class="bg-primary-50 dark:bg-primary-900/20 p-3 rounded-xl border border-primary-100 dark:border-primary-800/30">
+        <div class="text-xs text-primary-600 dark:text-primary-400 mb-1">拼图格子</div>
+        <div class="text-2xl font-bold text-primary-700 dark:text-primary-300">{{ cellCount }}</div>
+      </div>
+      <div class="bg-primary-50 dark:bg-primary-900/20 p-3 rounded-xl border border-primary-100 dark:border-primary-800/30">
+        <div class="text-xs text-primary-600 dark:text-primary-400 mb-1">使用照片</div>
+        <div class="text-2xl font-bold text-primary-700 dark:text-primary-300">{{ usedPhotoCount }}</div>
+      </div>
+    </div>
+
+    <!-- 选片策略 -->
+    <div>
+      <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-1.5">
+        <Sparkles class="w-4 h-4 text-primary-500" /> 选片策略
+      </h3>
+      <el-select
+        :model-value="config.strategy"
+        class="w-full"
+        size="default"
+        @update:model-value="(v: PhotoStrategy) => update('strategy', v)"
+      >
+        <el-option label="回忆价值优先" value="memory_score" />
+        <el-option label="画质优先" value="quality_score" />
+        <el-option label="最新拍摄优先" value="photo_time" />
+        <el-option label="随机" value="random" />
+      </el-select>
+      <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-1.5 leading-relaxed">
+        评分来自 AI 分析结果，未分析的照片会自动排在后面。
+      </p>
+    </div>
+
+    <!-- 数量 -->
+    <div>
+      <div class="flex items-center justify-between mb-1">
+        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">拼图精细度</h3>
+        <span class="text-xs font-medium text-primary-600 dark:text-primary-400">
+          {{ config.targetCount }}
+        </span>
+      </div>
+      <el-slider
+        :model-value="config.targetCount"
+        :min="countRange.min"
+        :max="countRange.max"
+        :step="countRange.step"
+        :show-tooltip="false"
+        @update:model-value="(v: number | number[]) => update('targetCount', v as number)"
+      />
+      <p class="text-[11px] text-gray-400 dark:text-gray-500 leading-relaxed">
+        {{
+          scope === 'nation'
+            ? '数值越大格子越小、照片用得越多。各省格子数按面积分配，照片不足时自动放大格子。'
+            : '数值越大格子越小、轮廓越精细。照片不足时会自动放大格子避免重复。'
+        }}
+      </p>
+    </div>
+
+    <!-- 开关与操作 -->
+    <div class="space-y-3">
+      <label
+        class="flex items-center justify-between cursor-pointer group"
+      >
+        <span class="text-sm font-semibold text-gray-700 dark:text-gray-300">显示区域名称</span>
+        <el-switch
+          :model-value="config.showLabel"
+          @update:model-value="(v: string | number | boolean) => update('showLabel', Boolean(v))"
+        />
+      </label>
+
+      <button
+        class="w-full py-2.5 rounded-xl bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium transition-colors flex items-center justify-center gap-2 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="loading"
+        @click="emit('reshuffle')"
+      >
+        <Shuffle class="w-4 h-4" />
+        换一批照片
+      </button>
+    </div>
+
+    <!-- Top 省份快捷入口（仅全国图） -->
+    <div v-if="scope === 'nation' && topRegions.length">
+      <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-1.5">
+        <Trophy class="w-4 h-4 text-yellow-500" /> 照片最多的省份
+      </h3>
+      <div class="space-y-2">
+        <button
+          v-for="(item, index) in topRegions"
+          :key="item.name"
+          class="w-full flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors text-left focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+          @click="emit('drill-down', item.name)"
+        >
+          <span
+            class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+            :class="
+              index === 0
+                ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500'
+                : index === 1
+                  ? 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                  : 'bg-orange-50 text-orange-600 dark:bg-orange-900/20 dark:text-orange-400'
+            "
+          >
+            {{ index + 1 }}
+          </span>
+          <span class="flex-1 text-sm text-gray-700 dark:text-gray-200 truncate">{{ item.name }}</span>
+          <span class="text-xs text-gray-500 dark:text-gray-400 shrink-0">{{ item.count }} 张</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ChevronLeft, Shuffle, Sparkles, Trophy } from 'lucide-vue-next'
+import type { PhotoStrategy, PuzzleConfig, PuzzleScope } from '@/composables/useMapPuzzle'
+
+const props = defineProps<{
+  scope: PuzzleScope
+  activeProvince: string | null
+  config: PuzzleConfig
+  cellCount: number
+  usedPhotoCount: number
+  regionCounts: Map<string, number>
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update-config', patch: Partial<PuzzleConfig>): void
+  (e: 'drill-down', provinceName: string): void
+  (e: 'drill-up'): void
+  (e: 'reshuffle'): void
+}>()
+
+/**
+ * 滑块范围。
+ *
+ * 全国图上限取 3000：格子数按面积分配，而单省占全国面积很小（陕西仅 2.12%），
+ * 原先 2000 的上限下陕西只能用到 47 张。实测再往上调收益递减 ——
+ * 6000 时格子边长降到 6.3px，照片已经看不清，且最坏情况需加载 4687 张缩略图。
+ */
+const countRange = computed(() =>
+  props.scope === 'nation'
+    ? { min: 200, max: 3000, step: 100 }
+    : { min: 20, max: 400, step: 10 }
+)
+
+const topRegions = computed(() =>
+  [...props.regionCounts.entries()]
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([name, count]) => ({ name, count }))
+)
+
+const update = <K extends keyof PuzzleConfig>(key: K, value: PuzzleConfig[K]) => {
+  emit('update-config', { [key]: value } as Partial<PuzzleConfig>)
+}
+</script>

--- a/package/website/tests/e2e/specs/album/location-puzzle.spec.ts
+++ b/package/website/tests/e2e/specs/album/location-puzzle.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect, type Page } from '@playwright/test'
+
+import { ensureAuthSession } from '../../helpers/auth'
+import { acquireMutex } from '../../helpers/mutex'
+
+/**
+ * P0 - 位置相册 · 照片拼图视图（/album/location, viewMode=puzzle）
+ *
+ * 覆盖 LocationPuzzleView.vue —— 位置相册的第六个视图模式。带 @p0 标签，
+ * PR 阶段必跑（见 playwright/run-e2e.mjs 的 SUITE_CONFIG.p0 = --grep @p0）。
+ *
+ * 与 location-p0 / location-p1 共用 LOCATION_MUTEX，避免并发切 viewMode /
+ * 触发 geojson + photos 请求时踩踏（这几个文件都在动 /album/location 页）。
+ *
+ * 设计原则（对齐 location-p0/p1 的既有约定）：
+ *   - CI 环境不保证有带 GPS 的照片，拼图可能是「全空」状态。因此断言只覆盖
+ *     「视图能进入、结构正确、控件存在、无照片时给空态」这些**不依赖数据**的路径，
+ *     数据相关的深度校验（格子填充、下钻）仅在探测到照片时才执行，否则跳过。
+ *   - 拼图是 Canvas2D 渲染，无法用 DOM 断言格子；改为断言 canvas 元素存在 +
+ *     geojson 接口被调用 + 面板控件渲染，作为「视图就绪」的可靠信号。
+ *
+ * UI 约定（src/views/album/location/）：
+ *   - 拼图视图根容器：.location-puzzle
+ *   - view toggle 按钮 title="照片拼图"
+ *   - 面板标题 "全国照片拼图"、区块 "选片策略" / "拼图精细度"、按钮 "换一批照片"
+ *   - 空态文案 "还没有带位置信息的照片，无法生成拼图"
+ *   - 单省视图左上角有 "全国" 返回按钮
+ */
+
+async function gotoRetry(page: Page, url: string, retries = 2): Promise<void> {
+  for (let i = 0; i <= retries; i += 1) {
+    try {
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 12_000 })
+      return
+    } catch (e) {
+      if (i >= retries) throw e
+      await page.waitForTimeout(1_000)
+    }
+  }
+}
+
+async function waitForLocationRoute(
+  page: Page,
+  testInfo: { skip(condition: boolean, ...args: unknown[]): void },
+): Promise<boolean> {
+  await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => undefined)
+  await page.waitForTimeout(500)
+  const url = page.url()
+  if (/\/album\/location(?:\?|$|\/)/.test(url)) return true
+  testInfo.skip(
+    true,
+    `Page did not stay on /album/location; landed on ${url}. Auth setup likely failed.`,
+  )
+  return false
+}
+
+/**
+ * 切换到照片拼图视图，并等待 geojson 请求完成（视图挂载即请求省界数据）。
+ * 返回 false 表示按钮不可见（拼图视图入口缺失）——理论上不该发生。
+ */
+async function switchToPuzzle(page: Page): Promise<boolean> {
+  const btn = page.locator('.location-list button[title="照片拼图"]').first()
+  if (!(await btn.isVisible().catch(() => false))) return false
+  const geoReq = page
+    .waitForResponse(
+      (res) => res.url().includes('/api/medias/geojson') && res.status() === 200,
+      { timeout: 12_000 },
+    )
+    .catch(() => undefined)
+  await btn.click()
+  await geoReq
+  return true
+}
+
+test.describe.serial('P0 - 位置相册照片拼图', () => {
+  test.use({ retries: 1 })
+  test.setTimeout(180_000)
+
+  // 与 location-p0 / location-p1 共用同一把锁
+  const LOCATION_MUTEX = 'location-scenes'
+  let releaseMutex: (() => Promise<void>) | undefined
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    releaseMutex = await acquireMutex(LOCATION_MUTEX, 120_000)
+    const authToken = await ensureAuthSession(request, page, testInfo)
+    if (!authToken) return
+    // 复位持久化视图状态，保证每次从网格视图进入
+    await page.addInitScript(() => {
+      try {
+        localStorage.removeItem('trailsnap-location-view-mode')
+        localStorage.removeItem('trailsnap-location-level')
+        localStorage.removeItem('trailsnap-location-filter-status')
+        localStorage.removeItem('trailsnap_map_state')
+      } catch {
+        // ignore
+      }
+    })
+  })
+
+  test.afterEach(async () => {
+    await releaseMutex?.()
+    releaseMutex = undefined
+  })
+
+  test('2.4.17 拼图视图入口 - 视图切换器含"照片拼图"按钮 @p0', async ({ page }, testInfo) => {
+    await gotoRetry(page, '/album/location')
+    if (!(await waitForLocationRoute(page, testInfo))) return
+
+    const puzzleBtn = page.locator('.location-list button[title="照片拼图"]').first()
+    await expect(puzzleBtn).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('2.4.18 切换到拼图视图 - 请求 geojson 并渲染 canvas + 配置面板 @p0', async ({ page }, testInfo) => {
+    await gotoRetry(page, '/album/location')
+    if (!(await waitForLocationRoute(page, testInfo))) return
+
+    const switched = await switchToPuzzle(page)
+    expect(switched, 'puzzle view button should be clickable').toBe(true)
+
+    // 拼图视图根容器出现
+    const puzzleRoot = page.locator('.location-puzzle')
+    await expect(puzzleRoot).toBeVisible({ timeout: 10_000 })
+
+    // Canvas 元素渲染（拼图绘制载体）
+    await expect(puzzleRoot.locator('canvas').first()).toBeVisible({ timeout: 10_000 })
+
+    // 右侧配置面板：标题 + 关键控件（不依赖是否有照片）
+    await expect(puzzleRoot.getByText('全国照片拼图')).toBeVisible({ timeout: 10_000 })
+    await expect(puzzleRoot.getByText('选片策略')).toBeVisible()
+    await expect(puzzleRoot.getByText('拼图精细度')).toBeVisible()
+    await expect(puzzleRoot.getByRole('button', { name: '换一批照片' })).toBeVisible()
+  })
+
+  test('2.4.19 拼图数据态 - 有照片则显示统计，无照片则显示空态 @p0', async ({ page }, testInfo) => {
+    await gotoRetry(page, '/album/location')
+    if (!(await waitForLocationRoute(page, testInfo))) return
+    if (!(await switchToPuzzle(page))) {
+      testInfo.skip(true, 'puzzle view entry not available')
+      return
+    }
+
+    const puzzleRoot = page.locator('.location-puzzle')
+    await expect(puzzleRoot).toBeVisible({ timeout: 10_000 })
+
+    // 生成过程可能有 loading，先等它消失（或超时也无妨）
+    await puzzleRoot
+      .getByText('正在生成拼图…')
+      .waitFor({ state: 'hidden', timeout: 15_000 })
+      .catch(() => undefined)
+
+    // 两条合法路径二选一：
+    //   A. 有带 GPS 的照片 → 面板「使用照片」统计
+    //   B. 无照片 → 画布空态文案
+    // 用 .first() 避免 strict mode：某些数据态下两者可能同时存在于 DOM
+    // （空态 <p> 与面板统计块），此处只需确认「视图已就绪」这一信号。
+    const readySignal = puzzleRoot
+      .getByText(/还没有带位置信息的照片，无法生成拼图|使用照片/)
+      .first()
+
+    await expect(readySignal).toBeVisible({ timeout: 20_000 })
+  })
+
+  test('2.4.20 换一批照片 - 按钮可点击且不报错 @p0', async ({ page }, testInfo) => {
+    await gotoRetry(page, '/album/location')
+    if (!(await waitForLocationRoute(page, testInfo))) return
+    if (!(await switchToPuzzle(page))) {
+      testInfo.skip(true, 'puzzle view entry not available')
+      return
+    }
+
+    const puzzleRoot = page.locator('.location-puzzle')
+    const reshuffleBtn = puzzleRoot.getByRole('button', { name: '换一批照片' })
+    await expect(reshuffleBtn).toBeVisible({ timeout: 10_000 })
+
+    // 点击换一批：不应抛错、画布仍在、按钮仍可用（幂等操作）
+    await reshuffleBtn.click()
+    await page.waitForTimeout(300)
+    await expect(puzzleRoot.locator('canvas').first()).toBeVisible()
+    await expect(reshuffleBtn).toBeEnabled()
+  })
+
+  test('2.4.21 拼图视图切走再切回 - canvas 正常重建 @p0', async ({ page }, testInfo) => {
+    await gotoRetry(page, '/album/location')
+    if (!(await waitForLocationRoute(page, testInfo))) return
+    if (!(await switchToPuzzle(page))) {
+      testInfo.skip(true, 'puzzle view entry not available')
+      return
+    }
+    await expect(page.locator('.location-puzzle')).toBeVisible({ timeout: 10_000 })
+
+    // 切到网格视图，拼图视图应卸载
+    const gridBtn = page.locator('.location-list button[title="网格视图"]').first()
+    await expect(gridBtn).toBeVisible({ timeout: 5_000 })
+    await gridBtn.click()
+    await expect(page.locator('.location-puzzle')).toBeHidden({ timeout: 8_000 })
+
+    // 再切回拼图：canvas 应重新渲染，不残留旧状态、不报错
+    if (!(await switchToPuzzle(page))) {
+      testInfo.skip(true, 'puzzle view re-entry not available')
+      return
+    }
+    await expect(page.locator('.location-puzzle')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.location-puzzle canvas').first()).toBeVisible({ timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
用照片按行政区轮廓拼出地图，作为位置相册的第六个视图模式，
与网格/地图/时间轴/轨迹/统计并列。

功能：
- 全国拼图：仅点亮有照片的省份，未去过的省保留淡色轮廓作版图参照
- 点击省份下钻到单省拼图，支持返回全国
- 选片策略：回忆价值/画质/最新拍摄/随机，复用后端 order_by 的 memory_score、quality_score 排序
- 单省视图支持点击格子替换或移除照片
- 拼图精细度可调，支持「换一批照片」

测试：
- 新增 location-puzzle.spec.ts（@p0，5 个用例）：视图入口、 切换渲染、数据态、换一批、切走再切回，本地 5/5 通过

后端无改动，复用 /api/medias/geojson、/api/photos、
/api/medias/{id}/thumbnail 现有接口。

## 描述
<!-- 请简要描述您的更改。如果是修复 Bug，请链接相关 Issue。 -->

## 变更类型
<!-- 请删除不相关的选项 -->
- [ ] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [ ] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue
<!-- 例如：Fixes #123 -->

## 如何测试
<!-- 请描述您是如何测试这些更改的 -->

## 检查清单
- [ ] 我已阅读并遵循项目的贡献指南
- [ ] 我的代码遵循项目的代码风格
- [ ] 我已添加/更新了必要的测试
- [ ] 所有测试均已通过
- [ ] 我已更新了相关文档
