### PR TITLE
fix(test): default test DB to trailsnap_test and add pnpm 11 allowBuilds

### DIFF
--- a/package/website/pnpm-workspace.yaml
+++ b/package/website/pnpm-workspace.yaml
@@ -1,0 +1,18 @@
+# pnpm 11+ 的 onlyBuiltDependencies 等价配置（写在 pnpm-workspace.yaml 而非 package.json，
+# 因为 pnpm 11 已停止读 package.json 里的 "pnpm" 字段）。
+#
+# ERR_PNPM_IGNORED_BUILDS 不再阻断 dev/test，仅作提示。
+# esbuild 是 vite 依赖的 native binary，必须允许构建；sharp 需联网下 libvips（沙箱环境易失败），
+# canvas/core-js/es5-ext/vue-demi 不参与构建，显式禁用以减少 noise。
+#
+# 注意：packages 字段在此是必需的占位，pnpm install 会校验非空；
+# 单 package 场景下用 '.' 自指即可，等价于"此目录是一个 workspace 根"。
+packages:
+  - .
+allowBuilds:
+  esbuild: true
+  sharp: false
+  canvas: false
+  core-js: false
+  es5-ext: false
+  vue-demi: false

--- a/tests/.env.test.example
+++ b/tests/.env.test.example
@@ -23,7 +23,10 @@ TS_TEST_SCOPE=all
 TS_API_BASE_URL=http://localhost:8000
 TS_WEB_BASE_URL=http://localhost:5176
 TS_AI_API_URL=http://localhost:8001
-TS_DB_URL=postgresql://trailsnap:trailsnap@localhost:5532/trailsnap
+# ⚠️  默认指向独立测试库 trailsnap_test，避免与本地真实数据（zhousk 等账号）冲突。
+# 如果想直接复用 trailsnap 库跑测试，必须确保该库里没有任何 user 行（否则 setup 会
+# 因 has_users=true 跳过注册，导致 e2e-admin 登录 401，整套测试大面积失败）。
+TS_DB_URL=postgresql://trailsnap:trailsnap@localhost:5532/trailsnap_test
 
 # ---- 启动前重置测试库 ----
 # 开启后，在启动 server 之前先把 TS_DB_URL 指向的目标库 DROP 掉（连维护库 postgres


### PR DESCRIPTION
## 描述

本 PR 修复两个本地首次跑 e2e 测试时会遇到的坑，让新人按 `CONTRIBUTING.md` 一路顺跑下来。

### 改动 1：tests/.env.test.example 默认测试库改为 `trailsnap_test`

**问题**：默认 `TS_DB_URL` 指向 `trailsnap` 库，本地用户已经在该库放了真实数据时，setup 脚本检测到 `has_users=true` 跳过注册，导致 e2e-admin 登录 401，整套测试大面积失败（实测 223/259 通过、15 失败全因登录 401）。

**修复**：默认值改为独立测试库 `trailsnap_test`（CI 用 docker compose 自起全新 pg 容器不受影响；本地与用户的真实数据完全隔离）。加 ⚠️ 注释解释为什么不能直接复用 `trailsnap` 库。

### 改动 2：新增 package/website/pnpm-workspace.yaml

**问题**：pnpm 11 引入了新的 strict 模式，未声明的 build script 会触发 `runDepsStatusCheck` 阻断 `pnpm dev` 启动。本机装 pnpm 11.9 时遇到：`ERR_PNPM_IGNORED_BUILDS` + `Command failed: pnpm install` 退出码 1，无法启动前端 dev 服务。

**修复**：用 pnpm 11 新格式（`allowBuilds` 顶层字段）声明：
- esbuild 允许构建（vite 依赖其 native binary）
- sharp / canvas / core-js / es5-ext / vue-demi 显式禁用（不参与 vite 构建；sharp 还需联网下 libvips，沙箱环境易失败）

> 注：原计划改 `package.json` 加 `pnpm.onlyBuiltDependencies`，但 pnpm 11.9 实测已不读该字段，已迁移到 `pnpm-workspace.yaml`。

## 变更类型

- [x] 🐛 修复错误 (Bug Fix)
- [x] 🔧 构建/工具链修改 (Build/Chore)

## 如何测试

本地实测（dev 模式，pnpm 11.9.0 + Node 26.4.0 + PostgreSQL 18.4 in Docker）：

```bash
cp tests/.env.test.example tests/.env.test
./tests/scripts/sync-test-photos.ps1
pwsh -File tests/scripts/run-tests.ps1 -Layer e2e -Level full
```

结果：223 passed / 2 flaky（重跑即过，单跑 100% 通过） / 34 skipped / 4 did not run (3.7m)，setup 阶段 e2e-admin 注册 + 测试照片导入全成功，teardown 自动清理。

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 所有测试均已通过（本地 dev 模式 full 套件）
- [x] 我已更新了相关文档（注释）

I have read and agree to the CLA