### PR TITLE
feat(website): add moon journal

### DIFF
--- a/package/website/src/components/PhotoLightbox.vue
+++ b/package/website/src/components/PhotoLightbox.vue
@@ -88,6 +88,9 @@
         </div>
       </div>
 
+      <!-- Feature pages can add compact contextual information without forking the lightbox. -->
+      <slot name="context-overlay"></slot>
+
       <!-- Photo Editor (replaces viewer when editing) -->
       <PhotoEditor
         v-if="isEditing && image"

--- a/package/website/src/components/moon/MoonPhaseIcon.vue
+++ b/package/website/src/components/moon/MoonPhaseIcon.vue
@@ -1,0 +1,29 @@
+<template>
+  <svg viewBox="0 0 48 48" role="img" :aria-label="label" class="block">
+    <defs>
+      <clipPath :id="clipId">
+        <circle cx="24" cy="24" r="19" />
+      </clipPath>
+    </defs>
+    <circle cx="24" cy="24" r="20" class="fill-gray-950 stroke-gray-600 dark:fill-gray-950 dark:stroke-gray-500" stroke-width="1.5" />
+    <g :clip-path="`url(#${clipId})`" class="fill-gray-50 dark:fill-gray-100">
+      <circle v-if="phase === 'full_moon'" cx="24" cy="24" r="19" />
+      <path v-else-if="phase === 'first_quarter'" d="M24 5a19 19 0 0 1 0 38z" />
+      <path v-else-if="phase === 'last_quarter'" d="M24 5a19 19 0 0 0 0 38z" />
+      <path v-else-if="phase === 'waxing_crescent'" d="M24 5a19 19 0 1 1 0 38c8-5 11-12 11-19S32 10 24 5z" />
+      <path v-else-if="phase === 'waxing_gibbous'" d="M24 5a19 19 0 1 1 0 38c-5-5-7-12-7-19s2-14 7-19z" />
+      <path v-else-if="phase === 'waning_gibbous'" d="M24 5a19 19 0 1 0 0 38c5-5 7-12 7-19s-2-14-7-19z" />
+      <path v-else-if="phase === 'waning_crescent'" d="M24 5a19 19 0 1 0 0 38c-8-5-11-12-11-19S16 10 24 5z" />
+    </g>
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { computed, useId } from 'vue'
+import type { MoonPhase } from '@/types/moon'
+import { MOON_PHASES } from '@/composables/useMoonPhase'
+
+const props = defineProps<{ phase: MoonPhase }>()
+const clipId = `moon-phase-${useId().replace(/:/g, '')}`
+const label = computed(() => MOON_PHASES.find((item) => item.phase === props.phase)?.label ?? '月相')
+</script>

--- a/package/website/src/composables/useMoonPhase.ts
+++ b/package/website/src/composables/useMoonPhase.ts
@@ -1,0 +1,132 @@
+import type {
+  MoonObservation,
+  MoonPhase,
+  MoonPhaseGroup,
+  MoonPhaseInfo,
+  MoonPhaseOption,
+} from '@/types/moon'
+import type { AlbumImage } from '@/types/album'
+
+const SYNODIC_MONTH = 29.530588853
+const DAY_MS = 86_400_000
+// 2000-01-06 18:14 UTC 是常用的已知朔时近似基准。
+const KNOWN_NEW_MOON_UTC = Date.UTC(2000, 0, 6, 18, 14)
+
+export const MOON_PHASES: MoonPhaseOption[] = [
+  { phase: 'new_moon', group: 'waxing', label: '新月', shortLabel: '初一' },
+  { phase: 'waxing_crescent', group: 'waxing', label: '蛾眉月', shortLabel: '渐盈' },
+  { phase: 'first_quarter', group: 'waxing', label: '上弦月', shortLabel: '上弦' },
+  { phase: 'waxing_gibbous', group: 'waxing', label: '盈凸月', shortLabel: '渐盈' },
+  { phase: 'full_moon', group: 'full', label: '满月', shortLabel: '十五' },
+  { phase: 'waning_gibbous', group: 'waning', label: '亏凸月', shortLabel: '渐亏' },
+  { phase: 'last_quarter', group: 'waning', label: '下弦月', shortLabel: '下弦' },
+  { phase: 'waning_crescent', group: 'waning', label: '残月', shortLabel: '月末' },
+]
+
+const PHASE_BY_NAME = new Map(MOON_PHASES.map((item) => [item.phase, item]))
+
+export const formatChineseLunarDay = (value: string | number) => {
+  const day = Number.parseInt(value, 10)
+  if (!Number.isFinite(day) || day < 1 || day > 30) return value
+  const digits = ['一', '二', '三', '四', '五', '六', '七', '八', '九', '十']
+  if (day <= 10) return day === 10 ? '初十' : `初${digits[day - 1]}`
+  if (day < 20) return `十${digits[day - 11] ?? ''}`
+  if (day === 20) return '二十'
+  if (day < 30) return `廿${digits[day - 21]}`
+  return '三十'
+}
+
+export const getChineseLunarDateParts = (date: Date) => {
+  try {
+    const parts = new Intl.DateTimeFormat('zh-CN-u-ca-chinese', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).formatToParts(date)
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value])) as Record<string, string>
+    const lunarDay = Number.parseInt(values.day ?? '', 10)
+    return {
+      year: Number.parseInt(values.relatedYear ?? values.year ?? String(date.getFullYear()), 10),
+      month: values.month ?? '农历月份',
+      day: Number.isFinite(lunarDay) ? lunarDay : 1,
+    }
+  } catch {
+    return { year: date.getFullYear(), month: '农历月份', day: 1 }
+  }
+}
+
+const getPhase = (age: number): MoonPhase => {
+  if (age < 1.84566 || age >= 27.68493) return 'new_moon'
+  if (age < 5.53699) return 'waxing_crescent'
+  if (age < 9.22831) return 'first_quarter'
+  if (age < 12.91963) return 'waxing_gibbous'
+  if (age < 16.61096) return 'full_moon'
+  if (age < 20.30228) return 'waning_gibbous'
+  if (age < 23.99361) return 'last_quarter'
+  return 'waning_crescent'
+}
+
+const formatLunarDate = (date: Date) => {
+  const lunar = getChineseLunarDateParts(date)
+  return `${lunar.month}${formatChineseLunarDay(lunar.day)}`
+}
+
+export const calculateMoonPhase = (input: Date | string | number): MoonPhaseInfo => {
+  const date = input instanceof Date ? input : new Date(input)
+  const daysSinceKnownNewMoon = (date.getTime() - KNOWN_NEW_MOON_UTC) / DAY_MS
+  const moonAge = ((daysSinceKnownNewMoon % SYNODIC_MONTH) + SYNODIC_MONTH) % SYNODIC_MONTH
+  const phase = getPhase(moonAge)
+  const option = PHASE_BY_NAME.get(phase)!
+  const illumination = (1 - Math.cos((2 * Math.PI * moonAge) / SYNODIC_MONTH)) / 2
+  const lunar = getChineseLunarDateParts(date)
+
+  return {
+    phase,
+    group: option.group as MoonPhaseGroup,
+    label: option.label,
+    shortLabel: option.shortLabel,
+    moonAge,
+    illumination,
+    lunarDate: formatLunarDate(date),
+    lunarYear: lunar.year,
+    lunarMonth: lunar.month,
+    lunarDay: lunar.day,
+  }
+}
+
+export const createMoonObservation = (photo: AlbumImage): MoonObservation | null => {
+  if (!photo.hasPhotoTime || !Number.isFinite(photo.timestamp)) return null
+  const takenAt = new Date(photo.timestamp)
+  if (Number.isNaN(takenAt.getTime())) return null
+
+  return {
+    photo,
+    takenAt,
+    ...calculateMoonPhase(takenAt),
+  }
+}
+
+export const getMoonPhaseForLunarDay = (day: number): MoonPhase => {
+  if (day === 1) return 'new_moon'
+  if (day <= 6) return 'waxing_crescent'
+  if (day <= 9) return 'first_quarter'
+  if (day <= 13) return 'waxing_gibbous'
+  if (day <= 17) return 'full_moon'
+  if (day <= 21) return 'waning_gibbous'
+  if (day <= 24) return 'last_quarter'
+  return 'waning_crescent'
+}
+
+export const findNextChineseLunarDay = (lunarDay: number, from: Date = new Date()) => {
+  if (lunarDay < 1 || lunarDay > 30) return null
+  const cursor = new Date(from)
+  cursor.setHours(12, 0, 0, 0)
+  // 农历三十并非每个月都有，扫描三个月可以覆盖下一个大月。
+  for (let offset = 0; offset <= 90; offset += 1) {
+    if (getChineseLunarDateParts(cursor).day === lunarDay) return new Date(cursor)
+    cursor.setDate(cursor.getDate() + 1)
+  }
+  return null
+}
+
+export const formatIllumination = (illumination: number) => `${Math.round(illumination * 100)}%`

