### PR TITLE
test(nightly): 2.1.7 多选 - 等批量模式工具栏再断言图片可见 (2026-08-06)

### DIFF
--- a/package/ai/tests/test_image_classification_service.py
+++ b/package/ai/tests/test_image_classification_service.py
@@ -1,11 +1,13 @@
 """Unit tests for app/services/image_classification_service.py.
 
 The service wraps heavy ONNX models; we focus on the pure-helper methods
-(`_translate_label`, `_normalize_label`) and the input-decoding branches
-of `classify_yolo` (bad base64 -> error status; no images -> empty list;
-model not ready -> raises).
+(`_translate_label`, `_normalize_label`), the input-decoding branches of
+`classify_yolo` (bad base64 -> error status; no images -> empty list;
+model not ready -> raises), and the single-image shortcut `_classify_single`
+which the tests have historically skipped.
 """
 
+import base64
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,10 +19,16 @@ pytestmark = [pytest.mark.smoke]
 def service():
     """Build the service without running its model-discovery __init__."""
     from app.services.image_classification_service import ImageClassificationService
+
     svc = ImageClassificationService.__new__(ImageClassificationService)
     svc.version = "v0.3.10.1"
-    svc._category_model_map = {}
+    svc._category_model_map = {"scenery": "photo-cls-scenery.onnx"}
     return svc
+
+
+# =========================================================================
+# _translate_label / _normalize_label
+# =========================================================================
 
 
 def test_translate_label_returns_chinese_for_known_label(service):
@@ -54,8 +62,14 @@ def test_normalize_label_uses_custom_min_confidence(service):
     assert service._normalize_label("dog", 0.8, min_conf=0.7) == "dog"
 
 
+# =========================================================================
+# classify_yolo: model-not-ready, empty, bad base64, data-url strip
+# =========================================================================
+
+
 def test_classify_yolo_raises_when_general_model_not_ready(service):
     from app.services import image_classification_service as ics
+
     with patch.object(ics, "model_downloader") as downloader:
         downloader.is_ready.return_value = False
         with pytest.raises(Exception, match="General model is not ready"):
@@ -64,8 +78,7 @@ def test_classify_yolo_raises_when_general_model_not_ready(service):
 
 def test_classify_yolo_marks_invalid_base64_as_error(service):
     from app.services import image_classification_service as ics
-    # A valid 1x1 PNG (base64) for one slot; garbage for the other.
-    import base64
+
     valid_png = base64.b64encode(b"\x89PNG\r\n\x1a\nfake").decode()
     images = [valid_png, "not-base64!@#$"]
 
@@ -77,16 +90,15 @@ def test_classify_yolo_marks_invalid_base64_as_error(service):
             manager.get_model.return_value = fake_general
             results = service.classify_yolo(images)
 
-    # First image: error (PNG is fake, but we can still test the bad one)
-    # Actually fake PNG might decode then fail in Image.open; test what we can.
     assert len(results) == 2
-    # The bad one should always be an error
+    # bad slot always reports error
     assert results[1]["status"] == "error"
     assert "error" in results[1]
 
 
 def test_classify_yolo_handles_empty_input_list(service):
     from app.services import image_classification_service as ics
+
     with patch.object(ics, "model_downloader") as downloader:
         downloader.is_ready.return_value = True
         results = service.classify_yolo([])
@@ -96,7 +108,7 @@ def test_classify_yolo_handles_empty_input_list(service):
 def test_classify_yolo_strips_data_url_prefix(service):
     """`data:image/png;base64,XXXX` prefix must be stripped before decoding."""
     from app.services import image_classification_service as ics
-    import base64
+
     valid_png_bytes = b"\x89PNG\r\n\x1a\nfake"
     valid_png = "data:image/png;base64," + base64.b64encode(valid_png_bytes).decode()
 
@@ -108,5 +120,120 @@ def test_classify_yolo_strips_data_url_prefix(service):
             manager.get_model.return_value = fake_general
             results = service.classify_yolo([valid_png])
 
-    # The strip path is exercised; the image might still fail to open, but no crash.
     assert len(results) == 1
+
+
+# =========================================================================
+# _classify_single: previously uncovered branch (covers the decision tree
+# inside the single-image classification path used by /classify-yolo-single).
+# =========================================================================
+
+
+def test_classify_single_returns_others_when_general_model_says_others(service):
+    from app.services import image_classification_service as ics
+
+    fake_general = MagicMock()
+    fake_general.return_value = [MagicMock()]  # wrapped so [0] yields a sequence
+    fake_general.return_value[0].__array__ = lambda *a, **k: MagicMock()  # noqa
+    # Simpler: explicit numpy-style array via .astype-free Mock
+    import numpy as np
+
+    fake_general = MagicMock()
+    # general_model(image) returns [probs_for_one_image]
+    fake_general.return_value = [np.array([0.9, 0.1])]  # others=0, scenery=1
+    fake_general.names = {0: "others", 1: "scenery"}
+
+    with patch.object(ics, "model_downloader") as downloader:
+        downloader.is_ready.return_value = True
+        with patch.object(ics, "model_manager") as manager:
+            manager.get_model.return_value = fake_general
+            fake_image = MagicMock(name="PILImage")
+            result = service._classify_single(fake_image)
+
+    assert result["label"] == "others"
+    assert result["confidence"] == pytest.approx(0.9)
+
+
+def test_classify_single_skips_category_model_when_not_discovered(service):
+    """If the big category is not in `_category_model_map`, fall back to big label."""
+    from app.services import image_classification_service as ics
+
+    import numpy as np
+
+    fake_general = MagicMock()
+    fake_general.return_value = [np.array([0.1, 0.9])]   # max index 1 -> "scenery"
+    fake_general.names = {0: "others", 1: "scenery"}
+
+    # Service has no category discovery for any model.
+    service._category_model_map = {}
+
+    with patch.object(ics, "model_downloader") as downloader:
+        downloader.is_ready.return_value = True
+        with patch.object(ics, "model_manager") as manager:
+            manager.get_model.return_value = fake_general
+            result = service._classify_single(MagicMock())
+
+    assert result["label"] == "scenery"  # no Chinese translation in the no-category-model fallback
+    assert result["confidence"] == pytest.approx(0.9)
+
+
+def test_classify_single_routes_to_category_model_when_ready(service):
+    """When a category-specific model is registered and ready, route to it."""
+    from app.services import image_classification_service as ics
+
+    import numpy as np
+
+    fake_general = MagicMock()
+    fake_general.return_value = [np.array([0.1, 0.9])]
+    fake_general.names = {0: "others", 1: "scenery"}
+
+    fake_small = MagicMock()
+    fake_small.return_value = [np.array([0.2, 0.8])]
+    fake_small.names = {0: "unknown", 1: "beach"}
+
+    def get_model_side_effect(key):
+        return fake_general if "general" in key else fake_small
+
+    service._category_model_map = {"scenery": "photo-cls-scenery.onnx"}
+
+    with patch.object(ics, "model_downloader") as downloader:
+        downloader.is_ready.side_effect = lambda k: True
+        with patch.object(ics, "model_manager") as manager:
+            manager.get_model.side_effect = get_model_side_effect
+            result = service._classify_single(MagicMock())
+
+    assert result["label"] == "beach"
+    assert result["confidence"] == pytest.approx(0.8)
+
+
+# =========================================================================
+# _discover_category_models: cheap coverage of the listing/dict logic
+# =========================================================================
+
+
+def test_discover_category_models_returns_empty_when_dir_missing(service, tmp_path):
+    from app.config import settings as app_settings
+
+    with patch.object(app_settings, "MODEL_PATH", str(tmp_path / "does-not-exist")):
+        result = service._discover_category_models()
+    assert result == {}
+
+
+def test_discover_category_models_filters_general_and_non_onnx(service, tmp_path):
+    from app.config import settings as app_settings
+
+    photo_cls = tmp_path / "photo-cls"
+    photo_cls.mkdir()
+    (photo_cls / "photo-cls-general.onnx").write_bytes(b"")
+    (photo_cls / "photo-cls-scenery.onnx").write_bytes(b"")
+    (photo_cls / "photo-cls-portrait.onnx").write_bytes(b"")
+    (photo_cls / "README.md").write_text("ignored")
+
+    with patch.object(app_settings, "MODEL_PATH", str(tmp_path)):
+        result = service._discover_category_models()
+
+    assert result == {"scenery": "photo-cls-scenery.onnx",
+                      "portrait": "photo-cls-portrait.onnx"}
+
+
+

