### PR TITLE
feat(frontend):添加PWA支持

### DIFF
--- a/.github/workflows/docker-build-push-frontend.yml
+++ b/.github/workflows/docker-build-push-frontend.yml
@@ -48,6 +48,12 @@ jobs:
             EXTRA_TAGS=""
           fi
 
+          # Docker tag 不允许包含分支名中的 / 等字符。
+          BASE_TAG=$(printf '%s' "$BASE_TAG" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^[.-]+//; s/[.-]+$//' | cut -c1-128)
+          if [[ -z "$BASE_TAG" ]]; then
+            BASE_TAG="sha-${GITHUB_SHA:0:12}"
+          fi
+
           if [[ "$COMMIT_MSG" == *"-latest"* ]]; then
             EXTRA_TAGS="latest"
           fi

--- a/.github/workflows/docker-build-push-server.yml
+++ b/.github/workflows/docker-build-push-server.yml
@@ -48,6 +48,12 @@ jobs:
             EXTRA_TAGS=""
           fi
 
+          # Docker tag 不允许包含分支名中的 / 等字符。
+          BASE_TAG=$(printf '%s' "$BASE_TAG" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_.-]+/-/g; s/^[.-]+//; s/[.-]+$//' | cut -c1-128)
+          if [[ -z "$BASE_TAG" ]]; then
+            BASE_TAG="sha-${GITHUB_SHA:0:12}"
+          fi
+
           if [[ "$COMMIT_MSG" == *"-latest"* ]]; then
             EXTRA_TAGS="latest"
           fi

--- a/package/website/index.html
+++ b/package/website/index.html
@@ -1,9 +1,14 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0ea5e9" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <!--
       注意：不使用 viewport-fit=cover。原因——加上 cover 后 fixed/sticky top:0 的页面顶栏
       (HomePage / RecycleBinPage 等的 sticky top-0 header) 会贴到屏幕物理顶部、被刘海遮挡；

--- a/package/website/public/manifest.webmanifest
+++ b/package/website/public/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "行影集 TrailSnap",
+  "short_name": "行影集",
+  "description": "由 AI 驱动的自托管相册",
+  "lang": "zh-CN",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0ea5e9",
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/package/website/public/offline.html
+++ b/package/website/public/offline.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0ea5e9" />
+    <title>行影集 - 当前离线</title>
+    <style>
+      :root { color: #1f2937; background: #f8fafc; font-family: system-ui, sans-serif; }
+      body { min-height: 100vh; margin: 0; display: grid; place-items: center; }
+      main { max-width: 22rem; padding: 2rem; text-align: center; }
+      img { width: 5rem; height: 5rem; }
+      h1 { font-size: 1.25rem; }
+      p { color: #6b7280; line-height: 1.65; }
+      button { border: 0; border-radius: .5rem; padding: .7rem 1rem; background: #0ea5e9; color: white; font: inherit; cursor: pointer; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <img src="/logo.svg" alt="行影集" />
+      <h1>当前处于离线状态</h1>
+      <p>请检查网络后重试。已访问过的页面可能仍可查看，但相册数据和上传功能需要连接到你的 TrailSnap 服务。</p>
+      <button type="button" onclick="location.reload()">重新连接</button>
+    </main>
+  </body>
+</html>

--- a/package/website/src/App.vue
+++ b/package/website/src/App.vue
@@ -3,6 +3,7 @@
   <el-config-provider :locale="zhCn">
     <!-- 动态渲染当前路由对应的布局 -->
     <component :is="currentLayout" />
+    <PwaInstallPrompt />
   </el-config-provider>
 </template>
 
@@ -17,6 +18,7 @@ import { provideNavItems } from '@/composables/useNavItems';
 import { useUserStore } from '@/stores/user';
 import { useNotificationStore } from '@/stores/notificationStore';
 import { useNotificationSSE } from '@/composables/useNotificationSSE';
+import PwaInstallPrompt from '@/components/PwaInstallPrompt.vue';
 import zhCn from 'element-plus/es/locale/lang/zh-cn';
 // 🚨 关键：确保调用了 provideTheme()
 const {

--- a/package/website/src/components/PwaInstallPrompt.vue
+++ b/package/website/src/components/PwaInstallPrompt.vue
@@ -1,0 +1,70 @@
+<template>
+  <aside
+    v-if="visible"
+    class="fixed bottom-4 left-4 right-4 z-[3000] mx-auto max-w-md rounded-xl border border-gray-200 bg-white p-4 shadow-xl dark:border-gray-700 dark:bg-gray-800"
+    role="status"
+    aria-live="polite"
+  >
+    <div class="flex items-start gap-3">
+      <img src="/logo.svg" alt="" class="h-10 w-10 shrink-0 rounded-lg" />
+      <div class="min-w-0 flex-1">
+        <p class="font-medium text-gray-900 dark:text-gray-100">{{ title }}</p>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ description }}</p>
+        <div v-if="canInstall || updateAvailable" class="mt-3 flex gap-2">
+          <button
+            type="button"
+            class="rounded-lg bg-primary-600 px-3 py-2 text-sm font-medium text-white hover:bg-primary-700 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+            @click="primaryAction"
+          >
+            {{ updateAvailable ? '立即更新' : '安装应用' }}
+          </button>
+          <button
+            type="button"
+            class="rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-gray-300 dark:hover:bg-gray-700"
+            @click="dismiss"
+          >
+            稍后
+          </button>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:hover:bg-gray-700 dark:hover:text-gray-300"
+        aria-label="关闭"
+        @click="dismiss"
+      >
+        ×
+      </button>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { usePwa } from '@/composables/usePwa'
+
+const dismissed = ref(sessionStorage.getItem('trailsnap-pwa-prompt-dismissed') === '1')
+const { canInstall, isIos, isInstalled, updateAvailable, installPwa, applyPwaUpdate } = usePwa()
+
+const showIosGuide = computed(() => isIos && !isInstalled.value)
+const visible = computed(() => !dismissed.value && (canInstall.value || updateAvailable.value || showIosGuide.value))
+const title = computed(() => updateAvailable.value ? '发现新版本' : '安装行影集')
+const description = computed(() => {
+  if (updateAvailable.value) return '刷新以使用最新功能和修复。'
+  if (showIosGuide.value) return '在 Safari 中轻点分享按钮，然后选择“添加到主屏幕”。'
+  return '安装到设备主屏幕，像应用一样快速打开。'
+})
+
+async function primaryAction() {
+  if (updateAvailable.value) {
+    applyPwaUpdate()
+    return
+  }
+  await installPwa()
+}
+
+function dismiss() {
+  dismissed.value = true
+  sessionStorage.setItem('trailsnap-pwa-prompt-dismissed', '1')
+}
+</script>

--- a/package/website/src/composables/usePwa.ts
+++ b/package/website/src/composables/usePwa.ts
@@ -1,0 +1,61 @@
+import { computed, ref } from 'vue'
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>
+}
+
+const deferredPrompt = ref<BeforeInstallPromptEvent | null>(null)
+const isOnline = ref(navigator.onLine)
+const updateAvailable = ref(false)
+const isInstalled = ref(window.matchMedia('(display-mode: standalone)').matches || (navigator as Navigator & { standalone?: boolean }).standalone === true)
+let registration: ServiceWorkerRegistration | undefined
+
+const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent)
+const canInstall = computed(() => !!deferredPrompt.value)
+
+window.addEventListener('online', () => { isOnline.value = true })
+window.addEventListener('offline', () => { isOnline.value = false })
+window.addEventListener('beforeinstallprompt', (event) => {
+  event.preventDefault()
+  deferredPrompt.value = event as BeforeInstallPromptEvent
+})
+window.addEventListener('appinstalled', () => {
+  deferredPrompt.value = null
+  isInstalled.value = true
+})
+
+export function registerPwa() {
+  if (!import.meta.env.PROD || !('serviceWorker' in navigator)) return
+
+  window.addEventListener('load', async () => {
+    registration = await navigator.serviceWorker.register('/sw.js')
+    if (registration.waiting) updateAvailable.value = true
+    registration.addEventListener('updatefound', () => {
+      const worker = registration?.installing
+      worker?.addEventListener('statechange', () => {
+        if (worker.state === 'installed' && navigator.serviceWorker.controller) updateAvailable.value = true
+      })
+    })
+  }, { once: true })
+
+  navigator.serviceWorker.addEventListener('controllerchange', () => window.location.reload())
+}
+
+export async function installPwa() {
+  const prompt = deferredPrompt.value
+  if (!prompt) return false
+
+  await prompt.prompt()
+  const { outcome } = await prompt.userChoice
+  deferredPrompt.value = null
+  return outcome === 'accepted'
+}
+
+export function applyPwaUpdate() {
+  registration?.waiting?.postMessage({ type: 'SKIP_WAITING' })
+}
+
+export function usePwa() {
+  return { canInstall, isInstalled, isIos, isOnline, updateAvailable, installPwa, applyPwaUpdate }
+}

--- a/package/website/src/composables/usePwa.ts
+++ b/package/website/src/composables/usePwa.ts
@@ -10,6 +10,7 @@ const isOnline = ref(navigator.onLine)
 const updateAvailable = ref(false)
 const isInstalled = ref(window.matchMedia('(display-mode: standalone)').matches || (navigator as Navigator & { standalone?: boolean }).standalone === true)
 let registration: ServiceWorkerRegistration | undefined
+let updateRequested = false
 
 const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent)
 const canInstall = computed(() => !!deferredPrompt.value)