--- a/package/website/src/router/index.ts
+++ b/package/website/src/router/index.ts
@@ -17,6 +17,7 @@ const LocationList = () => import('@/views/album/location/LocationList.vue');
 const LocationDetail = () => import('@/views/album/location/LocationDetail.vue');
 const ClassificationList = () => import('@/views/album/intelligent-classification/ClassificationList.vue');
 const ClassificationDetail = () => import('@/views/album/intelligent-classification/ClassificationDetail.vue');
+const MoonJournal = () => import('@/views/moon/MoonJournal.vue');
 const SearchResult = () => import('@/views/search/SearchResult.vue');
 const MobileSearch = () => import('@/views/search/MobileSearch.vue');
 const CleanupPage = () => import('@/views/toolbox/CleanupPage.vue');
@@ -54,6 +55,7 @@ const routes: RouteRecordRaw[] = [
       { path: '/album/location/:name', name: 'LocationDetail', component: LocationDetail, meta: { title: '位置详情' } },
       { path: '/album/classification', name: 'ClassificationList', component: ClassificationList, meta: { title: '智能分类' } },
       { path: '/album/classification/:name', name: 'ClassificationDetail', component: ClassificationDetail, meta: { title: '分类详情' } },
+      { path: '/moon', name: 'MoonJournal', component: MoonJournal, meta: { title: '月迹' } },
       { path: '/search', name: 'SearchResult', component: SearchResult, meta: { title: '搜索结果' } },
       { path: '/toolbox', name: 'Toolbox', component: ToolboxPage, meta: { title: '工具箱' } },
       { path: '/toolbox/similar', name: 'SimilarPhotoCleanup', component: SimilarPhotoCleanup, meta: { title: '相似照片清理' } },

--- a/package/website/src/types/moon.ts
+++ b/package/website/src/types/moon.ts
@@ -1,0 +1,39 @@
+import type { AlbumImage } from '@/types/album'
+
+export type MoonPhase =
+  | 'new_moon'
+  | 'waxing_crescent'
+  | 'first_quarter'
+  | 'waxing_gibbous'
+  | 'full_moon'
+  | 'waning_gibbous'
+  | 'last_quarter'
+  | 'waning_crescent'
+
+export type MoonPhaseGroup = 'waxing' | 'full' | 'waning'
+export type MoonView = 'phase' | 'calendar' | 'all'
+
+export interface MoonPhaseInfo {
+  phase: MoonPhase
+  group: MoonPhaseGroup
+  label: string
+  shortLabel: string
+  moonAge: number
+  illumination: number
+  lunarDate: string
+  lunarYear: number
+  lunarMonth: string
+  lunarDay: number
+}
+
+export interface MoonObservation extends MoonPhaseInfo {
+  photo: AlbumImage
+  takenAt: Date
+}
+
+export interface MoonPhaseOption {
+  phase: MoonPhase
+  group: MoonPhaseGroup
+  label: string
+  shortLabel: string
+}

--- a/package/website/src/views/album/intelligent-classification/ClassificationList.vue
+++ b/package/website/src/views/album/intelligent-classification/ClassificationList.vue
@@ -89,6 +89,10 @@ const fetchTags = async () => {
 }
 
 const goToTag = (name: string) => {
+  if (['月亮', 'moon'].includes(name.trim().toLowerCase())) {
+    router.push({ name: 'MoonJournal' })
+    return
+  }
   router.push({
     name: 'ClassificationDetail',
     params: { name: name }

--- a/package/website/src/views/moon/MoonJournal.vue
+++ b/package/website/src/views/moon/MoonJournal.vue
@@ -1,0 +1,548 @@
+<template>
+  <div class="moon-journal min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100" data-testid="moon-journal">
+    <div class="mx-auto max-w-[1600px] px-3 py-3 sm:px-5 md:px-8 md:py-6">
+      <header class="relative isolate min-h-[168px] overflow-hidden rounded-3xl bg-gray-950 text-white shadow-lg md:min-h-[190px]">
+        <img
+          v-if="heroPhoto"
+          :src="heroPhoto.preview || heroPhoto.thumbnail"
+          alt=""
+          class="absolute inset-0 -z-20 h-full w-full object-cover object-center opacity-30"
+        />
+        <div class="absolute inset-0 -z-10 bg-gradient-to-br from-gray-950/95 via-gray-950/75 to-gray-800/40"></div>
+        <div class="absolute -right-20 -top-24 -z-10 h-72 w-72 rounded-full bg-primary-500/20 blur-3xl"></div>
+
+        <div class="flex h-full min-h-[168px] flex-col justify-between p-4 sm:p-5 md:min-h-[190px] md:p-6">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex min-w-0 items-center gap-3">
+              <button
+                type="button"
+                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/10 text-white backdrop-blur transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                aria-label="返回"
+                @click="router.back()"
+              >
+                <ArrowLeft class="h-5 w-5" />
+              </button>
+              <div class="min-w-0">
+                <h1 class="text-xl font-bold tracking-wide sm:text-2xl">月迹</h1>
+                <p class="mt-0.5 truncate text-xs text-gray-300 dark:text-gray-300 sm:text-sm">记录每一次阴晴圆缺</p>
+              </div>
+            </div>
+            <div class="hidden rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm text-gray-200 backdrop-blur md:block">
+              {{ yearRange }}
+            </div>
+          </div>
+
+          <div class="flex items-end justify-between gap-3">
+            <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+              <p class="text-2xl font-bold tabular-nums sm:text-3xl">{{ photos.length }} <span class="text-base font-medium text-gray-300 dark:text-gray-300">次记录</span></p>
+              <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs text-gray-200 backdrop-blur">覆盖 {{ coveredPhaseCount }} / 8 种月相</span>
+            </div>
+            <div v-if="latestObservation" class="flex items-center gap-2.5 rounded-2xl border border-white/10 bg-black/20 px-3 py-2 backdrop-blur sm:px-4">
+              <MoonPhaseIcon :phase="latestObservation.phase" class="h-9 w-9 shrink-0" />
+              <div class="hidden sm:block">
+                <p class="text-sm font-semibold">最近记录 · {{ latestObservation.label }}</p>
+                <p class="text-xs text-gray-300 dark:text-gray-300">{{ formatDate(latestObservation.takenAt) }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <nav class="sticky top-2 z-40 mx-auto mt-4 flex w-fit rounded-full border border-gray-200/70 bg-white/90 p-1 shadow-sm backdrop-blur dark:border-gray-700/70 dark:bg-gray-900/90" aria-label="月迹视图">
+        <button
+          v-for="tab in viewTabs"
+          :key="tab.value"
+          type="button"
+          class="min-w-[76px] rounded-full px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 sm:min-w-[92px]"
+          :class="selectedView === tab.value ? 'bg-primary-600 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'"
+          :aria-current="selectedView === tab.value ? 'page' : undefined"
+          @click="selectedView = tab.value"
+        >
+          {{ tab.label }}
+        </button>
+      </nav>
+
+      <div v-if="loading" class="grid grid-cols-2 gap-3 py-10 sm:grid-cols-3 md:grid-cols-5 lg:grid-cols-6">
+        <div v-for="index in 12" :key="index" class="aspect-square animate-pulse rounded-2xl bg-gray-200 dark:bg-gray-800"></div>
+      </div>
+
+      <div v-else-if="error" class="my-10 rounded-2xl border border-red-200 bg-red-50 p-8 text-center dark:border-red-900/50 dark:bg-red-950/30">
+        <p class="font-medium text-red-700 dark:text-red-300">{{ error }}</p>
+        <button type="button" class="mt-4 rounded-full bg-primary-600 px-5 py-2 text-sm text-white hover:bg-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2" @click="loadPhotos">
+          重新加载
+        </button>
+      </div>
+
+      <div v-else-if="photos.length === 0" class="flex min-h-[45vh] flex-col items-center justify-center py-16 text-center">
+        <div class="h-24 w-24 rounded-full bg-gray-900 p-3 shadow-xl dark:bg-gray-950">
+          <MoonPhaseIcon phase="waxing_crescent" />
+        </div>
+        <h2 class="mt-6 text-xl font-semibold">还没有月亮记录</h2>
+        <p class="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">完成图片分类后，被识别为“月亮”的照片会自动出现在这里。</p>
+      </div>
+
+      <template v-else>
+        <main v-if="selectedView === 'phase'" class="py-8 md:py-10">
+          <section aria-labelledby="phase-filter-title">
+            <div class="mb-5 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <h2 id="phase-filter-title" class="text-xl font-bold md:text-2xl">月相记录</h2>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">从初一渐盈，到满月，再渐亏为残月</p>
+              </div>
+              <div class="flex w-full rounded-xl bg-gray-100 p-1 dark:bg-gray-800 md:w-auto" aria-label="月相阶段筛选">
+                <button
+                  v-for="group in groupFilters"
+                  :key="group.value"
+                  type="button"
+                  class="flex-1 whitespace-nowrap rounded-lg px-3 py-2 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 md:flex-none"
+                  :class="selectedGroup === group.value && !selectedPhase ? 'bg-white font-medium text-primary-600 shadow-sm dark:bg-gray-700 dark:text-primary-400' : 'text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white'"
+                  @click="selectGroup(group.value)"
+                >
+                  {{ group.label }}
+                </button>
+              </div>
+            </div>
+
+            <div class="moon-phase-scroller -mx-3 flex snap-x snap-mandatory gap-2 overflow-x-auto px-3 pb-3 sm:mx-0 sm:grid sm:grid-cols-4 sm:overflow-visible sm:px-0 md:grid-cols-8 md:gap-3">
+              <button
+                v-for="option in phaseOptions"
+                :key="option.phase"
+                type="button"
+                class="group min-w-[94px] snap-start rounded-2xl border bg-white p-3 text-center shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:bg-gray-800 sm:min-w-0"
+                :class="selectedPhase === option.phase ? 'border-primary-500 ring-1 ring-primary-500' : 'border-gray-200 dark:border-gray-700'"
+                :aria-pressed="selectedPhase === option.phase"
+                @click="selectPhase(option.phase)"
+              >
+                <span class="mx-auto block h-11 w-11 rounded-full bg-gray-950 p-0.5 shadow-inner sm:h-12 sm:w-12">
+                  <MoonPhaseIcon :phase="option.phase" class="h-full w-full" />
+                </span>
+                <span class="mt-2 block text-sm font-semibold text-gray-900 dark:text-gray-100">{{ option.label }}</span>
+                <span class="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">{{ phaseCounts[option.phase] }} 张</span>
+              </button>
+            </div>
+          </section>
+
+          <section class="mt-7" aria-live="polite">
+            <div class="mb-4 flex items-center justify-between gap-3">
+              <div>
+                <h3 class="text-lg font-semibold">{{ activeFilterLabel }}</h3>
+                <p class="text-xs text-gray-500 dark:text-gray-400">{{ filteredObservations.length }} 张照片</p>
+              </div>
+              <button
+                v-if="selectedPhase || selectedGroup !== 'all'"
+                type="button"
+                class="rounded-full px-3 py-1.5 text-sm text-primary-600 hover:bg-primary-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:text-primary-400 dark:hover:bg-primary-900/30"
+                @click="clearFilters"
+              >
+                查看全部
+              </button>
+            </div>
+
+            <div v-if="filteredObservations.length" class="grid grid-cols-2 gap-2.5 sm:grid-cols-3 sm:gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+              <button
+                v-for="observation in filteredObservations"
+                :key="observation.photo.id"
+                type="button"
+                class="group relative aspect-square overflow-hidden rounded-2xl bg-gray-200 text-left shadow-sm transition hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:bg-gray-800"
+                data-testid="moon-photo-card"
+                @click="openLightbox(observation.photo, filteredObservations.map((item) => item.photo))"
+              >
+                <img :src="observation.photo.thumbnail" :alt="observation.photo.filename || `${observation.label}照片`" class="h-full w-full object-cover transition duration-500 group-hover:scale-105" loading="lazy" />
+                <span class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/90 via-black/55 to-transparent px-3 pb-2.5 pt-9 text-white">
+                  <span class="flex items-center gap-1.5 text-sm font-semibold">
+                    <MoonPhaseIcon :phase="observation.phase" class="h-5 w-5 shrink-0" />
+                    {{ observation.label }} · {{ observation.lunarDate }}
+                  </span>
+                  <span class="mt-0.5 block text-xs text-gray-300 dark:text-gray-300">{{ formatDate(observation.takenAt) }} · 亮面 {{ formatIllumination(observation.illumination) }}</span>
+                </span>
+              </button>
+            </div>
+            <div v-else class="rounded-2xl border border-dashed border-gray-300 bg-white py-14 text-center dark:border-gray-700 dark:bg-gray-800">
+              <MoonPhaseIcon :phase="emptyPhase" class="mx-auto h-16 w-16 rounded-full bg-gray-950 p-1" />
+              <p class="mt-4 font-medium">还没有记录过{{ activeFilterLabel }}</p>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">下一次拍到时，这里就会被点亮。</p>
+            </div>
+          </section>
+
+          <section v-if="unknownTimePhotos.length" class="mt-8 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+            <p class="font-medium">{{ unknownTimePhotos.length }} 张照片缺少可靠拍摄时间</p>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">这些照片仍会出现在“全部”视图，但无法计算月相。</p>
+          </section>
+        </main>
+
+        <main v-else-if="selectedView === 'calendar'" class="py-8 md:py-10">
+          <section class="rounded-3xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-6">
+            <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 class="text-xl font-bold md:text-2xl">农历日记录</h2>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">选择一个农历日，查看历次在这一天拍摄的月亮</p>
+              </div>
+              <div class="w-fit rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 dark:bg-gray-900 dark:text-gray-300">
+                已记录 {{ recordedLunarDayCount }} / 30 天
+              </div>
+            </div>
+
+            <div class="space-y-5">
+              <div v-for="lane in lunarDayLanes" :key="lane.label" class="xl:flex xl:items-center xl:gap-4">
+                <div class="mb-2 flex items-center gap-2 xl:mb-0 xl:w-12 xl:shrink-0 xl:flex-col xl:gap-0.5">
+                  <span class="text-sm font-semibold text-gray-700 dark:text-gray-200">{{ lane.label }}</span>
+                  <span class="text-xs text-gray-400 dark:text-gray-500">{{ lane.range }}</span>
+                </div>
+                <div class="grid flex-1 grid-cols-5 gap-1.5 sm:gap-2 xl:grid-cols-[repeat(15,minmax(0,1fr))]">
+                <button
+                  v-for="day in lane.days"
+                  :key="day.day"
+                  data-testid="lunar-day"
+                  type="button"
+                  class="relative flex aspect-square min-w-0 flex-col items-center justify-center rounded-xl border px-1 py-1.5 transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                  :class="selectedLunarDay === day.day ? 'border-primary-500 bg-primary-50 text-primary-700 shadow-md ring-2 ring-primary-500 dark:bg-primary-900/30 dark:text-primary-300' : 'border-gray-200 bg-gray-50 text-gray-800 hover:border-primary-500/50 hover:bg-white dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800'"
+                  :aria-label="`农历${day.label}，${day.photos.length} 张月亮照片`"
+                  @click="selectedLunarDay = day.day"
+                >
+                  <MoonPhaseIcon :phase="day.phase" class="h-6 w-6 rounded-full bg-gray-950 sm:h-7 sm:w-7" />
+                  <span class="mt-1 text-[10px] font-semibold sm:text-xs">{{ day.label }}</span>
+                  <span class="mt-0.5 text-[9px] tabular-nums" :class="day.photos.length ? 'text-primary-600 dark:text-primary-400' : 'text-gray-400 dark:text-gray-500'">
+                    {{ day.photos.length ? `${day.photos.length} 次` : '—' }}
+                  </span>
+                </button>
+              </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="mt-6 rounded-3xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-6">
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex items-center gap-3">
+                <MoonPhaseIcon :phase="selectedLunarDayPhase" class="h-12 w-12 shrink-0 rounded-full bg-gray-950 p-1 sm:h-14 sm:w-14" />
+                <div>
+                  <h3 class="text-xl font-bold sm:text-2xl">农历{{ selectedLunarDayLabel }} · {{ selectedLunarDayPhaseLabel }}</h3>
+                  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">历次在农历{{ selectedLunarDayLabel }}拍摄的月亮</p>
+                </div>
+              </div>
+              <div class="flex gap-2 text-sm">
+                <span class="rounded-full bg-gray-100 px-3 py-1.5 text-gray-600 dark:bg-gray-900 dark:text-gray-300">{{ selectedLunarDayPhotos.length }} 次记录</span>
+                <span class="rounded-full bg-gray-100 px-3 py-1.5 text-gray-600 dark:bg-gray-900 dark:text-gray-300">跨越 {{ selectedLunarDayYearCount }} 年</span>
+              </div>
+            </div>
+            <div v-if="selectedLunarDayObservations.length" class="mt-5 grid grid-cols-2 gap-2.5 sm:grid-cols-3 sm:gap-4 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+                <button v-for="observation in selectedLunarDayObservations" :key="observation.photo.id" type="button" class="group relative aspect-square overflow-hidden rounded-2xl bg-gray-200 shadow-sm transition hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:bg-gray-700" @click="openLightbox(observation.photo, selectedLunarDayPhotos)">
+                  <img :src="observation.photo.thumbnail" :alt="observation.photo.filename || '月亮照片'" class="h-full w-full object-cover transition duration-500 group-hover:scale-105" />
+                  <span class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-3 pb-2 pt-8 text-xs text-white">{{ formatDate(observation.takenAt) }}</span>
+                </button>
+            </div>
+            <div v-else class="mt-5 flex flex-col items-center rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-4 py-10 text-center dark:border-gray-600 dark:bg-gray-900">
+              <span class="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50 text-primary-600 dark:bg-primary-900/30 dark:text-primary-400">
+                <CalendarDays class="h-6 w-6" />
+              </span>
+              <p class="mt-3 font-medium text-gray-800 dark:text-gray-100">农历{{ selectedLunarDayLabel }}还没有月亮记录</p>
+              <template v-if="nextCaptureDate">
+                <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">下一次补拍机会</p>
+                <p class="mt-1 text-base font-semibold text-primary-600 dark:text-primary-400">{{ nextCaptureDateLabel }}</p>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">拍摄后会根据照片时间自动归入农历{{ selectedLunarDayLabel }}</p>
+              </template>
+            </div>
+          </section>
+        </main>
+
+        <section v-else class="-mx-3 pb-6 pt-4 sm:-mx-5 md:-mx-8">
+          <UnifiedPhotoPage
+            :photos="photos"
+            :loading="false"
+            :has-more="false"
+            :timeline-items="timeline"
+            :timeline-stats="{ timeline }"
+            :show-back="false"
+            @confirm-delete="handleConfirmDelete"
+          >
+            <template #header-left><span aria-hidden="true"></span></template>
+            <template #batch-actions="{ selectedIds, clearSelection }">
+              <el-dropdown-item @click="removeFromMoonTag(Array.from(selectedIds)); clearSelection()">
+                <div class="flex items-center gap-2"><ImageMinus class="h-4 w-4" /><span>从月亮分类中移除</span></div>
+              </el-dropdown-item>
+            </template>
+          </UnifiedPhotoPage>
+        </section>
+      </template>
+    </div>
+
+    <PhotoLightbox
+      :visible="!!lightboxPhoto"
+      :image="lightboxPhoto"
+      :has-prev="lightboxIndex > 0"
+      :has-next="lightboxIndex >= 0 && lightboxIndex < lightboxPhotos.length - 1"
+      @close="closeLightbox"
+      @prev="moveLightbox(-1)"
+      @next="moveLightbox(1)"
+      @delete="handleLightboxDelete"
+    >
+      <template #context-overlay>
+        <div v-if="lightboxObservation" class="pointer-events-none fixed inset-x-0 bottom-5 z-[103] flex justify-center px-4 md:bottom-8">
+          <div class="flex items-center gap-3 rounded-2xl border border-white/10 bg-black/65 px-4 py-2.5 text-white shadow-xl backdrop-blur-md">
+            <MoonPhaseIcon :phase="lightboxObservation.phase" class="h-9 w-9 shrink-0" />
+            <div>
+              <p class="text-sm font-semibold">{{ lightboxObservation.label }} · {{ lightboxObservation.lunarDate }}</p>
+              <p class="text-xs text-gray-300 dark:text-gray-300">月龄 {{ lightboxObservation.moonAge.toFixed(1) }} 天 · 亮面 {{ formatIllumination(lightboxObservation.illumination) }}</p>
+            </div>
+          </div>
+        </div>
+      </template>
+    </PhotoLightbox>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ArrowLeft, CalendarDays, ImageMinus } from 'lucide-vue-next'
+import { ElMessage } from 'element-plus'
+
+import { classificationService } from '@/api/classification'
+import MoonPhaseIcon from '@/components/moon/MoonPhaseIcon.vue'
+import PhotoLightbox from '@/components/PhotoLightbox.vue'
+import UnifiedPhotoPage from '@/components/UnifiedPhotoPage.vue'
+import { createMoonObservation, findNextChineseLunarDay, formatChineseLunarDay, formatIllumination, getMoonPhaseForLunarDay, MOON_PHASES } from '@/composables/useMoonPhase'
+import { mapPhotoToImage, usePhotoStore } from '@/stores/photoStore'
+import type { AlbumImage } from '@/types/album'
+import type { MoonObservation, MoonPhase, MoonPhaseGroup, MoonView } from '@/types/moon'
+
+const MOON_TAG_NAME = '月亮'
+const route = useRoute()
+const router = useRouter()
+const photoStore = usePhotoStore()
+
+const viewTabs: Array<{ value: MoonView; label: string }> = [
+  { value: 'phase', label: '月相' },
+  { value: 'calendar', label: '农历日' },
+  { value: 'all', label: '全部' },
+]
+const groupFilters: Array<{ value: 'all' | MoonPhaseGroup; label: string }> = [
+  { value: 'all', label: '全部' },
+  { value: 'waxing', label: '渐盈' },
+  { value: 'full', label: '满月' },
+  { value: 'waning', label: '渐亏' },
+]
+const phaseOptions = MOON_PHASES
+
+const loading = ref(true)
+const error = ref('')
+const photos = ref<AlbumImage[]>([])
+const selectedView = ref<MoonView>(['phase', 'calendar', 'all'].includes(String(route.query.view)) ? route.query.view as MoonView : 'phase')
+const selectedGroup = ref<'all' | MoonPhaseGroup>('all')
+const selectedPhase = ref<MoonPhase | null>(null)
+const lightboxPhotos = ref<AlbumImage[]>([])
+const lightboxIndex = ref(-1)
+
+const queryLunarDay = Number.parseInt(String(route.query.day ?? ''), 10)
+const selectedLunarDay = ref(queryLunarDay >= 1 && queryLunarDay <= 30 ? queryLunarDay : 15)
+
+const initialPhaseFilter = typeof route.query.phase === 'string' ? route.query.phase : ''
+if (MOON_PHASES.some((item) => item.phase === initialPhaseFilter)) {
+  selectedPhase.value = initialPhaseFilter as MoonPhase
+  selectedGroup.value = MOON_PHASES.find((item) => item.phase === initialPhaseFilter)!.group
+} else if (['waxing', 'full', 'waning'].includes(initialPhaseFilter)) {
+  selectedGroup.value = initialPhaseFilter as MoonPhaseGroup
+}
+
+const observations = computed(() => photos.value
+  .map(createMoonObservation)
+  .filter((item): item is MoonObservation => item !== null)
+  .sort((a, b) => b.takenAt.getTime() - a.takenAt.getTime()))
+const unknownTimePhotos = computed(() => photos.value.filter((photo) => !photo.hasPhotoTime))
+const latestObservation = computed(() => observations.value[0] ?? null)
+const heroPhoto = computed(() => latestObservation.value?.photo ?? photos.value[0] ?? null)
+const coveredPhaseCount = computed(() => new Set(observations.value.map((item) => item.phase)).size)
+const yearRange = computed(() => {
+  if (!observations.value.length) return '暂无拍摄时间'
+  const years = observations.value.map((item) => item.takenAt.getFullYear())
+  const min = Math.min(...years)
+  const max = Math.max(...years)
+  return min === max ? `${min} 年` : `${min} — ${max}`
+})
+const phaseCounts = computed<Record<MoonPhase, number>>(() => {
+  const counts = Object.fromEntries(MOON_PHASES.map((item) => [item.phase, 0])) as Record<MoonPhase, number>
+  observations.value.forEach((item) => { counts[item.phase] += 1 })
+  return counts
+})
+const filteredObservations = computed(() => observations.value.filter((item) => {
+  if (selectedPhase.value) return item.phase === selectedPhase.value
+  if (selectedGroup.value !== 'all') return item.group === selectedGroup.value
+  return true
+}))
+const activeFilterLabel = computed(() => {
+  if (selectedPhase.value) return MOON_PHASES.find((item) => item.phase === selectedPhase.value)?.label ?? '月相'
+  return groupFilters.find((item) => item.value === selectedGroup.value)?.label ?? '全部月相'
+})
+const emptyPhase = computed<MoonPhase>(() => selectedPhase.value ?? (selectedGroup.value === 'waning' ? 'waning_crescent' : selectedGroup.value === 'full' ? 'full_moon' : 'waxing_crescent'))
+const timeline = computed(() => {
+  const stats = new Map<string, { year: number; month: number; day: number; count: number }>()
+  photos.value.forEach((photo) => {
+    const date = new Date(photo.timestamp)
+    const key = toDateKey(date)
+    const current = stats.get(key)
+    if (current) current.count += 1
+    else stats.set(key, { year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate(), count: 1 })
+  })
+  return Array.from(stats.values()).sort((a, b) => new Date(b.year, b.month - 1, b.day).getTime() - new Date(a.year, a.month - 1, a.day).getTime())
+})
+
+const observationsByLunarDay = computed(() => {
+  const map = new Map<number, MoonObservation[]>()
+  observations.value.forEach((item) => {
+    map.set(item.lunarDay, [...(map.get(item.lunarDay) ?? []), item])
+  })
+  return map
+})
+const lunarDayCells = computed(() => Array.from({ length: 30 }, (_, index) => {
+  const day = index + 1
+  const dayObservations = observationsByLunarDay.value.get(day) ?? []
+  return {
+    day,
+    label: formatChineseLunarDay(day),
+    phase: getMoonPhaseForLunarDay(day),
+    photos: dayObservations.map((item) => item.photo),
+  }
+}))
+const lunarDayLanes = computed(() => [
+  { label: '渐盈', range: '初一—十五', days: lunarDayCells.value.slice(0, 15) },
+  { label: '渐亏', range: '十六—三十', days: lunarDayCells.value.slice(15) },
+])
+const recordedLunarDayCount = computed(() => lunarDayCells.value.filter((item) => item.photos.length > 0).length)
+const selectedLunarDayObservations = computed(() => observationsByLunarDay.value.get(selectedLunarDay.value) ?? [])
+const selectedLunarDayPhotos = computed(() => selectedLunarDayObservations.value.map((item) => item.photo))
+const selectedLunarDayLabel = computed(() => formatChineseLunarDay(selectedLunarDay.value))
+const selectedLunarDayPhase = computed(() => getMoonPhaseForLunarDay(selectedLunarDay.value))
+const selectedLunarDayPhaseLabel = computed(() => MOON_PHASES.find((item) => item.phase === selectedLunarDayPhase.value)?.label ?? '月相')
+const selectedLunarDayYearCount = computed(() => new Set(selectedLunarDayObservations.value.map((item) => item.takenAt.getFullYear())).size)
+const nextCaptureDate = computed(() => findNextChineseLunarDay(selectedLunarDay.value))
+const nextCaptureDateLabel = computed(() => nextCaptureDate.value
+  ? new Intl.DateTimeFormat('zh-CN', { year: 'numeric', month: 'long', day: 'numeric', weekday: 'long' }).format(nextCaptureDate.value)
+  : '')
+const lightboxPhoto = computed(() => lightboxIndex.value >= 0 ? lightboxPhotos.value[lightboxIndex.value] ?? null : null)
+const lightboxObservation = computed(() => lightboxPhoto.value ? createMoonObservation(lightboxPhoto.value) : null)
+
+function toDateKey(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+const formatDate = (date: Date) => new Intl.DateTimeFormat('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(date)
+
+const loadPhotos = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    const result: AlbumImage[] = []
+    const limit = 500
+    let skip = 0
+    while (true) {
+      const page = await classificationService.getTagPhotos(MOON_TAG_NAME, skip, limit)
+      result.push(...page.map(mapPhotoToImage))
+      if (page.length < limit) break
+      skip += limit
+    }
+    photos.value = result.sort((a, b) => b.timestamp - a.timestamp)
+    if (!route.query.day && observations.value[0]) {
+      selectedLunarDay.value = observations.value[0].lunarDay
+    }
+  } catch (cause) {
+    console.error('Failed to load moon photos:', cause)
+    error.value = '月亮照片加载失败，请稍后重试。'
+  } finally {
+    loading.value = false
+  }
+}
+
+const selectGroup = (group: 'all' | MoonPhaseGroup) => {
+  selectedGroup.value = group
+  selectedPhase.value = null
+}
+
+const selectPhase = (phase: MoonPhase) => {
+  if (selectedPhase.value === phase) {
+    selectedPhase.value = null
+    selectedGroup.value = 'all'
+    return
+  }
+  selectedPhase.value = phase
+  selectedGroup.value = MOON_PHASES.find((item) => item.phase === phase)!.group
+}
+
+const clearFilters = () => {
+  selectedGroup.value = 'all'
+  selectedPhase.value = null
+}
+
+const openLightbox = (photo: AlbumImage, context: AlbumImage[]) => {
+  lightboxPhotos.value = context
+  lightboxIndex.value = context.findIndex((item) => item.id === photo.id)
+}
+
+const closeLightbox = () => { lightboxIndex.value = -1 }
+const moveLightbox = (offset: number) => {
+  const next = lightboxIndex.value + offset
+  if (next >= 0 && next < lightboxPhotos.value.length) lightboxIndex.value = next
+}
+
+const removeLocalPhotos = (ids: string[]) => {
+  photos.value = photos.value.filter((photo) => !ids.includes(photo.id))
+  lightboxPhotos.value = lightboxPhotos.value.filter((photo) => !ids.includes(photo.id))
+}
+
+const handleConfirmDelete = async (ids: string[], callback: (success: boolean) => void) => {
+  try {
+    await photoStore.deletePhotos(ids)
+    removeLocalPhotos(ids)
+    ElMessage.success('删除成功')
+    callback(true)
+  } catch {
+    ElMessage.error('删除失败')
+    callback(false)
+  }
+}
+
+const handleLightboxDelete = async (id: string) => {
+  try {
+    await photoStore.deletePhotos([id])
+    removeLocalPhotos([id])
+    closeLightbox()
+    ElMessage.success('删除成功')
+  } catch {
+    ElMessage.error('删除失败')
+  }
+}
+
+const removeFromMoonTag = async (ids: string[]) => {
+  try {
+    await classificationService.removePhotosFromTag(MOON_TAG_NAME, ids)
+    removeLocalPhotos(ids)
+    ElMessage.success('已从月亮分类中移除')
+  } catch {
+    ElMessage.error('移除失败')
+  }
+}
+
+watch([selectedView, selectedGroup, selectedPhase, selectedLunarDay], () => {
+  const phase = selectedPhase.value ?? (selectedGroup.value === 'all' ? undefined : selectedGroup.value)
+  router.replace({
+    query: {
+      ...route.query,
+      view: selectedView.value === 'phase' ? undefined : selectedView.value,
+      phase,
+      month: undefined,
+      date: undefined,
+      day: selectedView.value === 'calendar' ? selectedLunarDay.value : undefined,
+    },
+  })
+})
+
+onMounted(loadPhotos)
+</script>
+
+<style scoped>
+.moon-phase-scroller {
+  scrollbar-width: none;
+}
+
+.moon-phase-scroller::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/package/website/tests/e2e/specs/album/moon-journal.spec.ts
+++ b/package/website/tests/e2e/specs/album/moon-journal.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test'
+
+import { ensureAuthSession } from '../../helpers/auth'
+
+const moonPhotos = [
+  {
+    id: '00000000-0000-0000-0000-000000000101',
+    filename: 'full-moon.jpg',
+    photo_time: '2026-07-29T21:30:00',
+    upload_time: '2026-07-30T08:00:00',
+    file_type: 'image',
+    size: 1024,
+    width: 1200,
+    height: 1200,
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000102',
+    filename: 'crescent-moon.jpg',
+    photo_time: '2026-08-18T20:15:00',
+    upload_time: '2026-08-19T08:00:00',
+    file_type: 'image',
+    size: 2048,
+    width: 1600,
+    height: 1200,
+  },
+]
+
+test.describe('月迹页面 @p0', () => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    if (!(await ensureAuthSession(request, page, testInfo))) return
+    await page.route('**/api/tags/%E6%9C%88%E4%BA%AE/photos**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: moonPhotos }),
+      })
+    })
+    await page.route('**/api/medias/**', async (route) => {
+      await route.fulfill({ status: 204 })
+    })
+  })
+
+  test('月相视图展示八阶段导航和照片记录', async ({ page }) => {
+    await page.goto('/moon', { waitUntil: 'domcontentloaded' })
+
+    await expect(page.getByRole('heading', { name: '月迹' })).toBeVisible()
+    await expect(page.getByRole('navigation', { name: '月迹视图' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '满月', exact: true })).toBeVisible()
+    await expect(page.locator('[data-testid="moon-photo-card"]')).toHaveCount(2)
+  })
+
+  test('移动端可按农历日汇总历次照片', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/moon', { waitUntil: 'domcontentloaded' })
+    await page.getByRole('button', { name: '农历日' }).click()
+
+    await expect(page).toHaveURL(/view=calendar/)
+    await expect(page.getByRole('heading', { name: '农历日记录' })).toBeVisible()
+    await expect(page.getByText('初一', { exact: true })).toBeVisible()
+    const lunarDayCount = await page.locator('[data-testid="lunar-day"]').count()
+    expect(lunarDayCount).toBe(30)
+    await page.getByRole('button', { name: /农历十五/ }).click()
+    await expect(page).toHaveURL(/day=15/)
+
+    const emptyLunarDay = page.getByRole('button', { name: /0 张月亮照片/ }).first()
+    await emptyLunarDay.click()
+    await expect(page.getByText('下一次补拍机会')).toBeVisible()
+    await expect(page.getByText(/拍摄后会根据照片时间自动归入农历/)).toBeVisible()
+  })
+
+  test('全部视图滚动后仍可切换顶部导航', async ({ page }) => {
+    await page.goto('/moon', { waitUntil: 'domcontentloaded' })
+    const moonNavigation = page.getByRole('navigation', { name: '月迹视图' })
+    await moonNavigation.getByRole('button', { name: '全部', exact: true }).click()
+    await expect(page).toHaveURL(/view=all/)
+
+    const scrollContainer = page.locator('#main-content-wrapper > main')
+    await scrollContainer.evaluate((element) => { element.scrollTop = 600 })
+    await expect(moonNavigation).toBeVisible()
+    await moonNavigation.getByRole('button', { name: '月相', exact: true }).click()
+
+    await expect(page).not.toHaveURL(/view=all/)
+    await expect(page.getByRole('heading', { name: '月相记录' })).toBeVisible()
+  })
+})