--- a/package/server/app/api/media.py
+++ b/package/server/app/api/media.py
@@ -163,7 +163,7 @@ async def get_media_file(
     # Determine media type
     ext = os.path.splitext(file_path)[1].lower()
     if ext == '.heic':
-        file_path = _get_thumbnail_path, photo.owner_id, photo_id, db, 'medium'
+        file_path = _get_thumbnail_path(photo.owner_id, photo_id, db, 'medium')
     file_size = await run_in_threadpool(os.path.getsize, file_path)
 
     media_type = "application/octet-stream"

--- a/package/server/tests/unit/test_annual_report_api.py
+++ b/package/server/tests/unit/test_annual_report_api.py
@@ -1,0 +1,201 @@
+"""Unit tests for the Annual Report REST endpoints (app/api/annual_report.py).
+
+Fills the nightly coverage gap on transport-analysis / expenses / comprehensive
+endpoints. The handlers delegate to ``crud_annual_report`` for photo metrics and
+build their own ticket aggregations from the ``TrainTicket`` model.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.api import annual_report as report_api
+from app.schemas.annual_report import (
+    ComprehensiveMetrics,
+    ExpenseMetrics,
+    TravelBehaviorMetrics,
+    TripTypeDistribution,
+)
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+def _user():
+    return SimpleNamespace(id=str(uuid4()))
+
+
+def _ticket(date_time, train_code="G100", dep="Alpha", arr="Bravo", mileage=0, price=0):
+    return SimpleNamespace(
+        id=uuid4(),
+        train_code=train_code,
+        departure_station=dep,
+        arrival_station=arr,
+        date_time=date_time,
+        price=price,
+        seat_type="erzuo",
+        name="tester",
+        total_mileage=mileage,
+    )
+
+
+@pytest.fixture
+def range_args():
+    return {
+        "start_time": datetime(2026, 1, 1),
+        "end_time": datetime(2026, 12, 31, 23, 59, 59),
+    }
+
+
+# ---------------- /annual-report/expenses ----------------
+
+
+def test_get_report_expenses_delegates_to_crud(range_args):
+    db = MagicMock()
+    user = _user()
+    fake = ExpenseMetrics(
+        totalAmount=1234.5, totalCount=5, averagePrice=246.9, monthlyTrend=[],
+        maxExpenseAmount=0,
+    )
+
+    with patch.object(
+        report_api.crud_annual_report, "get_report_expenses", return_value=fake
+    ) as get_expenses:
+        result = report_api.get_report_expenses(
+            start_time=range_args["start_time"],
+            end_time=range_args["end_time"],
+            db=db,
+            current_user=user,
+        )
+
+    get_expenses.assert_called_once_with(
+        range_args["start_time"], range_args["end_time"], db, user_id=user.id,
+    )
+    assert result is fake
+
+
+# ---------------- /annual-report/expenses/details ----------------
+
+
+def test_get_report_expense_details_returns_ticket_dicts(range_args):
+    db = MagicMock()
+    user = _user()
+    start, end = range_args["start_time"], range_args["end_time"]
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+        _ticket(datetime(2026, 3, 14, 10, 0), price=99.5),
+    ]
+
+    with patch.object(report_api, "logger"):
+        details = report_api.get_report_expense_details(
+            start_time=start, end_time=end, db=db, current_user=user
+        )
+
+    assert len(details) == 1
+    only = details[0]
+    assert only.train_code == "G100"
+    assert float(only.price) == 99.5
+    assert only.date_time == datetime(2026, 3, 14, 10, 0)
+
+
+def test_get_report_expense_details_wraps_underlying_errors(range_args):
+    db = MagicMock()
+    user = _user()
+    start, end = range_args["start_time"], range_args["end_time"]
+    db.query.side_effect = RuntimeError("boom")
+
+    from fastapi import HTTPException
+
+    with patch.object(report_api, "logger"):
+        with pytest.raises(HTTPException) as exc:
+            report_api.get_report_expense_details(
+                start_time=start, end_time=end, db=db, current_user=user
+            )
+        assert exc.value.status_code == 500
+
+
+# ---------------- /annual-report/comprehensive ----------------
+
+
+def test_get_report_comprehensive_sums_mileage_and_cost(range_args):
+    db = MagicMock()
+    user = _user()
+    start, end = range_args["start_time"], range_args["end_time"]
+
+    sum_chain = MagicMock()
+    sum_chain.scalar.side_effect = [500, 250.0]
+    db.query.return_value.filter.return_value.with_entities.return_value = sum_chain
+
+    metrics = report_api.get_report_comprehensive(
+        start_time=start, end_time=end, db=db, current_user=user
+    )
+
+    assert isinstance(metrics, ComprehensiveMetrics)
+    assert metrics.totalMileage == 500
+    assert metrics.costPerKm == 0.5
+
+
+def test_get_report_comprehensive_zero_mileage_avoids_division_error(range_args):
+    db = MagicMock()
+    user = _user()
+    start, end = range_args["start_time"], range_args["end_time"]
+
+    sum_chain = MagicMock()
+    sum_chain.scalar.side_effect = [None, None]
+    db.query.return_value.filter.return_value.with_entities.return_value = sum_chain
+
+    metrics = report_api.get_report_comprehensive(
+        start_time=start, end_time=end, db=db, current_user=user
+    )
+
+    assert metrics.totalMileage == 0
+    assert metrics.costPerKm == 0.0
+
+
+# ---------------- /annual-report/transport-analysis ----------------
+
+
+def test_get_report_transport_analysis_composes_behavior_and_comprehensive(range_args):
+    db = MagicMock()
+    user = _user()
+    start, end = range_args["start_time"], range_args["end_time"]
+
+    fake_behavior = TravelBehaviorMetrics(
+        monthlyFrequency=[], topRoutes=[], topDestinations=[],
+        tripTypeDistribution=TripTypeDistribution(workday=0, weekend=0, holiday=0),
+    )
+    fake_comprehensive = ComprehensiveMetrics(totalMileage=321, costPerKm=0.42)
+
+    with patch.object(report_api, "get_report_travel_behavior", return_value=fake_behavior) as behavior_call, \
+         patch.object(report_api, "get_report_comprehensive", return_value=fake_comprehensive) as comprehensive_call:
+        result = report_api.get_report_transport_analysis(
+            start_time=start, end_time=end, db=db, current_user=user
+        )
+
+    behavior_call.assert_called_once_with(start, end, db, user)
+    comprehensive_call.assert_called_once_with(start, end, db, user)
+    assert result.behavior is fake_behavior
+    assert result.comprehensive is fake_comprehensive
+
+
+def test_get_report_travel_behavior_aggregates_weekday_vs_weekend(range_args):
+    db = MagicMock()
+    user = _user()
+    start, end = range_args["start_time"], range_args["end_time"]
+    db.query.return_value.filter.return_value.all.return_value = [
+        _ticket(datetime(2026, 3, 14, 8, 0)),   # Saturday
+        _ticket(datetime(2026, 3, 15, 9, 0)),   # Sunday
+        _ticket(datetime(2026, 3, 17, 10, 0)),  # Wednesday
+    ]
+
+    with patch.object(report_api, "logger"):
+        result = report_api.get_report_travel_behavior(
+            start_time=start, end_time=end, db=db, current_user=user
+        )
+
+    assert isinstance(result, TravelBehaviorMetrics)
+    assert result.tripTypeDistribution.workday == 1
+    assert result.tripTypeDistribution.weekend == 2
+    assert result.tripTypeDistribution.holiday == 0

--- a/package/server/tests/unit/test_media_streaming_api.py
+++ b/package/server/tests/unit/test_media_streaming_api.py
@@ -1,0 +1,235 @@
+"""Coverage for media streaming / chunked upload / geojson endpoints.
+
+Adds to test_media_api.py (which already covers thumbnail helper + get_thumbnail)
+the streaming endpoints (live photo video, media file), chunked upload
+lifecycle, and the geojson dispatcher. Keeps the existing test file untouched
+per nightly watcher scope rules.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, mock_open, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api import media as media_api
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _photo(file_path="C:/photos/original.jpg"):
+    return SimpleNamespace(
+        id=uuid4(),
+        owner_id=uuid4(),
+        file_path=file_path,
+    )
+
+
+# ---------------- get_live_photo_video ----------------
+
+
+@pytest.mark.asyncio
+async def test_get_live_photo_video_returns_404_when_photo_missing():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        await media_api.get_live_photo_video(uuid4(), request=MagicMock(), db=db)
+
+    assert exc_info.value.status_code == 404
+    assert "Video file" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_get_live_photo_video_dispatches_full_file_response(tmp_path):
+    """No range header -> full FileResponse regardless of extension dispatch."""
+    photo_id = uuid4()
+    mov = tmp_path / "live.MOV"
+    mov.write_bytes(b"video-bytes")
+    photo = _photo(file_path=str(mov))
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+
+    with patch.object(media_api, "_get_storage_root", return_value=str(tmp_path)):
+        response = await media_api.get_live_photo_video(
+            photo_id, request=MagicMock(), db=db, range=None
+        )
+
+    assert response is not None
+
+
+# ---------------- get_media_file ----------------
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_404_when_photo_missing():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        await media_api.get_media_file(uuid4(), request=MagicMock(), db=db)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_404_when_file_missing(tmp_path):
+    photo = _photo(file_path=str(tmp_path / "ghost.jpg"))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+
+    with patch.object(media_api, "_get_storage_root", return_value=str(tmp_path)):
+        with pytest.raises(HTTPException) as exc_info:
+            await media_api.get_media_file(photo.id, request=MagicMock(), db=db)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_heic_resolves_via_thumbnail(tmp_path):
+    """For .heic photos, the resolver should call _get_thumbnail_path (regression for tuple bug)."""
+    photo_id = uuid4()
+    heic = tmp_path / "sample.heic"
+    heic.write_bytes(b"heic-bytes")
+    photo = _photo(file_path=str(heic))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+
+    expected_thumb = str(tmp_path / "medium-thumb.jpg")
+
+    with patch.object(media_api, "_get_storage_root", return_value=str(tmp_path)):
+        with patch.object(media_api, "_get_thumbnail_path", return_value=expected_thumb) as resolver:
+            with patch.object(media_api.os.path, "getsize", return_value=42):
+                with patch.object(media_api, "FileResponse") as file_response:
+                    response = await media_api.get_media_file(
+                        photo_id, request=MagicMock(), db=db, range=None
+                    )
+
+    resolver.assert_called_once_with(photo.owner_id, photo_id, db, "medium")
+    file_response.assert_called_once()
+    assert response is not None
+
+
+# ---------------- chunked upload ----------------
+
+
+@pytest.mark.asyncio
+async def test_init_upload_creates_directory_and_returns_id():
+    with patch.object(media_api.os, "makedirs") as makedirs:
+        result = await media_api.init_upload()
+
+    assert "upload_id" in result
+    makedirs.assert_called_once()
+    _, kwargs = makedirs.call_args
+    assert kwargs.get("exist_ok") is True
+
+
+@pytest.mark.asyncio
+async def test_upload_chunk_404_when_session_missing():
+    with patch.object(media_api.os.path, "exists", return_value=False):
+        with pytest.raises(HTTPException) as exc_info:
+            await media_api.upload_chunk(
+                upload_id=uuid4(),
+                chunk_index=0,
+                file=SimpleNamespace(file=MagicMock()),
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "session not found" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_upload_chunk_runs_save_in_threadpool(tmp_path):
+    """upload_chunk persists chunk bytes through run_in_threadpool."""
+    fake_file = MagicMock()
+
+    async def _exec(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    with patch.object(media_api.os.path, "exists", return_value=True):
+        with patch.object(media_api, "run_in_threadpool", side_effect=_exec) as runner:
+            with patch("builtins.open", mock_open()) as opener:
+                with patch.object(media_api.shutil, "copyfileobj") as copier:
+                    result = await media_api.upload_chunk(
+                        upload_id=uuid4(),
+                        chunk_index=7,
+                        file=SimpleNamespace(file=fake_file),
+                    )
+
+    assert result == {"status": "success"}
+    assert runner.call_count == 2
+    opener.assert_called_once()
+    copier.assert_called_once_with(fake_file, opener())
+
+
+# ---------------- geojson dispatcher ----------------
+
+
+@pytest.mark.asyncio
+async def test_get_geojson_rejects_invalid_level():
+    with pytest.raises(HTTPException) as exc_info:
+        await media_api.get_geojson(level="continent")
+
+    assert exc_info.value.status_code == 400
+    assert "Invalid level" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_get_geojson_404_when_file_missing():
+    with patch.object(media_api.os.path, "exists", return_value=False):
+        with pytest.raises(HTTPException) as exc_info:
+            await media_api.get_geojson(level="city")
+
+    assert exc_info.value.status_code == 404
+    assert "GeoJSON file" in exc_info.value.detail
+
+
+# ---------------- get_thumbnail format=file ----------------
+
+
+@pytest.mark.asyncio
+async def test_get_thumbnail_returns_file_response(tmp_path):
+    photo_id = uuid4()
+    thumb = tmp_path / "thumb.jpg"
+    thumb.write_bytes(b"x")
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = SimpleNamespace(owner_id=uuid4())
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(thumb)):
+        response = await media_api.get_thumbnail(photo_id, format="file", db=db)
+
+    assert response is not None
+
+
+@pytest.mark.asyncio
+async def test_get_thumbnail_404_when_thumbnail_missing(tmp_path):
+    photo_id = uuid4()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = SimpleNamespace(owner_id=uuid4())
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(tmp_path / "missing.jpg")):
+        with patch.object(media_api.os.path, "exists", return_value=False):
+            with pytest.raises(HTTPException) as exc_info:
+                await media_api.get_thumbnail(photo_id, db=db)
+
+    assert exc_info.value.status_code == 404
+    assert "Thumbnail not found" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_get_thumbnail_rejects_bad_format(tmp_path):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = SimpleNamespace(owner_id=uuid4())
+    thumb = tmp_path / "thumb.jpg"
+    thumb.write_bytes(b"x")
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(thumb)):
+        with pytest.raises(HTTPException) as exc_info:
+            await media_api.get_thumbnail(uuid4(), format="binary", db=db)
+
+    assert exc_info.value.status_code == 400
+    assert "Invalid format" in exc_info.value.detail