@@ -39,7 +40,9 @@ export function registerPwa() {
     })
   }, { once: true })
 
-  navigator.serviceWorker.addEventListener('controllerchange', () => window.location.reload())
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (updateRequested) window.location.reload()
+  })
 }
 
 export async function installPwa() {
@@ -53,7 +56,11 @@ export async function installPwa() {
 }
 
 export function applyPwaUpdate() {
-  registration?.waiting?.postMessage({ type: 'SKIP_WAITING' })
+  const waitingWorker = registration?.waiting
+  if (!waitingWorker) return
+
+  updateRequested = true
+  waitingWorker.postMessage({ type: 'SKIP_WAITING' })
 }
 
 export function usePwa() {

--- a/package/website/src/main.ts
+++ b/package/website/src/main.ts
@@ -9,6 +9,7 @@ import './style.css'
 
 import App from './App.vue'
 import router from '@/router';
+import { registerPwa } from '@/composables/usePwa'
 const app = createApp(App);
 // 2. 创建 Pinia 实例
 const pinia = createPinia()
@@ -17,4 +18,5 @@ app.use(router);
 app.use(ElementPlus)
 app.mount('#app');
 
+registerPwa()
 

--- a/package/website/vite.config.js
+++ b/package/website/vite.config.js
@@ -2,6 +2,46 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path';
 
+function pwaPlugin() {
+  return {
+    name: 'trailsnap-pwa',
+    apply: 'build',
+    generateBundle(_, bundle) {
+      const precache = Object.keys(bundle)
+        .filter((fileName) => /\.(?:js|css|woff2?|ttf|svg|png|jpe?g|webp)$/i.test(fileName))
+        .map((fileName) => `/${fileName}`)
+
+      const source = `
+const CACHE_NAME = 'trailsnap-app-shell-v1';
+const PRECACHE_URLS = ${JSON.stringify(['/', '/index.html', '/offline.html', '/manifest.webmanifest', '/logo.svg', '/favicon.ico', ...precache])};
+self.addEventListener('install', (event) => event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))));
+self.addEventListener('activate', (event) => event.waitUntil(caches.keys().then((keys) => Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))).then(() => self.clients.claim())));
+self.addEventListener('message', (event) => { if (event.data?.type === 'SKIP_WAITING') self.skipWaiting(); });
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  if (request.method !== 'GET') return;
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin || url.pathname.startsWith('/api/')) return;
+  if (request.mode === 'navigate') {
+    event.respondWith(fetch(request).then((response) => {
+      caches.open(CACHE_NAME).then((cache) => cache.put('/index.html', response.clone()));
+      return response;
+    }).catch(() => caches.match('/index.html').then((response) => response || caches.match('/offline.html'))));
+    return;
+  }
+  if (request.destination === 'image' || request.destination === 'video') return;
+  event.respondWith(caches.match(request).then((cached) => cached || fetch(request).then((response) => {
+    if (response.ok && ['script', 'style', 'font'].includes(request.destination)) caches.open(CACHE_NAME).then((cache) => cache.put(request, response.clone()));
+    return response;
+  })));
+});
+`
+
+      this.emitFile({ type: 'asset', fileName: 'sw.js', source })
+    },
+  }
+}
+
 // /api 代理目标。优先读环境变量 TS_API_BASE_URL（测试脚本 run-tests.ps1 会注入，
 // 例如本地测试后端在 9000）；未设置时回退到默认 dev 后端 8000。
 // 这样测试期前端 (9080) 与 e2e 直连后端 (TS_API_BASE_URL) 指向同一个后端，
@@ -10,7 +50,7 @@ const apiTarget = (process.env.TS_API_BASE_URL || 'http://127.0.0.1:8000').repla
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), pwaPlugin()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'), // 这里定义 @ 代表 src 目录


### PR DESCRIPTION
## 变更内容

- 增加 Web App Manifest、离线回退页面与 PWA 元信息
- 构建时生成并预缓存前端静态资源的 Service Worker
- 增加 Android/桌面安装提示、iOS 添加到主屏幕引导
- 增加 Service Worker 更新提示与在线状态管理
- API、原图和视频不进入自动缓存，避免用户数据过期或占满浏览器存储

## 用户影响

TrailSnap 可从支持的浏览器安装到手机或桌面，并在断网时打开已缓存的应用壳；实时相册数据与写操作仍要求连接服务端。

## 验证

- 前端生产构建通过，成功生成 `dist/sw.js`
- `tests/scripts/run-tests.ps1 -Layer e2e -Level full` 完整 E2E 通过
- Playwright 最终状态：passed，失败用例：0

I have read and agree to the CLA