--- a/package/website/tests/e2e/specs/views-coverage/moment-caption-streaming.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/moment-caption-streaming.spec.ts
@@ -193,14 +193,22 @@ test.describe("朋友圈 · photo_time 按墙上时间归日 @moments-timezone",
     ).toBeVisible({ timeout: 10_000 })
 
     // 断言 2：点击"AI 生成"，服务端接收的 day 参数是 2025-08-05
-    await page.locator('button:has-text("AI 生成")').first().click({ force: true })
-
-    // 等 generate 响应返回（capturedBody 在 route handler 里、fulfill 之前赋值）；
-    // 不依赖 SSE 文案渲染，避免 mocked event-stream 在 docker 下抖动
-    await page.waitForResponse(
+    const dayBlock = page.locator(".day-block").first()
+    await dayBlock.hover()
+    const generateButton = dayBlock.getByRole("button", {
+      name: "AI 生成",
+      exact: true,
+    })
+    await expect(generateButton).toBeVisible()
+    const generateResponse = page.waitForResponse(
       (r) => r.url().includes("/api/moments/day-captions/generate"),
       { timeout: 15_000 }
     )
+    await generateButton.click()
+
+    // 等 generate 响应返回（capturedBody 在 route handler 里、fulfill 之前赋值）；
+    // 不依赖 SSE 文案渲染，避免 mocked event-stream 在 docker 下抖动
+    await generateResponse
 
     expect(capturedBody).toBeTruthy()
     // 关键断言：day 一定是 2025-08-05，绝不能因时区偏移到 08-04 / 08-06

--- a/package/website/tests/e2e/specs/views-coverage/views-deeper-p5.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/views-deeper-p5.spec.ts
@@ -304,13 +304,15 @@ test.describe("Moments 日文案 AI 生成 & 编辑 @views-coverage", () => {
     await expect(page.getByText("初稿：随便写点什么。")).toBeVisible({ timeout: 10_000 })
 
     // 点「编辑」按钮 -> 出现 textarea
-    await page.locator('button:has-text("编辑")').first().click({ force: true })
-    const textarea = page.locator("textarea").first()
+    const dayBlock = page.locator(".day-block").first()
+    await dayBlock.hover()
+    await dayBlock.getByRole("button", { name: "编辑", exact: true }).click()
+    const textarea = dayBlock.locator("textarea")
     await expect(textarea).toBeVisible({ timeout: 5_000 })
     await textarea.fill("手写的一句：夜里的江面比白天更沉。")
 
     // 保存
-    await page.locator('button:has-text("保存")').first().click()
+    await dayBlock.getByRole("button", { name: "保存", exact: true }).click()
 
     // DOM 应更新为新文案
     await expect(page.getByText("手写的一句：夜里的江面比白天更沉。")).toBeVisible({ timeout: 10_000 })
@@ -359,13 +361,14 @@ test.describe("Moments 日文案 AI 生成 & 编辑 @views-coverage", () => {
     // 点「清除」并等待 DELETE 落地（替代旧版 expect.poll(deleteHit, 5s)；
     // 旧版本在 docker CI 高负载下 5s 内偶发不触发是因为 click 较慢，
     // 改用 waitForResponse(15s) 更稳健，与 moment-caption-streaming 用法一致）
-    await page.locator('button:has-text("清除")').first().click({ force: true })
-    await page.waitForResponse(
+    const deleteResponse = page.waitForResponse(
       (r) =>
         r.url().includes("/api/moments/day-captions/2025-08-05") &&
         r.request().method() === "DELETE",
       { timeout: 15_000 }
     )
+    await page.locator('button:has-text("清除")').first().click({ force: true })
+    await deleteResponse
     await expect(
       page.getByText(/这是\s*2025\s*年\s*8\s*月\s*5\s*日\s*的美好回忆/)
     ).toBeVisible({ timeout: 10_000 })


### PR DESCRIPTION
## Summary
- add a responsive Moon Journal page with eight moon-phase views, lunar-day aggregation, and an all-photo gallery
- show next capture-date hints for lunar days without records and preserve lunar context in the photo lightbox
- route the Moon intelligent-classification entry to the dedicated journal
- stabilize Moments E2E controls by scoping actions to the active day card

## Testing
- `pnpm build`
- `pnpm exec playwright test tests/e2e/specs/views-coverage/moment-caption-streaming.spec.ts tests/e2e/specs/views-coverage/views-deeper-p5.spec.ts` (12 passed)
- `.\tests\scripts\run-tests.ps1 -Layer e2e -Level full` (260 passed, 4 skipped)

## Checklist
- [x] Desktop and mobile layouts covered
- [x] Theme-aware colors and dark mode preserved
- [x] Keyboard focus styles included for new interactive elements
- [x] Full local E2E suite passed