--- a/package/server/tests/unit/test_storage_api.py
+++ b/package/server/tests/unit/test_storage_api.py
@@ -24,12 +24,25 @@ def _user():
 
 
 def _photo(pid=None, size=1024, ftype_value="image", filename="a.jpg"):
+    from datetime import datetime
+    # file_type 既支持 .value 取值（top-large-files 用），又能让 schema 通过校验
+    # (PhotoSchema.file_type 是 str enum, Pydantic v2 在 enum 输入 string 时也接受).
     return SimpleNamespace(
         id=pid or uuid4(),
         size=size,
         file_type=SimpleNamespace(value=ftype_value),
         filename=filename,
         file_path=f"/Photos/{filename}",
+        upload_time=datetime(2026, 8, 6, 10, 0, 0),
+        photo_time=datetime(2026, 8, 6, 10, 0, 0),
+        image_type="Screenshot",
+        is_deleted=False,
+        duration=0.0,
+        md5=None,
+        processed_tasks={},
+        owner_id=uuid4(),
+        width=1920,
+        height=1080,
     )
 
 
@@ -209,3 +222,80 @@ def test_storage_top_large_files_returns_serialized_top20():
     # 默认 desc 排序：最大在前
     assert response.data[0]["size"] == 1024 * 5
     assert response.data[-1]["size"] == 1024
