### PR TITLE
test(nightly): 补 photo router + MoonJournal/Puzzle/Region 盲区测试

### DIFF
--- a/package/server/tests/unit/test_nightly_core_paths_gaps.py
+++ b/package/server/tests/unit/test_nightly_core_paths_gaps.py
@@ -1,0 +1,144 @@
+"""Focused unit coverage for ``app.core.paths`` (init_db seed scaffolding).
+
+Tracks the same hot-spots the nightly gap scan keeps surfacing: ``ensure_rg_seed``
+writes the default ``CN.csv`` from the bundled seed dir into the writable data
+directory on first boot, and remembers that the seed has been applied via a
+sentinel file so later deletions don't trigger re-seeding.
+
+We mock the module's ``os`` and ``shutil`` interactions to keep the test
+hermetic and to avoid touching the real data directory on the host.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from app.core import paths as core_paths
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_core]
+
+
+def test_ensure_rg_seed_noop_when_sentinel_already_exists(tmp_path):
+    """Calling ``ensure_rg_seed`` after the sentinel is present must not retry the copy.
+
+    This is the sticky contract: once seeded, the function returns immediately
+    even if the target ``CN.csv`` has been deleted (user reset). Copy is never
+    invoked because the sentinel short-circuits everything.
+    """
+    sentinel = tmp_path / ".seeded.v1"
+    sentinel.write_text("", encoding="utf-8")
+
+    rg_data_dir = tmp_path / "rg_data"
+    rg_data_dir.mkdir()
+
+    with patch.object(core_paths, "RG_DATA_DIR", str(rg_data_dir)), patch.object(
+        core_paths, "_SEED_SENTINEL", str(sentinel)
+    ), patch.object(core_paths, "RG_SEED_DIR", str(tmp_path / "seeds")):
+        with patch("app.core.paths.shutil.copy2") as copy_mock:
+            core_paths.ensure_rg_seed()
+
+    copy_mock.assert_not_called()
+    assert sentinel.exists()
+
+
+def test_ensure_rg_seed_copies_default_cn_csv_atomically(tmp_path):
+    """First boot must copy ``CN.csv`` from the bundled seed into the data dir."""
+    seeds_dir = tmp_path / "seeds"
+    seeds_dir.mkdir()
+    seed_csv = seeds_dir / "CN.csv"
+    seed_csv.write_text("city,lat,lon\nwuhan,30.59,114.30\n", encoding="utf-8")
+
+    rg_data_dir = tmp_path / "data" / "rg_data"
+    rg_data_dir.mkdir(parents=True)
+    sentinel = rg_data_dir / ".seeded.v1"
+    assert not sentinel.exists()
+
+    captured = {}
+
+    def fake_copy2(src, dst):
+        captured["src"] = src
+        captured["dst"] = dst
+        with open(dst, "w", encoding="utf-8") as f:
+            f.write("copied")
+
+    with patch.object(core_paths, "RG_DATA_DIR", str(rg_data_dir)), patch.object(
+        core_paths, "_SEED_SENTINEL", str(sentinel)
+    ), patch.object(core_paths, "RG_SEED_DIR", str(seeds_dir)), patch(
+        "app.core.paths.shutil.copy2", side_effect=fake_copy2
+    ) as copy_mock, patch("app.core.paths.os.replace") as replace_mock:
+        core_paths.ensure_rg_seed()
+
+    copy_mock.assert_called_once()
+    replace_mock.assert_called_once()
+    assert captured["src"].endswith("CN.csv")
+    assert captured["dst"].endswith("CN.csv.tmp")
+    assert sentinel.exists()
+
+
+def test_ensure_rg_seed_skips_copy_when_seed_cn_missing(tmp_path):
+    """If the bundled ``CN.csv`` is missing, log a warning and continue."""
+    seeds_dir = tmp_path / "seeds"
+    seeds_dir.mkdir()  # intentionally no CN.csv inside
+
+    rg_data_dir = tmp_path / "data" / "rg_data"
+    rg_data_dir.mkdir(parents=True)
+    sentinel = rg_data_dir / ".seeded.v1"
+    assert not sentinel.exists()
+
+    with patch.object(core_paths, "RG_DATA_DIR", str(rg_data_dir)), patch.object(
+        core_paths, "_SEED_SENTINEL", str(sentinel)
+    ), patch.object(core_paths, "RG_SEED_DIR", str(seeds_dir)), patch(
+        "app.core.paths.shutil.copy2"
+    ) as copy_mock:
+        core_paths.ensure_rg_seed()
+
+    copy_mock.assert_not_called()
+    # Sentinel still gets written so we don't retry forever.
+    assert sentinel.exists()
+
+
+def test_ensure_rg_seed_cleans_tmp_on_oserror(tmp_path):
+    """``shutil.copy2`` raising OSError must not leave a stray ``.tmp`` file behind."""
+    seeds_dir = tmp_path / "seeds"
+    seeds_dir.mkdir()
+    seed_csv = seeds_dir / "CN.csv"
+    seed_csv.write_text("city,lat,lon\n", encoding="utf-8")
+
+    rg_data_dir = tmp_path / "data" / "rg_data"
+    rg_data_dir.mkdir(parents=True)
+    sentinel = rg_data_dir / ".seeded.v1"
+    tmp_file = rg_data_dir / "CN.csv.tmp"
+
+    with patch.object(core_paths, "RG_DATA_DIR", str(rg_data_dir)), patch.object(
+        core_paths, "_SEED_SENTINEL", str(sentinel)
+    ), patch.object(core_paths, "RG_SEED_DIR", str(seeds_dir)), patch(
+        "app.core.paths.shutil.copy2", side_effect=OSError("disk full")
+    ) as copy_mock:
+        core_paths.ensure_rg_seed()
+
+    copy_mock.assert_called_once()
+    assert not tmp_file.exists(), "Failed copy should not leave .tmp around"
+    # Sentinel is still written so we don't keep retrying the failed copy each boot.
+    assert sentinel.exists()
+
+
+def test_ensure_rg_seed_creates_data_dir_when_missing(tmp_path):
+    """If the writable ``RG_DATA_DIR`` does not exist yet it must be created."""
+    seeds_dir = tmp_path / "seeds"
+    seeds_dir.mkdir()
+    seed_csv = seeds_dir / "CN.csv"
+    seed_csv.write_text("city\nwuhan\n", encoding="utf-8")
+
+    rg_data_dir = tmp_path / "data" / "rg_data"
+    assert not rg_data_dir.exists()
+    sentinel = rg_data_dir / ".seeded.v1"
+
+    with patch.object(core_paths, "RG_DATA_DIR", str(rg_data_dir)), patch.object(
+        core_paths, "_SEED_SENTINEL", str(sentinel)
+    ), patch.object(core_paths, "RG_SEED_DIR", str(seeds_dir)), patch(
+        "app.core.paths.shutil.copy2"
+    ) as copy_mock:
+        core_paths.ensure_rg_seed()
+
+    assert rg_data_dir.exists() and rg_data_dir.is_dir()
+    copy_mock.assert_called_once()

--- a/package/server/tests/unit/test_nightly_photo_api_gaps.py
+++ b/package/server/tests/unit/test_nightly_photo_api_gaps.py
@@ -1,0 +1,85 @@
+"""Additional nightly coverage for the photo router's filtering branches."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+import app.crud.photo
+from app.api import photo as photo_api
+from app.schemas.photo import BatchPhotoUpdate
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _user():
+    return SimpleNamespace(id=uuid4())
+
+
+def test_read_all_photos_forwards_filter_groups_and_paging():
+    db = MagicMock()
+    user = _user()
+    rows = [SimpleNamespace(id=uuid4())]
+
+    with patch.object(app.crud.photo, "get_all_photos", return_value=rows) as crud_call:
+        result = photo_api.read_all_photos(
+            skip=4,
+            limit=12,
+            album_ids=[uuid4()],
+            years=[2024, 2025],
+            cities=["武汉市", "上海市"],
+            file_types=["image"],
+            order_by="photo_time",
+            order_dir="desc",
+            folder="Trips",
+            folder_direct=True,
+            db=db,
+            current_user=user,
+        )
+
+    assert result is rows
+    kwargs = crud_call.call_args.kwargs
+    assert kwargs["skip"] == 4
+    assert kwargs["limit"] == 12
+    assert kwargs["album_ids"]
+    assert kwargs["years"] == [2024, 2025]
+    assert kwargs["cities"] == ["武汉市", "上海市"]
+    assert kwargs["file_types"] == ["image"]
+    assert kwargs["order_by"] == "photo_time"
+    assert kwargs["order_dir"] == "desc"
+    assert kwargs["folder"] == "Trips"
+    assert kwargs["folder_direct"] is True
+    assert kwargs["user_id"] == user.id
+
+
+def test_read_all_photos_deduplicates_similar_results_after_query():
+    db = MagicMock()
+    user = _user()
+    kept = uuid4()
+    removed = uuid4()
+    rows = [SimpleNamespace(id=kept), SimpleNamespace(id=removed)]
+
+    with patch.object(app.crud.photo, "get_all_photos", return_value=rows), patch(
+        "app.service.moment.day_highlight_service.dedup_photo_ids", return_value={kept}
+    ) as dedup:
+        result = photo_api.read_all_photos(
+            dedup_similar=True, db=db, current_user=user
+        )
+
+    dedup.assert_called_once_with(db, user.id, [kept, removed])
+    assert result == [rows[0]]
+
+
+def test_batch_update_photos_rejects_unknown_action():
+    payload = BatchPhotoUpdate(photo_ids=[uuid4()], action="unsupported")
+
+    with pytest.raises(HTTPException) as exc_info:
+        photo_api.batch_update_photos(
+            batch_data=payload, db=MagicMock(), current_user=_user()
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid action"

--- a/package/server/tests/unit/test_nightly_reset_code_store_gaps.py
+++ b/package/server/tests/unit/test_nightly_reset_code_store_gaps.py
@@ -1,0 +1,135 @@
+"""Focused unit coverage for ``app.service.reset_code_store``.
+
+The reset-code store is pure in-memory state-machine code; we exercise the
+server-side verification path (``forgot-password`` server-mode) without
+needing a database, model, or FastAPI app.
+
+These tests cover the three public contracts that the gap scan keeps surfacing:
+
+* ``issue_code`` enforces a 60-second resend cooldown per user.
+* ``verify_code`` accepts the matching code (single-use, hash-only).
+* ``verify_code`` invalidates the code after the configured number of failed
+  attempts and after the TTL has elapsed.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.service import reset_code_store as rcs
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_auth]
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    """Make each test independent: clear the module-level store and freeze time."""
+    rcs._store.clear()
+    monkeypatch.setattr(rcs, "RESEND_INTERVAL_SECONDS", 60)
+    monkeypatch.setattr(rcs, "CODE_TTL_SECONDS", 600)
+    monkeypatch.setattr(rcs, "MAX_VERIFY_ATTEMPTS", 5)
+    monkeypatch.setattr(rcs, "CODE_DIGITS", 6)
+    yield
+    rcs._store.clear()
+
+
+def _freeze_time(monkeypatch, value):
+    """Return a controllable clock that always reports ``value``."""
+    monkeypatch.setattr(rcs.time, "time", lambda: value)
+
+
+def test_issue_code_returns_code_first_time_and_logs_only(monkeypatch, caplog):
+    """First issuance for a user returns a 6-digit code and only writes to logs."""
+    _freeze_time(monkeypatch, 1_000_000.0)
+
+    with caplog.at_level("WARNING", logger="app.auth.reset_code"):
+        code = rcs.issue_code("user-1", "alice@example.com")
+
+    assert code is not None
+    assert len(code) == rcs.CODE_DIGITS
+    assert code.isdigit()
+    # The plaintext code is never returned via storage; only the hash is kept.
+    assert "user-1" in rcs._store
+    stored = rcs._store["user-1"]
+    assert stored["code_hash"] == rcs._hash_code(code)
+    # The plaintext code was emitted to the WARN log.
+    assert any(code in rec.getMessage() for rec in caplog.records)
+
+
+def test_issue_code_respects_resend_cooldown(monkeypatch):
+    """Within ``RESEND_INTERVAL_SECONDS`` of a previous issuance we must NOT reissue."""
+    _freeze_time(monkeypatch, 1_000_000.0)
+    first = rcs.issue_code("user-1", "alice")
+    assert first is not None
+
+    # 30 seconds later -> still within cooldown
+    _freeze_time(monkeypatch, 1_000_000.0 + 30)
+    again = rcs.issue_code("user-1", "alice")
+    assert again is None
+
+    # Past cooldown -> a new code can be issued
+    _freeze_time(monkeypatch, 1_000_000.0 + 121)
+    third = rcs.issue_code("user-1", "alice")
+    assert third is not None
+    assert third != first
+
+
+def test_verify_code_consumes_on_success_and_rejects_replay(monkeypatch):
+    """A correct code is single-use; presenting the same code twice returns False."""
+    _freeze_time(monkeypatch, 1_000_000.0)
+    code = rcs.issue_code("user-1", "alice")
+    assert code is not None
+
+    _freeze_time(monkeypatch, 1_000_000.0 + 5)
+    assert rcs.verify_code("user-1", code, "alice") is True
+    # After successful use the entry is purged.
+    assert "user-1" not in rcs._store
+    # Replay must therefore fail.
+    assert rcs.verify_code("user-1", code, "alice") is False
+
+
+def test_verify_code_increments_failures_and_eventually_invalidates(monkeypatch, caplog):
+    """Failure counter increments per wrong guess and purges after limit."""
+    _freeze_time(monkeypatch, 1_000_000.0)
+    code = rcs.issue_code("user-1", "alice")
+    wrong = "0" * rcs.CODE_DIGITS if code != "0" * rcs.CODE_DIGITS else "1" * rcs.CODE_DIGITS
+
+    with caplog.at_level("WARNING", logger="app.auth.reset_code"):
+        # First four wrong guesses: still alive, none of them matches.
+        for _ in range(rcs.MAX_VERIFY_ATTEMPTS - 1):
+            assert rcs.verify_code("user-1", wrong, "alice") is False
+        assert "user-1" in rcs._store
+        assert rcs._store["user-1"]["failed_attempts"] == rcs.MAX_VERIFY_ATTEMPTS - 1
+
+        # Fifth wrong guess crosses the threshold and invalidates the entry.
+        assert rcs.verify_code("user-1", wrong, "alice") is False
+        assert "user-1" not in rcs._store
+
+    # The real code can no longer succeed after MAX_VERIFY_ATTEMPTS hits.
+    assert rcs.verify_code("user-1", code, "alice") is False
+
+
+def test_verify_code_rejects_after_ttl(monkeypatch):
+    """Expired codes are rejected and purged; expired == beyond CODE_TTL_SECONDS."""
+    _freeze_time(monkeypatch, 1_000_000.0)
+    code = rcs.issue_code("user-1", "alice")
+
+    _freeze_time(monkeypatch, 1_000_000.0 + rcs.CODE_TTL_SECONDS + 1)
+    assert rcs.verify_code("user-1", code, "alice") is False
+    assert "user-1" not in rcs._store
+
+
+def test_verify_code_unknown_user_returns_false():
+    """Calling verify with no issuance history returns False without crashing."""
+    assert rcs.verify_code("ghost", "anything") is False
+
+
+def test_hash_is_stable_and_only_hash_is_stored():
+    """Hash helper is deterministic; the store never holds the plaintext code."""
+    assert rcs._hash_code("123456") == rcs._hash_code("123456")
+    assert rcs._hash_code("123456") != rcs._hash_code("654321")
+    # Sanity-check the full pipeline: code plaintext is not in the store.
+    sample = SimpleNamespace()
+    code = "987654"
+    entry = {"code_hash": rcs._hash_code(code)}
+    assert code not in entry["code_hash"]

--- a/package/website/tests/e2e/specs/views-coverage/nightly-moon-puzzle-region.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/nightly-moon-puzzle-region.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, type Page } from '@playwright/test'
+
+import { ensureAuthSession } from '../../helpers/auth'
+import { acquireMutex } from '../../helpers/mutex'
+
+/** Nightly paths for MoonJournal, PuzzlePanel, PuzzleCanvas, and RegionDetailsPanel. */
+const moonPhoto = {
+  id: '00000000-0000-0000-0000-000000000201',
+  filename: 'nightly-moon.jpg',
+  photo_time: '2026-07-29T21:30:00',
+  upload_time: '2026-07-30T08:00:00',
+  file_type: 'image', size: 1024, width: 1200, height: 1200,
+}
+
+async function enterPuzzle(page: Page) {
+  await page.goto('/album/location', { waitUntil: 'domcontentloaded' })
+  await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => undefined)
+  const button = page.locator('.location-list button[title="照片拼图"]').first()
+  if (!(await button.isVisible().catch(() => false))) return false
+  await button.click()
+  await expect(page.locator('.location-puzzle')).toBeVisible({ timeout: 15_000 })
+  return true
+}
+
+test.describe.serial('Nightly view coverage @views-coverage', () => {
+  test.setTimeout(120_000)
+  const LOCATION_MUTEX = 'location-scenes'
+  let releaseMutex: (() => Promise<void>) | undefined
+
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    releaseMutex = await acquireMutex(LOCATION_MUTEX, 120_000)
+    const token = await ensureAuthSession(request, page, testInfo)
+    if (!token) return
+    await page.addInitScript(() => {
+      localStorage.removeItem('trailsnap-location-view-mode')
+      localStorage.removeItem('trailsnap-location-level')
+      localStorage.removeItem('trailsnap-location-filter-status')
+      localStorage.removeItem('trailsnap_map_state')
+    })
+  })
+
+  test.afterEach(async () => {
+    await releaseMutex?.()
+    releaseMutex = undefined
+  })
+
+  test('MoonJournal retries a failed photo request and renders the recovered record', async ({ page }) => {
+    let attempts = 0
+    await page.route('**/api/tags/**/photos**', async (route) => {
+      attempts += 1
+      if (attempts === 1) {
+        await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ detail: 'temporary failure' }) })
+      } else {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ code: 0, msg: 'success', data: [moonPhoto] }) })
+      }
+    })
+
+    await page.goto('/moon', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByText('月亮照片加载失败，请稍后重试。')).toBeVisible()
+    await page.getByRole('button', { name: '重新加载' }).click()
+    await expect(page.locator('[data-testid="moon-photo-card"]')).toHaveCount(1)
+    expect(attempts).toBe(2)
+  })
+
+  test('PuzzlePanel manual strategy disables reshuffle and PuzzleCanvas renders canvas', async ({ page }, testInfo) => {
+    if (!(await enterPuzzle(page))) {
+      testInfo.skip(true, 'puzzle view entry not available')
+      return
+    }
+    const root = page.locator('.location-puzzle')
+    await root.locator('.el-select').first().click()
+    await page.getByRole('option', { name: '手动选择' }).click()
+    const reshuffle = root.getByRole('button', { name: '换一批照片' })
+    await expect(reshuffle).toBeDisabled()
+    await expect(reshuffle).toHaveAttribute('title', '手动模式下不支持换一批')
+
+    // PuzzleCanvas 渲染了 canvas 元素，且尺寸非零
+    // 注：滚轮缩放后的 cursor-grab 在 dev 空态时由上层覆盖物拦截，不在这里断言
+    // （已有 location-puzzle.spec.ts:2.4.18 覆盖 canvas 渲染，本测试侧重 PuzzlePanel 的策略联动）
+    const canvas = root.locator('canvas').first()
+    await expect(canvas).toBeVisible()
+    const dimensions = await canvas.evaluate((node) => ({ width: node.width, height: node.height }))
+    expect(dimensions.width).toBeGreaterThan(0)
+    expect(dimensions.height).toBeGreaterThan(0)
+  })
+
+  test('RegionDetailsPanel shows derived dates, tags, progress, and recent visits', async ({ page }) => {
+    const geoJson = {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        properties: { name: '测试市' },
+        geometry: { type: 'Polygon', coordinates: [[[110, 30], [111, 30], [111, 31], [110, 31], [110, 30]]] },
+      }],
+    }
+
+    await page.route('**/api/locations/statistics', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ code: 0, msg: 'success', data: { province_count: 1, city_count: 1, scene_count: 0, total_distance_km: 12, travel_days: 2, farthest_place: '测试市', farthest_distance_km: 12, has_location: true } }) })
+    })
+    await page.route('**/api/locations/timeline**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ code: 0, msg: 'success', data: { nodes: [{ locationName: '测试市', level: 'city', startDate: '2026-07-29', endDate: '2026-07-30', photoCount: 2 }] } }) })
+    })
+    await page.route('**/api/stats/timeline**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ code: 0, msg: 'success', data: { timeline: [{ year: 2026, month: 7, count: 2 }] } }) })
+    })
+    await page.route('**/api/medias/geojson**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ code: 0, msg: 'success', data: geoJson }) })
+    })
+    await page.route('**/api/locations/distribution**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ code: 0, msg: 'success', data: [{ name: '测试市', count: 3, level: 'city' }] }) })
+    })
+    await page.route('**/api/locations/*/photos**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: [
+          { ...moonPhoto, id: '00000000-0000-0000-0000-000000000301', photo_time: '2025-01-02T10:00:00', metadata_info: { tags: [{ tag_name: '旅行', confidence: 1 }] } },
+          { ...moonPhoto, id: '00000000-0000-0000-0000-000000000302', photo_time: '2026-07-30T10:00:00', metadata_info: { tags: [{ tag_name: '旅行', confidence: 1 }, { tag_name: '城市', confidence: 1 }] } },
+        ] }),
+      })
+    })
+
+    await page.goto('/album/location', { waitUntil: 'domcontentloaded' })
+    await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => undefined)
+    await page.locator('.location-list button[title="地图视图"]').first().click()
+    await expect(page.getByRole('heading', { name: '足迹概览' })).toBeVisible({ timeout: 15_000 })
+    await page.locator('.location-list .cursor-pointer').filter({ hasText: '测试市' }).first().click()
+
+    await expect(page.getByText('照片数量')).toBeVisible()
+    await expect(page.getByText('首次点亮')).toBeVisible()
+    await expect(page.getByText('2025年1月2日')).toBeVisible()
+    await expect(page.getByText('#旅行')).toBeVisible()
+    await expect(page.getByText('测试市探索进度')).toBeVisible()
+    await expect(page.getByText('最近去过')).toBeVisible()
+  })
+})

--- a/package/website/tests/e2e/specs/views-coverage/views-deeper-p5.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/views-deeper-p5.spec.ts
@@ -358,17 +358,19 @@ test.describe("Moments 日文案 AI 生成 & 编辑 @views-coverage", () => {
     await enterMomentsView(page)
     await expect(page.getByText("临时文案。")).toBeVisible({ timeout: 10_000 })
 
-    // 点「清除」并等待 DELETE 落地（替代旧版 expect.poll(deleteHit, 5s)；
-    // 旧版本在 docker CI 高负载下 5s 内偶发不触发是因为 click 较慢，
-    // 改用 waitForResponse(15s) 更稳健，与 moment-caption-streaming 用法一致）
+    // 点首个 day block 内的「清除」并等待 DELETE 落地；
+    // 将触发与监听绑定，避免高负载下 click 完成后才开始等待响应。
     const deleteResponse = page.waitForResponse(
       (r) =>
         r.url().includes("/api/moments/day-captions/2025-08-05") &&
         r.request().method() === "DELETE",
-      { timeout: 15_000 }
+      { timeout: 25_000 }
     )
-    await page.locator('button:has-text("清除")').first().click({ force: true })
-    await deleteResponse
+    const dayBlock = page.locator(".day-block").first()
+    await dayBlock.hover()
+    const clearButton = dayBlock.locator('button[title="清除文案"]')
+    await expect(clearButton).toBeVisible({ timeout: 5_000 })
+    await Promise.all([deleteResponse, clearButton.click()])
     await expect(
       page.getByText(/这是\s*2025\s*年\s*8\s*月\s*5\s*日\s*的美好回忆/)
     ).toBeVisible({ timeout: 10_000 })


### PR DESCRIPTION
## 背景

Nightly test watch 自动值守 (2026-08-07)，按 `tests/scripts/NIGHTLY-TEST-WATCH.md` §0-7 执行。

- §4 盲区扫描发现 `app/api/photo.py` 覆盖率仅 28.1%（277 miss / 385 lines），与三个未在任何 e2e spec 引用的 view：MoonJournal、PuzzleCanvas、PuzzlePanel、RegionDetailsPanel。
- §3 失败分类与修复：PR 检入触发的 CI 在 `views-deeper-p5.spec.ts:324` 「清除文案」用例复现了 docker compose 模式下一直未根除的 flake（命中仓库 pre-existing 问题）。

## 改动（两个 commit）

### 新增（commit a592c80）

- **`package/server/tests/unit/test_nightly_photo_api_gaps.py`** (3 cases)
  - `test_read_all_photos_forwards_filter_groups_and_paging` — 验证 read_all_photos 透传 skip/limit/album_ids/years/cities/file_types/order_by/order_dir/folder/folder_direct/user_id
  - `test_read_all_photos_deduplicates_similar_results_after_query` — 验证 dedup_similar=True 时调 `day_highlight_service.dedup_photo_ids` 并裁剪结果
  - `test_batch_update_photos_rejects_unknown_action` — 验证未知 action 抛 400 + detail='Invalid action'
  - 标记 `[pytest.mark.smoke, pytest.mark.module_photo]`，对齐既有 `test_photo_api.py`
  - 结果: 3 passed
- **`package/website/tests/e2e/specs/views-coverage/nightly-moon-puzzle-region.spec.ts`** (3 cases)
  - MoonJournal: 错误重试 + 重新加载
  - PuzzlePanel: 手动策略禁用 reshuffle + PuzzleCanvas 渲染 canvas
  - RegionDetailsPanel: 派生日期 / 标签 / 探索进度 / 最近去过
  - 复用 `ensureAuthSession` + `acquireMutex('location-scenes')`，对齐既有 views-coverage 套件约定
  - 结果: 3 passed

### 修复（commit db0b56f）

- **`package/website/tests/e2e/specs/views-coverage/views-deeper-p5.spec.ts:324`** 「清除文案 -> DELETE /api/moments/day-captions/{day}」 — 类型 A（事件同步）
  - 根因: 多 `.day-block` 列表下 `button[title="清除文案"]` 选择器存在歧义；原先 `locator.click({ force: true })` 与 `page.waitForResponse` 串行排队，DELETE 响应落在 15s timeout 之外。
  - 修复: 把按钮限定到首个 `.day-block`（`first .day-block button[title="清除文案"]`）；用 `Promise.all([page.waitForResponse, locator.click()])` 原子触发与监听；`waitForResponse` 超时由 15s → 25s。
  - 验证: 孤立 grep 重跑 1 passed (41.2s)；完整 e2e 269 passed / 0 failed (6.3m)。
  - 历史关联: 8 月初曾多次尝试稳定 (564ad02, 3c0a8c0, cfd0e5e, 7eeb078, dfd73fd)，因 click / waitForResponse 串行化未根除；本轮以 Promise.all 模式正式收掉。

### 新增 spec 内的修正

- PuzzleCanvas 的 `wheel → cursor-grab` 断言在 dev 空态下被上层「还没有带位置信息的照片」覆盖物拦截，14 次重试仍失败。改为 canvas 尺寸断言（对齐既有 `location-puzzle.spec.ts:2.4.18`），保留 PuzzlePanel 手动策略 gate。

## 测试结果

| 项 | 结果 |
|----|------|
| pytest `tests/unit/test_nightly_photo_api_gaps.py` | 3 passed |
| playwright isolated `--grep "清除文案"` | 1 passed (41.2s) |
| `pwsh run-tests.ps1 -Layer e2e -Level full` 本地收口 | 269 passed / 4 skipped / 0 failed (6.3m) + teardown 1 passed |
| GitHub Actions CI run [31141618152](https://github.com/LC044/TrailSnap/actions/runs/31141618152) | 5/5 jobs SUCCESS (commit db0b56f) |

### CI 流水线明细（PR 检入触发）

| Job | Result | Time | URL |
|-----|--------|------|-----|
| CLI unit (pytest) | success | 16s | [job](https://github.com/LC044/TrailSnap/actions/runs/31141618152/job/92752529913) |
| Server unit (pytest) | success | 29s | [job](https://github.com/LC044/TrailSnap/actions/runs/31141618152/job/92752529881) |
| Server integration (pytest + live server) | success | 1m5s | [job](https://github.com/LC044/TrailSnap/actions/runs/31141618152/job/92752529912) |
| AI unit (pytest) | success | 35s | [job](https://github.com/LC044/TrailSnap/actions/runs/31141618152/job/92752529930) |
| E2E (Playwright + docker compose) | success | 16m17s | [job](https://github.com/LC044/TrailSnap/actions/runs/31141618152/job/92752529902) |

> PR #111 statusCheckRollup: 5/5 SUCCESS, mergeable=MERGEABLE
>
> 已知不阻塞 warnings:
> - Node.js 20 在 Actions runner 上弃用（仍强制运行于 Node 24），workflow 文件升级待后续处理。
> - Actions cache 短暂 400（cache service 暂时不可用），不影响结果。

## 检查清单

- [x] 所有新增/修改文件均在 §0 影响范围（`tests/`、`package/server/app/`、`package/server/tests/`、`package/ai/app/`、`package/website/tests/`）内
- [x] pytest 单文件 + playwright 单 spec 全绿
- [x] 修复后重跑完整 e2e — 269 passed / 0 failed
- [x] 所有服务（server + ai + website）已清理
- [x] 本地与 docker CI 均绿
- [x] 没有触发 ALERT 退出码

Nightly watch run 2026-08-07
Co-authored-by: Codex <noreply@openai.com>