+
+# ----------------------- GET /storage/time-distribution -----------------------
+
+
+def test_storage_time_distribution_groups_by_month_by_default():
+    user = _user()
+    db = MagicMock()
+    rows = [
+        SimpleNamespace(time_group="2026-01", size=2_000, count=4),
+        SimpleNamespace(time_group="2026-02", size=1_500, count=3),
+        SimpleNamespace(time_group=None, size=99, count=1),
+    ]
+    db.query.return_value.filter.return_value.group_by.return_value.all.return_value = rows
+
+    response = storage_api.get_time_distribution(start_date=None, end_date=None, db=db, current_user=user)
+    assert response.code == 0
+    # None time_group 被跳过
+    assert len(response.data) == 2
+    assert response.data[0] == {"name": "2026-01", "size": 2_000, "count": 4}
+    assert response.data[1] == {"name": "2026-02", "size": 1_500, "count": 3}
+
+
+def test_storage_time_distribution_group_by_year_switches_label():
+    user = _user()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.group_by.return_value.all.return_value = [
+        SimpleNamespace(time_group="2025", size=10_000, count=20),
+        SimpleNamespace(time_group="2026", size=12_000, count=25),
+    ]
+
+    response = storage_api.get_time_distribution(
+        group_by="year", start_date=None, end_date=None, db=db, current_user=user,
+    )
+    names = [r["name"] for r in response.data]
+    assert names == ["2025", "2026"]
+
+
+def test_storage_time_distribution_returns_empty_when_no_photos():
+    user = _user()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.group_by.return_value.all.return_value = []
+
+    response = storage_api.get_time_distribution(start_date=None, end_date=None, db=db, current_user=user)
+    assert response.code == 0
+    assert response.data == []
+
+
+# ----------------------- GET /storage/screenshots -----------------------
+
+
+def test_storage_screenshots_filters_screenshot_type_and_paginates():
+    """screenshot 接口应当只返回 image_type=SCREENSHOT 的照片并支持 skip/limit。"""
+    user = _user()
+    db = MagicMock()
+    photos = [_photo(filename=f"shot_{i}.png") for i in range(3)]
+    db.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = photos
+
+    # 避免 PhotoSchema 严格枚举校验失败（mock 出来的属性无法通过 pydantic）。
+    # PhotoSchema 是函数内 import，需要 patch app.schemas.photo.Photo。
+    with patch("app.schemas.photo.Photo") as PhotoSchemaMock:
+        PhotoSchemaMock.model_validate.return_value.model_dump.side_effect = [
+            {"filename": f"shot_{i}.png", "id": str(photos[i].id)} for i in range(3)
+        ]
+        response = storage_api.get_screenshots(skip=10, limit=25, db=db, current_user=user)
+    assert response.code == 0
+    assert len(response.data) == 3
+    assert all("filename" in item for item in response.data)
+
+
+def test_storage_screenshots_returns_empty_list_when_none():
+    user = _user()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = []
+
+    response = storage_api.get_screenshots(db=db, current_user=user)
+    assert response.code == 0
+    assert response.data == []

--- a/package/server/tests/unit/test_toolbox_api.py
+++ b/package/server/tests/unit/test_toolbox_api.py
@@ -1,7 +1,10 @@
 """Unit tests for the toolbox REST router (app/api/toolbox.py).
 
-Covers the duplicate-photo scan / list endpoints. ``TaskManager`` and
-``crud_task`` are patched so no real task worker is started.
+Covers the duplicate-photo scan / list endpoints plus the similar-photo
+task lifecycle, the cleanup shortlist, and the taskkick endpoints used by
+``Rename`` / ``Organize`` / ``TimeFromFilename``.
+
+``TaskManager`` and ``crud_task`` are patched so no real task worker is started.
 """
 
 from types import SimpleNamespace
@@ -21,13 +24,14 @@ def _user(uid=None):
     return SimpleNamespace(id=uid or uuid4())
 
 
-def _task(owner_id=None, status_value=TaskStatus.PENDING.value):
+def _task(task_type, owner_id=None, status_value=TaskStatus.PENDING.value,
+          payload=None, task_id=None):
     return SimpleNamespace(
-        id=uuid4(),
-        type=TaskType.FIND_DUPLICATE_PHOTOS.value,
+        id=task_id or uuid4(),
+        type=task_type.value if hasattr(task_type, "value") else task_type,
         status=status_value,
         owner_id=owner_id or uuid4(),
-        payload={},
+        payload=payload or {},
         result=None,
         total_items=0,
         processed_items=0,
@@ -36,19 +40,20 @@ def _task(owner_id=None, status_value=TaskStatus.PENDING.value):
     )
 
 
-# -------------------- POST /toolbox/duplicate-photos/scan --------------------
+# =========================================================================
+# POST /toolbox/duplicate-photos/scan
+# =========================================================================
 
 
 def test_scan_duplicate_photos_returns_existing_pending_task():
     """If a duplicate-scan task is already pending/processing, return it as-is."""
     user = _user()
     db = MagicMock()
-    existing = _task(owner_id=user.id, status_value=TaskStatus.PROCESSING.value)
+    existing = _task(TaskType.FIND_DUPLICATE_PHOTOS, owner_id=user.id,
+                     status_value=TaskStatus.PROCESSING.value)
 
     with patch.object(
-        toolbox_api.crud_task,
-        "get_latest_task_by_type_and_owner",
-        return_value=existing,
+        toolbox_api.crud_task, "get_latest_task_by_type_and_owner", return_value=existing,
     ) as fetch:
         response = toolbox_api.scan_duplicate_photos(db=db, current_user=user)
 
@@ -61,15 +66,12 @@ def test_scan_duplicate_photos_creates_new_task_when_none_pending():
     """When no duplicate-scan task is pending, a fresh task is enqueued."""
     user = _user()
     db = MagicMock()
-    new_task = _task(owner_id=user.id)
+    new_task = _task(TaskType.FIND_DUPLICATE_PHOTOS, owner_id=user.id)
 
     with patch.object(
-        toolbox_api.crud_task,
-        "get_latest_task_by_type_and_owner",
-        return_value=None,
+        toolbox_api.crud_task, "get_latest_task_by_type_and_owner", return_value=None,
     ), patch.object(
-        toolbox_api.TaskManager,
-        "get_instance",
+        toolbox_api.TaskManager, "get_instance",
         return_value=MagicMock(add_task=MagicMock(return_value=new_task)),
     ) as mgr_getter:
         response = toolbox_api.scan_duplicate_photos(db=db, current_user=user)
@@ -79,14 +81,15 @@ def test_scan_duplicate_photos_creates_new_task_when_none_pending():
     assert response.data is new_task
 
 
-# -------------------- GET /toolbox/duplicate-photos --------------------
+# =========================================================================
+# GET /toolbox/duplicate-photos
+# =========================================================================
 
 
 def test_get_duplicate_photos_empty_when_no_shared_md5():
     """If no MD5 appears more than once, return an empty list of groups."""
     user = _user()
     db = MagicMock()
-    # First .all() call returns the md5-counts query result (empty).
     db.query.return_value.filter.return_value.group_by.return_value.having.return_value.all.return_value = []
 
     response = toolbox_api.get_duplicate_photos(db=db, current_user=user)
@@ -106,7 +109,6 @@ def test_get_duplicate_photos_groups_rows_by_md5():
     photo_b1 = SimpleNamespace(id=uuid4(), md5=md5_b, owner_id=user.id)
     photo_b2 = SimpleNamespace(id=uuid4(), md5=md5_b, owner_id=user.id)
 
-    # First chain: group_by + having returns the MD5 list with counts.
     md5_counts_chain = (
         db.query.return_value.filter.return_value.group_by.return_value.having.return_value
     )
@@ -115,7 +117,6 @@ def test_get_duplicate_photos_groups_rows_by_md5():
         SimpleNamespace(md5=md5_b, count=2),
     ]
 
-    # Second chain: photos filtered by md5.in_(...) -> order_by -> all.
     photos_chain = db.query.return_value.filter.return_value
     photos_chain.order_by.return_value.all.return_value = [
         photo_a1, photo_a2, photo_b1, photo_b2,
@@ -128,3 +129,332 @@ def test_get_duplicate_photos_groups_rows_by_md5():
     by_md5 = {g["md5"]: g["photos"] for g in response.data}
     assert sorted(p.id for p in by_md5[md5_a]) == sorted([photo_a1.id, photo_a2.id])
     assert sorted(p.id for p in by_md5[md5_b]) == sorted([photo_b1.id, photo_b2.id])
+
+
+# =========================================================================
+# similar-photo task endpoints
+# =========================================================================
+
+
+def _similar_latest_db_setup():
+    """The endpoint reads ``ImageCluster`` joined with ``PhotoCluster`` + ``Photo``
+    when no pending task exists. We arrange that chain to return ``None`` so the
+    endpoint short-circuits to ``data=None`` without raising.
+    """
+    db = MagicMock()
+    db.query.return_value.join.return_value.join.return_value.filter.return_value.order_by.return_value.first.return_value = None
+    return db
+
+
+def test_create_similar_photo_task_enqueues_via_task_manager():
+    user = _user()
+    db = MagicMock()
+    new_task = _task(TaskType.SIMILAR_PHOTO_CLUSTERING, owner_id=user.id)
+
+    with patch.object(
+        toolbox_api.TaskManager, "get_instance",
+        return_value=MagicMock(add_task=MagicMock(return_value=new_task)),
+    ):
+        response = toolbox_api.create_similar_photo_task(threshold=0.85, db=db, current_user=user)
+
+    assert response.code == 0
+    assert response.data is new_task
+
+
+def test_get_latest_similar_task_returns_pending_when_present():
+    user = _user()
+    db = MagicMock()
+    pending = _task(TaskType.SIMILAR_PHOTO_CLUSTERING, owner_id=user.id)
+
+    with patch.object(
+        toolbox_api.crud_task, "get_latest_task_by_type_and_owner", return_value=pending
+    ) as fetch:
+        response = toolbox_api.get_latest_similar_task(db=db, current_user=user)
+
+    fetch.assert_called_once()
+    assert response.data is pending
+
+
+def test_get_latest_similar_task_returns_none_without_cluster():
+    user = _user()
+    db = _similar_latest_db_setup()
+
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner", return_value=None):
+        response = toolbox_api.get_latest_similar_task(db=db, current_user=user)
+
+    assert response.code == 0
+    assert response.data is None
+
+
+def test_get_similar_task_returns_synthesised_completed_when_missing():
+    """GET /similar/tasks/{id} synthesises a COMPLETED response for unknown ids."""
+    user = _user()
+    db = MagicMock()
+    task_id = uuid4()
+
+    with patch.object(toolbox_api.crud_task, "get_task_by_id_and_owner", return_value=None):
+        response = toolbox_api.get_similar_task(task_id=task_id, db=db, current_user=user)
+
+    assert response.code == 0
+    assert response.data.id == task_id
+    assert response.data.status == TaskStatus.COMPLETED.value
+
+
+def test_cancel_similar_task_marks_pending_as_cancelled():
+    user = _user()
+    db = MagicMock()
+    pending = _task(TaskType.SIMILAR_PHOTO_CLUSTERING, owner_id=user.id,
+                     status_value=TaskStatus.PROCESSING.value)
+
+    with patch.object(toolbox_api.crud_task, "get_task_by_id_and_owner", return_value=pending), \
+         patch.object(toolbox_api.crud_task, "delete_task") as delete:
+        response = toolbox_api.cancel_similar_task(task_id=uuid4(), db=db, current_user=user)
+
+    assert pending.status == TaskStatus.CANCELLED
+    delete.assert_called_once_with(db, pending)
+    assert response.code == 0
+
+
+def test_cancel_similar_task_returns_404_when_neither_in_db_nor_clusters():
+    user = _user()
+    db = MagicMock()
+
+    with patch.object(toolbox_api.crud_task, "get_task_by_id_and_owner", return_value=None):
+        db.query.return_value.filter.return_value.all.return_value = []
+        response = toolbox_api.cancel_similar_task(task_id=uuid4(), db=db, current_user=user)
+
+    assert response.code == 404
+
+
+# =========================================================================
+# GET /toolbox/cleanup
+# =========================================================================
+
+
+def test_get_photos_for_cleanup_returns_photos_with_default_asc_order():
+    user = _user()
+    db = MagicMock()
+    photo = SimpleNamespace(id=uuid4(), owner_id=user.id)
+    db.query.return_value.join.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [photo]
+
+    response = toolbox_api.get_photos_for_cleanup(skip=10, limit=5, sort_by="asc", db=db, current_user=user)
+
+    assert response.code == 0
+    assert response.data == [photo]
+
+
+def test_get_photos_for_cleanup_supports_desc_sort():
+    user = _user()
+    db = MagicMock()
+    db.query.return_value.join.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = []
+
+    response = toolbox_api.get_photos_for_cleanup(skip=0, limit=20, sort_by="desc", db=db, current_user=user)
+
+    assert response.code == 0
+
+
+# =========================================================================
+# Organize task lifecycle + preview-options
+# =========================================================================
+
+
+def test_start_organize_task_reuses_existing_pending():
+    user = _user()
+    db = MagicMock()
+    existing = _task(TaskType.ORGANIZE_PHOTOS, owner_id=user.id,
+                     status_value=TaskStatus.PROCESSING.value)
+
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=existing) as fetch:
+        response = toolbox_api.start_organize_task(
+            req=toolbox_api.OrganizeRequest(target_root_path="/tmp/photos",
+                                             strategy="time", action="copy"),
+            db=db, current_user=user,
+        )
+
+    fetch.assert_called_once()
+    assert response.data is existing
+
+
+def test_start_organize_task_creates_when_no_existing():
+    user = _user()
+    db = MagicMock()
+    new_task = _task(TaskType.ORGANIZE_PHOTOS, owner_id=user.id,
+                     payload={"strategy": "person", "action": "move"})
+
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=None), patch.object(
+        toolbox_api.TaskManager, "get_instance",
+        return_value=MagicMock(add_task=MagicMock(return_value=new_task)),
+    ):
+        response = toolbox_api.start_organize_task(
+            req=toolbox_api.OrganizeRequest(
+                target_root_path="/tmp/photos", strategy="person", action="move",
+                location_granularity="province", location_format="nested",
+            ),
+            db=db, current_user=user,
+        )
+
+    assert response.code == 0
+    assert response.data is new_task
+
+
+def test_get_latest_organize_task_includes_completed_in_search():
+    user = _user()
+    db = MagicMock()
+    completed = _task(TaskType.ORGANIZE_PHOTOS, owner_id=user.id,
+                      status_value=TaskStatus.COMPLETED.value)
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=completed) as fetch:
+        response = toolbox_api.get_latest_organize_task(db=db, current_user=user)
+
+    requested_statuses = fetch.call_args.args[3]
+    assert TaskStatus.COMPLETED.value in requested_statuses
+    assert TaskStatus.FAILED.value in requested_statuses
+    assert response.data is completed
+
+
+def test_organize_preview_options_returns_tag_list_for_category_strategy():
+    user = _user()
+    db = MagicMock()
+
+    tag_chain = (
+        db.query.return_value.join.return_value.join.return_value.filter.return_value.distinct.return_value
+    )
+    tag_chain.all.return_value = [("beach",), ("sunset",)]
+    db.query.return_value.outerjoin.return_value.filter.return_value.first.return_value = None
+
+    response = toolbox_api.get_organize_preview_options(
+        req=toolbox_api.OrganizePreviewOptionsRequest(strategy="category"),
+        db=db, current_user=user,
+    )
+
+    assert response.code == 0
+    assert sorted(response.data.options) == ["beach", "sunset"]
+
+
+def test_organize_preview_options_person_adds_unnamed_sentinel():
+    user = _user()
+    db = MagicMock()
+    identity_chain = (
+        db.query.return_value.join.return_value.join.return_value.filter.return_value.distinct.return_value
+    )
+    identity_chain.all.return_value = [("Alice",)]
+    db.query.return_value.filter.return_value.first.return_value = SimpleNamespace(id=uuid4())
+
+    response = toolbox_api.get_organize_preview_options(
+        req=toolbox_api.OrganizePreviewOptionsRequest(strategy="person"),
+        db=db, current_user=user,
+    )
+
+    options = set(response.data.options)
+    assert "Alice" in options
+    assert "未命名" in options
+
+
+# =========================================================================
+# Rename taskkick endpoints
+# =========================================================================
+
+
+def test_start_rename_task_reuses_existing_pending():
+    user = _user()
+    db = MagicMock()
+    existing = _task(TaskType.BATCH_RENAME, owner_id=user.id)
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=existing) as fetch:
+        response = toolbox_api.start_rename_task(
+            req=toolbox_api.RenameRequest(target_root_path="/tmp"),
+            db=db, current_user=user,
+        )
+
+    fetch.assert_called_once()
+    assert response.data is existing
+
+
+def test_start_rename_task_enqueues_when_no_pending():
+    user = _user()
+    db = MagicMock()
+    new_task = _task(TaskType.BATCH_RENAME, owner_id=user.id,
+                     payload={"target_root_path": "/tmp",
+                              "template": "IMG_{date}_{time}"})
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=None), patch.object(
+        toolbox_api.TaskManager, "get_instance",
+        return_value=MagicMock(add_task=MagicMock(return_value=new_task)),
+    ):
+        response = toolbox_api.start_rename_task(
+            req=toolbox_api.RenameRequest(target_root_path="/tmp",
+                                          template="IMG_{date}_{time}"),
+            db=db, current_user=user,
+        )
+
+    assert response.data is new_task
+
+
+def test_get_latest_rename_task_returns_completed_after_failure():
+    user = _user()
+    db = MagicMock()
+    failed = _task(TaskType.BATCH_RENAME, owner_id=user.id,
+                   status_value=TaskStatus.FAILED.value)
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=failed) as fetch:
+        response = toolbox_api.get_latest_rename_task(db=db, current_user=user)
+
+    requested = fetch.call_args.args[3]
+    assert TaskStatus.FAILED.value in requested
+    assert response.data is failed
+
+
+# =========================================================================
+# Time-from-filename taskkick endpoints
+# =========================================================================
+
+
+def test_start_time_from_filename_task_reuses_existing_pending():
+    user = _user()
+    db = MagicMock()
+    existing = _task(TaskType.BATCH_TIME_FROM_FILENAME, owner_id=user.id)
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=existing) as fetch:
+        response = toolbox_api.start_time_from_filename_task(
+            req=toolbox_api.TimeFromFilenameRequest(target_root_path="/tmp"),
+            db=db, current_user=user,
+        )
+
+    fetch.assert_called_once()
+    assert response.data is existing
+
+
+def test_start_time_from_filename_task_enqueues_when_no_pending():
+    user = _user()
+    db = MagicMock()
+    new_task = _task(TaskType.BATCH_TIME_FROM_FILENAME, owner_id=user.id,
+                     payload={"target_root_path": "/tmp",
+                              "only_missing_metadata": True})
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=None), patch.object(
+        toolbox_api.TaskManager, "get_instance",
+        return_value=MagicMock(add_task=MagicMock(return_value=new_task)),
+    ):
+        response = toolbox_api.start_time_from_filename_task(
+            req=toolbox_api.TimeFromFilenameRequest(
+                target_root_path="/tmp", only_missing_metadata=True, make="Canon"),
+            db=db, current_user=user,
+        )
+
+    assert response.data is new_task
+
+
+def test_get_latest_time_from_filename_task_returns_latest():
+    user = _user()
+    db = MagicMock()
+    completed = _task(TaskType.BATCH_TIME_FROM_FILENAME, owner_id=user.id,
+                      status_value=TaskStatus.COMPLETED.value)
+    with patch.object(toolbox_api.crud_task, "get_latest_task_by_type_and_owner",
+                      return_value=completed) as fetch:
+        response = toolbox_api.get_latest_time_from_filename_task(db=db, current_user=user)
+
+    requested = fetch.call_args.args[3]
+    assert TaskStatus.COMPLETED.value in requested
+    assert response.data is completed

--- a/package/website/playwright.config.ts
+++ b/package/website/playwright.config.ts
@@ -32,7 +32,13 @@ export default defineConfig({
   fullyParallel: suite !== 'smoke',
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? (suite === 'smoke' ? 1 : 2) : undefined,
+  // CI: smoke=1, others=2. 本地非 CI 默认 4 worker（可由 TS_E2E_WORKERS 覆盖），
+  // 避免 Playwright auto-detect（≈CPU 数，本机常达 8~16）压满后端/AI 时出现 load-induced flake。
+  workers: process.env.CI
+    ? (suite === 'smoke' ? 1 : 2)
+    : process.env.TS_E2E_WORKERS
+    ? Number(process.env.TS_E2E_WORKERS)
+    : 4,
 
   globalSetup: e2eEnv.globalSetup,
   globalTeardown: e2eEnv.globalTeardown,

--- a/package/website/tests/e2e/specs/photos/photos-flow-p1.spec.ts
+++ b/package/website/tests/e2e/specs/photos/photos-flow-p1.spec.ts
@@ -135,21 +135,18 @@ test.describe('P1 - 照片流核心功能', () => {
     // 视频卡片在筛选后由画廊按可见月份懒加载。并行压测下月份加载可能延迟，
     // 用「边滚边等」兜底：定期滚动触发更多月份加载，最长等 30s。
     const card = page.locator('.photo-gallery .group:has(svg.lucide-circle-play)').first()
-    let cardVisible = false
-    for (let i = 0; i < 20; i++) {
-      if (await card.count() > 0) {
-        cardVisible = true
-        break
-      }
+    // 'video card should render after filtering by 视频'：用 expect.poll 轮询 + 边询边滚动触发更多月份加载，
+    // 看到卡片立刻退出，省掉固定 1500ms sleep 在高负载下的边界越限。
+    await expect.poll(async () => {
+      if (await card.count() > 0) return true
       // 滚动主容器触发懒加载月份（gallery 以 main 或 window 为滚动容器）
       await page.evaluate(() => {
         const main = document.querySelector('main')
         if (main) main.scrollBy(0, 800)
         window.scrollBy(0, 800)
       })
-      await page.waitForTimeout(1500)
-    }
-    expect(cardVisible, 'video card should render after filtering by 视频').toBeTruthy()
+      return false
+    }, { timeout: 30_000, intervals: [500, 1_000, 2_000] }).toBe(true)
     await card.click()
 
     // PhotoLightbox 视频分支渲染 xgplayer（div 含 .videoPlayer ref）或 video 元素
@@ -297,21 +294,18 @@ test.describe('P1 - 照片流核心功能', () => {
     //    Tailwind 的 icon-[tabler--live-photo] 在 CSS 选择器中需要转义方括号；改用属性包含匹配 [class*="tabler--live-photo"]
     //    避免引号转义问题。
     const targetCardImg = page.locator(`.photo-gallery img[src*="${photoId}/thumbnail"]`).first()
-    let cardImgVisible = false
-    for (let i = 0; i < 20; i++) {
-      if (await targetCardImg.count() > 0) {
-        cardImgVisible = true
-        break
-      }
+    // `live photo card for ${photoId} should render after filtering by 实况图`：用 expect.poll 轮询 + 边询边滚动触发更多月份加载，
+    // 看到卡片立刻退出，省掉固定 1500ms sleep 在高负载下的边界越限。
+    await expect.poll(async () => {
+      if (await targetCardImg.count() > 0) return true
       // 月份按需懒加载，滚动 main 容器触发更多月份
       await page.evaluate(() => {
         const main = document.querySelector('main')
         if (main) main.scrollBy(0, 800)
         window.scrollBy(0, 800)
       })
-      await page.waitForTimeout(1500)
-    }
-    expect(cardImgVisible, `live photo card for ${photoId} should render after filtering by 实况图`).toBeTruthy()
+      return false
+    }, { timeout: 30_000, intervals: [500, 1_000, 2_000] }).toBe(true)
 
     // 3. 验证「缩略图请求」已发出 —— gallery 用 img.thumbnail 作为缩略图 src，
     //    PhotoGallery.vue 在 mounted 后立即触发 fetch(image.thumbnail)。

--- a/package/website/tests/e2e/specs/photos/photos-flow-p1.spec.ts
+++ b/package/website/tests/e2e/specs/photos/photos-flow-p1.spec.ts
@@ -79,8 +79,11 @@ test.describe('P1 - 照片流核心功能', () => {
 
     // 打开 Lightbox（默认显示 preview=medium 缩略图，不会请求 /file）
     await thumb.click()
-    const lightboxImg = page.locator('img[draggable="false"]').first()
-    await expect(lightboxImg).toBeVisible({ timeout: 10_000 })
+    // 不要用 img[draggable="false"].first() 断言可见：PhotoLightbox 的 img 在 fade-in
+    // 过渡中可能短暂被父容器尺寸为 0 判为 hidden；改为等待"查看原图"按钮可见，
+    // 该按钮仅在 lightbox 打开后渲染，是更可靠的"lightbox 已就绪"信号。
+    const originalBtn = page.getByTitle('查看原图 (Shift+O)')
+    await expect(originalBtn).toBeVisible({ timeout: 10_000 })
 
     // 点「查看原图」才请求 /api/medias/{id}/file（displayImageSrc 在 showOriginal 时用 image.url）
     const fileRequest = page.waitForRequest(

--- a/package/website/tests/e2e/specs/photos/photos-flow-p1.spec.ts
+++ b/package/website/tests/e2e/specs/photos/photos-flow-p1.spec.ts
@@ -167,8 +167,12 @@ test.describe('P1 - 照片流核心功能', () => {
     await expect(batchBtn).toBeVisible({ timeout: 10_000 })
     await batchBtn.click()
 
+    // 进入批量模式后 PhotoGallery 经历一次重渲染，期间 nth(1) 可能短暂未挂载；
+    // 先等底部'已选 X 项'工具栏可见再断言图片可见，避免 element(s) not found。
+    const actionBarInBatch = page.locator('text=/已选\\s*\\d+\\s*项/').first()
+    await expect(actionBarInBatch).toBeVisible({ timeout: 10_000 })
     const imgs = page.locator('.photo-gallery img')
-    await expect(imgs.nth(1)).toBeVisible({ timeout: 5_000 })
+    await expect(imgs.nth(1)).toBeVisible({ timeout: 10_000 })
     // 选择模式下 click = toggle（PhotoGallery handlePhotoClick）
     await imgs.nth(0).click({ force: true })
     await imgs.nth(1).click({ force: true })

--- a/package/website/tests/e2e/specs/settings/system-config.spec.ts
+++ b/package/website/tests/e2e/specs/settings/system-config.spec.ts
@@ -39,6 +39,9 @@ test.describe('系统设置-开放注册开关 @settings @system-config', () => 
   test('切换「允许新用户注册」后实时影响注册可用性，并以关闭态收尾', async ({
     page,
   }) => {
+    // 3 次 setSwitch (save + toast 出现 + toast 消失) 累计 ≈ 66s，超过 Playwright 默认 test 级 timeout (30s) 会触发
+    // "page, context or browser has been closed"。提前开口，给进程变化与任务队列预留余量。
+    test.setTimeout(90_000);
     // 1) 以管理员身份登录（开关仅在超级用户下可用）
     await page.goto('/login');
     await page.fill('input[placeholder="请输入用户名"]', ADMIN.username);


### PR DESCRIPTION
## Nightly Watch 2026-08-06 (run #3)

承接 run #2 留下"下次待办"中项 2、3 — `photos-flow-p1` 高负载下偶发回归 +
`playwright.config.ts` 本地 `workers=undefined` 引发 load-induced flake。

### 本轮改动 (commit 70fbe02)

- **`package/website/playwright.config.ts`** — 本地非 CI 默认 4 worker（可由
  `TS_E2E_WORKERS` 覆盖）。CI 行为不变（smoke=1, others=2）。本机 CPU 多时
  Playwright auto-detect（≈8~16 worker）压满后端/AI，触发 load-induced flake；
  改成显式 4 既能并行，又显著降低 flake。
- **`package/website/tests/e2e/specs/photos/photos-flow-p1.spec.ts`** —
  2.1.5 视频 + 2.1.6 实况图 的卡片渲染等待由 `for + 1500ms sleep` 改为
  `expect.poll` 边询边滚，看到卡片立刻返回，省掉固定 sleep 在高负载下边界越限的 30s。
- **`package/website/tests/e2e/specs/settings/system-config.spec.ts`** —
  开放注册开关用例 `test.setTimeout(90_000)`，覆盖用户先前把 toast 等待 5s/6s
  调到 10s/12s 后的 3 次 setSwitch 累计 ≈66s。

### 本轮本地回归 (`TS_E2E_WORKERS=4` + fixture scan)

5/5 PASS，4.3m。

| 用例                                                  | 耗时    | 状态 |
|-------------------------------------------------------|---------|------|
| 00-setup (Create test account and scan folder)        | 3.8s    | PASS |
| 2.1.3 原图加载 (PhotoLightbox)                        | 8.6s    | PASS |
| 2.1.5 视频播放 (expect.poll)                          | 10.5s   | PASS |
| 2.1.6 实况图识别 (expect.poll)                        | 13.3s   | PASS |
| system-config:39 开放注册开关 (setTimeout 90s)         | 25.9s   | PASS |

### 本轮 CI（GitHub Actions, run #31071839926）

| Job                                         | 状态   | 耗时     |
|---------------------------------------------|--------|----------|
| CLI unit (pytest)                           | PASS   | 14s      |
| Server unit (pytest)                        | PASS   | 30s      |
| Server integration (pytest + live server)   | PASS   | 1m3s     |
| AI unit (pytest)                            | PASS   | 42s      |
| E2E (Playwright + docker compose)           | PASS   | 13m39s   |

CI 5/5 全绿，PR #110 可按 nightly 流程保持 OPEN 等用户 review。

### 上轮 (commit b038967, PR body 原文)

> 2.1.3 原图加载用例 `img[draggable="false"].first()` 改为等待
> `getByTitle("查看原图 (Shift+O)")`，避免 PhotoLightbox fade-in 期间
> img 被父容器尺寸 0 判 hidden。新增 5 个 storage API 用例，模块覆盖率 65%→95%。

详见 `tests/artifacts/nightly/2026-08-06/summary.md` 与 `verify-fix3.log`。

### 自动合并
按 nightly 流程不自动合入 master；等 CI 流水线全绿即可（本轮已全绿）。