### PR TITLE
test(nightly): cover service.tasks.scan + time_from_filename.process (2026-08-17)

### DIFF
--- a/package/ai/tests/test_nightly_ai_logger_gaps_20260817.py
+++ b/package/ai/tests/test_nightly_ai_logger_gaps_20260817.py
@@ -1,0 +1,247 @@
+"""Unit tests for app/core/logger.py (nightly round 13, 2026-08-17).
+
+Targets:
+  * JSONFormatter -- base fields, exc_info, defaults, UTF-8 message.
+  * DailySizeRotatingFileHandler -- filename format, cleanup logic,
+    date rollover behaviour.
+  * setup_logging -- returns listener, attaches queue handler, configures
+    uvicorn loggers.
+  * log_operation -- info / warn / error helpers, error -> exc_info.
+
+The full module is import-safe without GPU; tests pass a tmp_path as
+LOG_DIR via ``monkeypatch.setenv`` to keep disk footprint contained.
+"""
+import json as _json
+import logging
+import logging.handlers
+import os
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _make_record(name="app", level=logging.INFO, msg="hello", exc_info=None,
+                 args=()):
+    logger = logging.getLogger(name)
+    return logger.makeRecord(
+        name=name,
+        level=level,
+        fn="x.py",
+        lno=1,
+        msg=msg,
+        args=args,
+        exc_info=exc_info,
+    )
+
+
+@pytest.fixture
+def log_dir(monkeypatch, tmp_path):
+    """Pin ``TS_AI_LOG_DIR`` to a fresh tmp_path for the duration of the
+    test, so the handler does not touch the user's real log directory."""
+    monkeypatch.setenv("TS_AI_LOG_DIR", str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# JSONFormatter
+# ---------------------------------------------------------------------------
+class TestJSONFormatter:
+    def test_basic_fields_present(self):
+        from app.core.logger import JSONFormatter
+
+        rec = _make_record(msg="basic")
+        out = _json.loads(JSONFormatter().format(rec))
+        assert out["level"] == "INFO"
+        assert out["message"] == "basic"
+        assert out["operation"] == "N/A"
+        assert out["params"] == {}
+        assert out["result"] == "N/A"
+        assert "timestamp" in out
+
+    def test_exc_info_adds_stack_trace(self):
+        from app.core.logger import JSONFormatter
+
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            import sys
+            rec = _make_record(level=logging.ERROR, msg="err", exc_info=sys.exc_info())
+
+        out = _json.loads(JSONFormatter().format(rec))
+        assert out["level"] == "ERROR"
+        assert "stack_trace" in out
+        assert "RuntimeError" in out["stack_trace"]
+
+    def test_extra_fields_propagate_to_output(self):
+        from app.core.logger import JSONFormatter
+
+        rec = _make_record(msg="hi")
+        rec.operation = "scan"
+        rec.params = {"foo": "bar"}
+        rec.result = "ok"
+
+        out = _json.loads(JSONFormatter().format(rec))
+        assert out["operation"] == "scan"
+        assert out["params"] == {"foo": "bar"}
+        assert out["result"] == "ok"
+
+    def test_utf8_message_preserved(self):
+        from app.core.logger import JSONFormatter
+
+        rec = _make_record(msg="中文日志")
+        raw = JSONFormatter().format(rec)
+        # ensure_ascii=False so message is preserved as-is in the JSON.
+        assert "中文日志" in raw
+
+
+# ---------------------------------------------------------------------------
+# DailySizeRotatingFileHandler
+# ---------------------------------------------------------------------------
+class TestDailySizeRotatingHandler:
+    def test_filename_format_uses_iso_date(self, log_dir):
+        from app.core.logger import DailySizeRotatingFileHandler
+
+        handler = DailySizeRotatingFileHandler(
+            filename="main", log_dir=str(log_dir), maxBytes=1024, backupCount=5
+        )
+        try:
+            expected = log_dir / f"main-{date.today().isoformat()}.log"
+            assert handler.baseFilename == str(expected)
+        finally:
+            handler.close()
+
+    def test_cleanup_no_op_when_under_limit(self, log_dir):
+        from app.core.logger import DailySizeRotatingFileHandler
+
+        handler = DailySizeRotatingFileHandler(
+            filename="main",
+            log_dir=str(log_dir),
+            maxBytes=1024 * 1024,
+            backupCount=10,
+        )
+        try:
+            # Handler creates ``main-<today>.log`` on init. Add 2 more
+            # historical files (total = 3 < backupCount=10).
+            for i in range(2):
+                (log_dir / f"main-2026-08-0{i}.log").write_text("x")
+
+            before = sorted(p.name for p in log_dir.glob("*.log*"))
+            handler._cleanup_logs()
+            after = sorted(p.name for p in log_dir.glob("*.log*"))
+            assert before == after
+        finally:
+            handler.close()
+
+    def test_cleanup_deletes_oldest_when_over_limit(self, log_dir):
+        from app.core.logger import DailySizeRotatingFileHandler
+
+        handler = DailySizeRotatingFileHandler(
+            filename="main",
+            log_dir=str(log_dir),
+            maxBytes=1024 * 1024,
+            backupCount=2,
+        )
+        try:
+            # Add 5 historical files with distinct mtimes -- ordered oldest
+            # to newest. Handler's init-created file (today) is newer than
+            # all of them, so cleanup will delete the 5 oldest of the 6
+            # total files, leaving today's file + the newest historical.
+            for i in range(5):
+                p = log_dir / f"main-2026-08-0{i}.log"
+                p.write_text("x")
+                os.utime(p, (1_700_000_000 + i * 60, 1_700_000_000 + i * 60))
+
+            handler._cleanup_logs()
+
+            remaining = sorted(p.name for p in log_dir.glob("*.log*"))
+            # backupCount=2 means keep the 2 newest files. The handler's
+            # init file (``main-<today>.log``) has the latest mtime, then
+            # ``main-2026-08-04.log`` is the most recent user file.
+            assert len(remaining) == 2
+            assert any("2026-08-04" in name for name in remaining)
+        finally:
+            handler.close()
+
+
+# ---------------------------------------------------------------------------
+# setup_logging
+# ---------------------------------------------------------------------------
+class TestSetupLogging:
+    def test_returns_listener_and_attaches_queue_handler(self, log_dir, monkeypatch):
+        import app.core.logger as logger_mod
+
+        # Stub QueueListener so we don't actually spawn a thread.
+        fake_listener = MagicMock()
+        fake_listener_class = MagicMock(return_value=fake_listener)
+        monkeypatch.setattr(
+            logger_mod.logging.handlers, "QueueListener", fake_listener_class
+        )
+
+        root = logging.getLogger()
+        saved_handlers = root.handlers[:]
+        saved_level = root.level
+        root.handlers = []
+        try:
+            listener = logger_mod.setup_logging(filename="probe")
+            assert listener is fake_listener
+            fake_listener.start.assert_called_once()
+            handlers = root.handlers
+            assert len(handlers) == 1
+            assert isinstance(handlers[0], logging.handlers.QueueHandler)
+
+            for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "fastapi"):
+                l = logging.getLogger(name)
+                assert l.propagate is False
+                assert l.handlers == handlers
+        finally:
+            root.handlers = saved_handlers
+            root.level = saved_level
+
+
+# ---------------------------------------------------------------------------
+# log_operation helper
+# ---------------------------------------------------------------------------
+class TestLogOperation:
+    def test_info_logs_without_error(self, caplog):
+        from app.core.logger import log_operation
+
+        caplog.set_level(logging.INFO, logger="app")
+        log_operation("info", "did thing", operation="op", params={"k": 1}, result="ok")
+        records = [r for r in caplog.records if r.name == "app"]
+        assert any(r.levelno == logging.INFO for r in records)
+        rec = next(r for r in records if r.levelno == logging.INFO)
+        assert rec.operation == "op"
+        assert rec.params == {"k": 1}
+        assert rec.result == "ok"
+        assert rec.message == "did thing"
+
+    def test_warning_logs_at_warning_level(self, caplog):
+        from app.core.logger import log_operation
+
+        caplog.set_level(logging.WARNING, logger="app")
+        log_operation("warn", "careful", operation="op")
+        records = [r for r in caplog.records if r.name == "app"]
+        assert any(r.levelno == logging.WARNING for r in records)
+
+    def test_error_passes_exc_info(self, caplog):
+        from app.core.logger import log_operation
+
+        caplog.set_level(logging.ERROR, logger="app")
+        try:
+            raise RuntimeError("kaboom")
+        except RuntimeError as e:
+            log_operation("error", "failed", operation="op", error=e)
+
+        records = [r for r in caplog.records if r.name == "app"]
+        assert any(r.levelno == logging.ERROR for r in records)
+        rec = next(r for r in records if r.levelno == logging.ERROR)
+        assert rec.exc_info is not None
+        assert rec.exc_info[0] is RuntimeError

--- a/package/server/tests/unit/test_nightly_annual_report_crud_gaps_20260817.py
+++ b/package/server/tests/unit/test_nightly_annual_report_crud_gaps_20260817.py
@@ -1,0 +1,376 @@
+"""Unit tests covering 2026-08-17 nightly coverage gap scan (round 12).
+
+Modules exercised:
+* app/crud/annual_report.py -- functions still < 33% after 2026-08-14 round:
+  - get_report_expenses: total / avg / max + monthly trend + last-year comparison
+    + leap-year edge branch (Feb 29 -> ValueError handled with day=28 fallback).
+  - get_report_summary: TimeMetrics aggregation including first/last photo dates
+    and late-night count + distinct dates.
+  - find_best_match_photo: postgres branch (dialect != sqlite) ordering by
+    cosine_distance + months filter application.
+  - get_report_season: SEASON_VECTORS branch + representative photo URL build
+    + picsum fallback when no rep photo.
+  - get_report_emotion: live photo + camera photo + video duration aggregation
+    with user_id filtering.
+  - get_report_easter_egg: best photo URL + date fallback to default.
+
+Note: get_annual_report_photos is skipped because its window-function subquery
+relies on `ranked.c.rn <= 10` column comparisons that MagicMock cannot satisfy
+without an SQLAlchemy session.
+
+Pattern: MagicMock chains mimic SQLAlchemy's fluent query API without booting
+Postgres; the goal is to exercise branch logic in crud/annual_report.py and
+shove coverage past 33%.
+"""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _chain(first=None, count=0, scalar=None, all_rows=None):
+    """Build a self-returning fluent mock with the supplied terminal values."""
+    q = MagicMock(name="q")
+    q.filter.return_value = q
+    q.with_entities.return_value = q
+    q.join.return_value = q
+    q.order_by.return_value = q
+    q.group_by.return_value = q
+    q.distinct.return_value = q
+    q.label.return_value = q
+    q.first.return_value = first
+    q.count.return_value = count
+    q.scalar.return_value = scalar
+    q.all.return_value = all_rows if all_rows is not None else []
+    return q
+
+
+def _photo(id_=None, time=None, **kw):
+    return SimpleNamespace(
+        id=id_ or ("photo-" + (time.isoformat() if time else "x")),
+        photo_time=time,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_report_expenses
+# ---------------------------------------------------------------------------
+
+
+def test_get_report_expenses_zero_count_uses_zero_average():
+    from app.crud import annual_report as ar
+
+    q = _chain()
+    q.scalar.return_value = None
+    q.first.return_value = None
+    q.all.return_value = []
+
+    db = MagicMock()
+    db.query.return_value = q
+
+    metrics = ar.get_report_expenses(
+        datetime(2024, 1, 1), datetime(2024, 12, 31), db
+    )
+    assert metrics.totalCount == 0
+    assert metrics.totalAmount == 0.0
+    assert metrics.averagePrice == 0.0
+    assert metrics.maxExpenseTicket is None
+    assert metrics.maxExpenseAmount == 0.0
+    assert metrics.monthlyTrend == []
+    assert metrics.totalAmountLastYear == 0.0
+
+
+def test_get_report_expenses_aggregates_with_max_ticket():
+    from app.crud import annual_report as ar
+
+    ticket = SimpleNamespace(
+        price=300.0,
+        train_code="G1",
+        departure_station="\u5317\u4eac\u5357",
+        arrival_station="\u4e0a\u6d77\u8679\u6865",
+    )
+    monthly_rows = [
+        SimpleNamespace(year=2024, month=1, amount=120.0),
+        SimpleNamespace(year=2024, month=2, amount=180.0),
+    ]
+
+    q = _chain(count=2, first=ticket, all_rows=monthly_rows)
+    q.scalar.side_effect = [300.0, 150.0]
+
+    db = MagicMock()
+    db.query.return_value = q
+
+    metrics = ar.get_report_expenses(
+        datetime(2024, 1, 1), datetime(2024, 12, 31), db
+    )
+    assert metrics.totalCount == 2
+    assert metrics.totalAmount == 300.0
+    assert metrics.averagePrice == 150.0
+    assert metrics.maxExpenseAmount == 300.0
+    assert "G1" in metrics.maxExpenseTicket
+    assert len(metrics.monthlyTrend) == 2
+    assert metrics.monthlyTrend[0].month == "2024-01"
+
+
+def test_get_report_expenses_handles_leap_year_feb_29():
+    """Feb 29 -> ValueError; crud falls back to day=28."""
+    from app.crud import annual_report as ar
+
+    q = _chain()
+    q.scalar.return_value = None
+    q.first.return_value = None
+    q.all.return_value = []
+
+    db = MagicMock()
+    db.query.return_value = q
+
+    metrics = ar.get_report_expenses(
+        datetime(2024, 2, 29), datetime(2024, 3, 1), db
+    )
+    assert metrics.totalCount == 0
+
+
+def test_get_report_expenses_applies_user_id_filter():
+    from app.crud import annual_report as ar
+
+    q = _chain()
+    q.scalar.return_value = None
+    q.first.return_value = None
+    q.all.return_value = []
+
+    db = MagicMock()
+    db.query.return_value = q
+
+    ar.get_report_expenses(
+        datetime(2024, 1, 1), datetime(2024, 12, 31), db, user_id="user-42"
+    )
+    assert q.filter.called
+
+
+# ---------------------------------------------------------------------------
+# get_report_summary
+# ---------------------------------------------------------------------------
+
+
+def test_get_report_summary_empty_query_returns_zero_metrics():
+    from app.crud import annual_report as ar
+
+    q = _chain()
+    q.distinct.return_value = q
+
+    db = MagicMock()
+    db.query.return_value = q
+
+    summary = ar.get_report_summary(datetime(2024, 1, 1), datetime(2024, 12, 31), db)
+    assert summary.user.nickname == "\u65f6\u5149\u65c5\u4eba"
+    assert summary.time.totalPhotos == 0
+    assert summary.time.accompanyDays == 0
+    assert summary.time.firstPhotoDate is None
+    assert summary.time.lastPhotoDate is None
+    assert summary.time.lateNightPhotoCount == 0
+    assert summary.time.photoDates == []
+
+
+def test_get_report_summary_populates_first_last_and_late_night():
+    from app.crud import annual_report as ar
+
+    # get_report_summary calls count() three times: totalPhotos / accompanyDays
+    # / lateNightPhotoCount -- so the side_effect must yield three values.
+    q = _chain()
+    q.distinct.return_value = q
+    q.count.side_effect = [10, 3, 1]
+    q.first.side_effect = [
+        _photo(id_="p1", time=datetime(2024, 1, 15, 8, 0)),
+        _photo(id_="p2", time=datetime(2024, 6, 1, 22, 30)),
+    ]
+    q.all.return_value = [
+        ("2024-01-15",),
+        ("2024-03-20",),
+        ("2024-06-01",),
+    ]
+
+    db = MagicMock()
+    db.query.return_value = q
+
+    summary = ar.get_report_summary(datetime(2024, 1, 1), datetime(2024, 12, 31), db)
+    assert summary.time.totalPhotos == 10
+    assert summary.time.accompanyDays == 3
+    assert summary.time.firstPhotoDate == "2024-01-15"
+    assert summary.time.lastPhotoDate == "2024-06-01"
+    assert summary.time.lateNightPhotoCount == 1
+    assert len(summary.time.photoDates) == 3
+
+
+# ---------------------------------------------------------------------------
+# find_best_match_photo (postgres branch)
+# ---------------------------------------------------------------------------
+
+
+def test_find_best_match_photo_postgres_branch_orders_by_cosine_distance():
+    from app.crud import annual_report as ar
+
+    db = MagicMock()
+    db.bind.dialect.name = "postgresql"
+
+    expected = _photo(id_="best", time=datetime(2024, 5, 5))
+
+    q = _chain(first=expected)
+    db.query.return_value.join.return_value = q
+
+    result = ar.find_best_match_photo(
+        db, datetime(2024, 1, 1), datetime(2024, 12, 31), [0.5, 0.5, 0.5]
+    )
+    assert result is expected
+
+
+def test_find_best_match_photo_applies_months_filter_when_provided():
+    from app.crud import annual_report as ar
+
+    db = MagicMock()
+    db.bind.dialect.name = "postgresql"
+
+    expected = _photo(id_="best")
+    q = _chain(first=expected)
+    db.query.return_value.join.return_value = q
+
+    ar.find_best_match_photo(
+        db, datetime(2024, 1, 1), datetime(2024, 12, 31),
+        [0.1, 0.2, 0.3], months=[3, 4, 5],
+    )
+    assert q.filter.call_count >= 4
+
+
+# ---------------------------------------------------------------------------
+# get_report_season
+# ---------------------------------------------------------------------------
+
+
+def test_get_report_season_returns_picsum_fallback_when_no_rep_photo():
+    from app.crud import annual_report as ar
+
+    q = _chain()
+    q.first.return_value = None
+
+    db = MagicMock()
+    db.query.return_value = q
+
+    with patch.object(ar, "find_best_match_photo", return_value=None):
+        metrics = ar.get_report_season(
+            datetime(2024, 1, 1), datetime(2024, 12, 31), db
+        )
+
+    assert len(metrics.seasonList) == 4
+    seasons = {s.seasonName for s in metrics.seasonList}
+    assert seasons == {"\u6625", "\u590f", "\u79cb", "\u51ac"}
+    for s in metrics.seasonList:
+        assert s.representativePhoto.startswith("https://picsum.photos/seed/")
+
+
+def test_get_report_season_uses_rep_photo_thumbnail_url():
+    from app.crud import annual_report as ar
+
+    q = _chain(count=7)
+    q.first.return_value = None
+
+    db = MagicMock()
+    db.query.return_value = q
+
+    rep_photo = _photo(id_="rep-1")
+    with patch.object(ar, "find_best_match_photo", return_value=rep_photo):
+        metrics = ar.get_report_season(
+            datetime(2024, 1, 1), datetime(2024, 12, 31), db
+        )
+
+    spring = next(s for s in metrics.seasonList if s.seasonName == "\u6625")
+    assert spring.representativePhoto == "/api/medias/rep-1/thumbnail"
+    assert spring.photoCount == 7
+    assert spring.shootMonth == "3-5\u6708"
+
+
+# ---------------------------------------------------------------------------
+# get_report_emotion
+# ---------------------------------------------------------------------------
+
+
+def test_get_report_emotion_aggregates_video_live_camera_counts():
+    from app.crud import annual_report as ar
+
+    db = MagicMock()
+
+    q_total = _chain(count=100)
+    q_video = _chain(scalar=123.4)
+    q_live = _chain(count=5)
+    q_camera = _chain(count=60)
+
+    db.query.side_effect = [q_total, q_video, q_live, q_camera]
+
+    metrics = ar.get_report_emotion(
+        datetime(2024, 1, 1), datetime(2024, 12, 31), db, user_id="user-1"
+    )
+    assert metrics.backupPhotos == 100
+    assert metrics.totalVideoDuration == 123.4
+    assert metrics.livePhotos == 5
+    assert metrics.cameraPhotos == 60
+    assert len(metrics.emotionCarouselGroups) == 1
+
+
+def test_get_report_emotion_handles_missing_video_scalar():
+    from app.crud import annual_report as ar
+
+    db = MagicMock()
+    q_total = _chain(count=0)
+    q_video = _chain(scalar=None)
+    q_live = _chain(count=0)
+    q_camera = _chain(count=0)
+
+    db.query.side_effect = [q_total, q_video, q_live, q_camera]
+
+    metrics = ar.get_report_emotion(
+        datetime(2024, 1, 1), datetime(2024, 12, 31), db
+    )
+    assert metrics.totalVideoDuration == 0
+    assert metrics.backupPhotos == 0
+
+
+# ---------------------------------------------------------------------------
+# get_report_easter_egg
+# ---------------------------------------------------------------------------
+
+
+def test_get_report_easter_egg_uses_best_photo_when_found():
+    from app.crud import annual_report as ar
+
+    db = MagicMock()
+    best = _photo(id_="egg-1", time=datetime(2024, 10, 1, 14, 30))
+
+    with patch.object(ar, "find_best_match_photo", return_value=best):
+        egg = ar.get_report_easter_egg(
+            datetime(2024, 1, 1), datetime(2024, 12, 31), db
+        )
+
+    assert egg.bestPhotoUrl == "/api/medias/egg-1/thumbnail"
+    assert egg.bestPhotoDate == "2024-10-01"
+    assert egg.tags.main == "\u751f\u6d3b\u8bb0\u5f55\u5bb6"
+
+
+def test_get_report_easter_egg_falls_back_when_no_photo():
+    from app.crud import annual_report as ar
+
+    db = MagicMock()
+    with patch.object(ar, "find_best_match_photo", return_value=None):
+        egg = ar.get_report_easter_egg(
+            datetime(2024, 1, 1), datetime(2024, 12, 31), db
+        )
+
+    assert egg.bestPhotoUrl == "https://picsum.photos/seed/best/400/600"
+    assert egg.bestPhotoDate == "2024-10-01"

--- a/package/server/tests/unit/test_nightly_basic_location_session_gaps_20260817.py
+++ b/package/server/tests/unit/test_nightly_basic_location_session_gaps_20260817.py
@@ -1,0 +1,433 @@
+"""Unit tests for nightly coverage gap scan (round 13, 2026-08-17).
+
+Targets:
+  * app.service.tasks.basic.BasicTaskStrategy.process_batch (happy,
+    file-not-found, batch failure, min_width filter, live_photo).
+  * app.crud.location.get_map_markers, get_location_statistics,
+    get_timeline_nodes, search_locations.
+  * app.db.session engine creation (sqlite / postgres branches).
+
+Other nightly rounds already cover:
+  * BasicTaskStrategy happy/release_resources (test_basic_tasks.py).
+  * location_stats pure helpers (test_nightly_crud_location_stats_helpers_gaps_20260812.py).
+  * sqlalchemy session/transaction (test_sqlalchemy_session.py).
+"""
+from contextlib import contextmanager
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _task(task_id=None, owner_id=None, payload=None):
+    return SimpleNamespace(
+        id=task_id if task_id is not None else uuid4(),
+        type="process_basic",
+        payload=payload if payload is not None else {},
+        owner_id=owner_id if owner_id is not None else uuid4(),
+    )
+
+
+def _filter(min_width=0, min_height=0, enable=True):
+    return SimpleNamespace(
+        enable=enable,
+        min_width=min_width,
+        min_height=min_height,
+    )
+
+
+def _run_async(coro):
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _chain(return_value):
+    """Build a MagicMock chain where any of the common SQLAlchemy builder
+    methods returns the same chain and ``.all()`` returns ``return_value``."""
+    chain = MagicMock()
+    chain.join.return_value = chain
+    chain.outerjoin.return_value = chain
+    chain.filter.return_value = chain
+    chain.distinct.return_value = chain
+    chain.limit.return_value = chain
+    chain.group_by.return_value = chain
+    chain.order_by.return_value = chain
+    chain.all.return_value = return_value
+    return chain
+
+
+# ---------------------------------------------------------------------------
+# BasicTaskStrategy.process_batch
+# ---------------------------------------------------------------------------
+class TestBasicTaskStrategy:
+    def _strategy(self):
+        from app.service.tasks import basic
+        return basic.BasicTaskStrategy()
+
+    def _setup_worker(self):
+        worker = MagicMock()
+        worker.thread_pool = MagicMock()
+        worker.scan_status = {"added": 0, "processed_files": 0}
+        return worker
+
+    def _patch_run_in_executor(self, fake_results):
+        """Bypass ``loop.run_in_executor`` by returning an awaitable that
+        resolves to ``fake_results`` -- avoids invoking the real
+        ``concurrent.futures.Future`` wrapper on a MagicMock thread pool."""
+        from app.service.tasks import basic
+
+        async def _fake_executor(*_args, **_kwargs):
+            return fake_results
+
+        fake_loop = MagicMock()
+        fake_loop.run_in_executor.side_effect = _fake_executor
+        return patch.object(basic.asyncio, "get_running_loop", return_value=fake_loop)
+
+    def test_process_batch_happy_path_completes(self):
+        from app.service.tasks import basic
+
+        worker = self._setup_worker()
+        db = MagicMock()
+        owner = uuid4()
+        task = _task(owner_id=owner, payload={"file_path": "/p/a.jpg", "user_id": str(owner)})
+
+        cfg = MagicMock()
+        cfg.filter = _filter(min_width=0, min_height=0, enable=False)
+
+        fake_results = [
+            {
+                "task_id": task.id,
+                "success": True,
+                "thumb_path": "/t/a.jpg",
+                "meta": {"photo_time": datetime(2026, 1, 1, 12, 0, 0), "exif_info": "{}"},
+                "size": 1024,
+                "width": 800,
+                "height": 600,
+                "duration": 0.0,
+                "file_name": "a.jpg",
+                "is_motion_photo": False,
+                "md5_hash": "abc",
+                "color_info": None,
+            }
+        ]
+
+        with patch.object(basic.os.path, "exists", return_value=True), \
+             self._patch_run_in_executor(fake_results), \
+             patch.object(basic, "storage") as fake_storage, \
+             patch.object(basic, "config_manager") as fake_cm:
+            fake_storage._get_storage_root.return_value = "/srv"
+            fake_cm.get_user_config.return_value = cfg
+
+            results = _run_async(self._strategy().process_batch(worker, [task], db))
+
+        assert len(results) == 1
+        assert results[0]["status"] == "completed"
+        assert results[0]["result"]["photo_create_data"]["file_path"] == "/p/a.jpg"
+
+    def test_process_batch_skips_missing_file(self):
+        from app.service.tasks import basic
+
+        worker = self._setup_worker()
+        db = MagicMock()
+        task = _task(payload={"file_path": "/p/missing.jpg", "user_id": "u1"})
+
+        with patch.object(basic.os.path, "exists", return_value=False):
+            results = _run_async(self._strategy().process_batch(worker, [task], db))
+
+        assert len(results) == 1
+        assert results[0]["status"] == "completed"
+        assert results[0]["result"]["status"] == "skipped"
+        assert results[0]["result"]["reason"] == "file not found"
+
+    def test_process_batch_reports_failure_when_batch_returns_error(self):
+        from app.service.tasks import basic
+
+        worker = self._setup_worker()
+        db = MagicMock()
+        task = _task(payload={"file_path": "/p/a.jpg", "user_id": "u1"})
+
+        fake_results = [{"task_id": task.id, "success": False, "error": "boom"}]
+
+        with patch.object(basic.os.path, "exists", return_value=True), \
+             self._patch_run_in_executor(fake_results), \
+             patch.object(basic, "config_manager") as fake_cm, \
+             patch.object(basic, "storage") as fake_storage:
+            fake_cm.get_user_config.return_value.filter = _filter(enable=False)
+            fake_storage._get_storage_root.return_value = "/srv"
+
+            results = _run_async(self._strategy().process_batch(worker, [task], db))
+
+        assert len(results) == 1
+        assert results[0]["status"] == "failed"
+        assert "boom" in results[0]["error"]
+
+    def test_process_batch_skips_when_min_width_filter_blocks(self):
+        from app.service.tasks import basic
+
+        worker = self._setup_worker()
+        db = MagicMock()
+        owner = uuid4()
+        task = _task(owner_id=owner, payload={"file_path": "/p/tiny.jpg", "user_id": str(owner)})
+
+        cfg = MagicMock()
+        cfg.filter = _filter(min_width=1000, min_height=0, enable=True)
+
+        fake_results = [
+            {
+                "task_id": task.id,
+                "success": True,
+                "meta": {"photo_time": datetime(2026, 1, 1), "exif_info": "{}"},
+                "size": 10,
+                "width": 100,
+                "height": 50,
+                "duration": 0,
+                "file_name": "tiny.jpg",
+                "is_motion_photo": False,
+                "md5_hash": "x",
+                "color_info": None,
+            }
+        ]
+
+        with patch.object(basic.os.path, "exists", return_value=True), \
+             self._patch_run_in_executor(fake_results), \
+             patch.object(basic, "config_manager") as fake_cm, \
+             patch.object(basic, "storage") as fake_storage:
+            fake_cm.get_user_config.return_value = cfg
+            fake_storage._get_storage_root.return_value = "/srv"
+
+            results = _run_async(self._strategy().process_batch(worker, [task], db))
+
+        assert len(results) == 1
+        assert results[0]["status"] == "completed"
+        assert results[0]["result"]["status"] == "skipped"
+        assert results[0]["result"]["reason"] == "filtered_by_width"
+
+    def test_process_batch_marks_live_photo_when_flag_set(self):
+        from app.service.tasks import basic
+        from app.db.models.photo import FileType
+
+        worker = self._setup_worker()
+        db = MagicMock()
+        owner = uuid4()
+        task = _task(
+            owner_id=owner,
+            payload={
+                "file_path": "/p/live.jpg",
+                "user_id": str(owner),
+                "is_live_photo": True,
+            },
+        )
+
+        cfg = MagicMock()
+        cfg.filter = _filter(enable=False)
+
+        fake_results = [
+            {
+                "task_id": task.id,
+                "success": True,
+                "meta": {"photo_time": datetime(2026, 1, 1), "exif_info": "{}"},
+                "size": 1,
+                "width": 500,
+                "height": 500,
+                "duration": 0,
+                "file_name": "live.jpg",
+                "is_motion_photo": False,
+                "md5_hash": "y",
+                "color_info": None,
+            }
+        ]
+
+        with patch.object(basic.os.path, "exists", return_value=True), \
+             self._patch_run_in_executor(fake_results), \
+             patch.object(basic, "config_manager") as fake_cm, \
+             patch.object(basic, "storage") as fake_storage, \
+             patch.object(basic.photo_schemas, "PhotoCreate") as fake_pc:
+            fake_cm.get_user_config.return_value = cfg
+            fake_storage._get_storage_root.return_value = "/srv"
+
+            results = _run_async(self._strategy().process_batch(worker, [task], db))
+
+        assert results[0]["status"] == "completed"
+        assert fake_pc.call_args.kwargs["file_type"] == FileType.live_photo
+
+
+# ---------------------------------------------------------------------------
+# crud.location
+# ---------------------------------------------------------------------------
+class TestGetMapMarkers:
+    def test_returns_list_of_dicts_with_id_lat_lng(self):
+        from app.crud import location
+
+        db = MagicMock()
+        rows = [
+            (UUID(int=1), 30.5, 114.3),
+            (UUID(int=2), 31.0, 121.0),
+        ]
+        db.query.return_value = _chain(rows)
+
+        markers = location.get_map_markers(db, uuid4())
+
+        assert len(markers) == 2
+        assert markers[0]["lat"] == 30.5
+        assert markers[1]["lng"] == 121.0
+        assert markers[0]["id"] == str(UUID(int=1))
+
+
+class TestGetLocationStatistics:
+    def test_zero_when_no_photos(self):
+        from app.crud import location
+
+        db = MagicMock()
+        chain = MagicMock()
+        chain.join.return_value.first.return_value = (None, None, None, None)
+        db.query.return_value = chain
+
+        stats = location.get_location_statistics(db, uuid4())
+
+        assert stats == {
+            "province_count": 0,
+            "city_count": 0,
+            "district_count": 0,
+            "country_count": 0,
+        }
+
+    def test_positive_counts_when_metadata_present(self):
+        from app.crud import location
+
+        db = MagicMock()
+        chain = MagicMock()
+        chain.join.return_value.first.return_value = (3, 5, 7, 1)
+        db.query.return_value = chain
+
+        stats = location.get_location_statistics(db, uuid4())
+
+        assert stats["province_count"] == 3
+        assert stats["city_count"] == 5
+        assert stats["district_count"] == 7
+        assert stats["country_count"] == 1
+
+
+class TestGetTimelineNodes:
+    def test_merges_consecutive_rows_with_same_location(self):
+        from app.crud import location
+
+        cover1, cover2 = uuid4(), uuid4()
+        row1 = SimpleNamespace(
+            date="2026-01-01", loc_name="Shanghai", level="city",
+            photo_count=2, lat=31.0, lng=121.0, cover_id=str(cover1),
+        )
+        row2 = SimpleNamespace(
+            date="2026-01-02", loc_name="Shanghai", level="city",
+            photo_count=3, lat=31.5, lng=121.5, cover_id=str(cover2),
+        )
+
+        db = MagicMock()
+        db.query.return_value = _chain([row1, row2])
+
+        resp = location.get_timeline_nodes(db, uuid4(), level="city")
+
+        assert resp.total == 1
+        node = resp.nodes[0]
+        assert node.locationName == "Shanghai"
+        assert node.photoCount == 5
+        # Weighted-average lat: (31.0*2 + 31.5*3) / 5
+        assert abs(node.lat - 31.3) < 1e-6
+        # The source overwrites startDate on each merge (it tracks the
+        # latest visit, not the earliest). endDate stays at first-append.
+        assert node.startDate == "2026-01-02"
+        assert node.endDate == "2026-01-01"
+
+        # coverId is NOT updated on merge -- stays at first-append.
+
+    def test_creates_new_node_for_different_location(self):
+        from app.crud import location
+
+        row1 = SimpleNamespace(
+            date="2026-01-01", loc_name="Shanghai", level="city",
+            photo_count=1, lat=31.0, lng=121.0, cover_id=str(uuid4()),
+        )
+        row2 = SimpleNamespace(
+            date="2026-01-02", loc_name="Beijing", level="city",
+            photo_count=1, lat=39.9, lng=116.4, cover_id=str(uuid4()),
+        )
+
+        db = MagicMock()
+        db.query.return_value = _chain([row1, row2])
+
+        resp = location.get_timeline_nodes(db, uuid4(), level="city")
+
+        assert resp.total == 2
+        assert {n.locationName for n in resp.nodes} == {"Shanghai", "Beijing"}
+
+
+class TestSearchLocations:
+    def test_dedupes_province_city_district_labels(self):
+        from app.crud import location
+
+        province_chain = _chain([("上海",)])
+        city_chain = _chain([("上海", "徐汇区")])
+        district_chain = _chain([("上海", "徐汇区", "田林路")])
+
+        db = MagicMock()
+        db.query.side_effect = [province_chain, city_chain, district_chain]
+
+        suggestions = location.search_locations(db, uuid4(), "上海")
+
+        labels = [s["label"] for s in suggestions]
+        assert "上海" in labels
+        # city query returns ("上海", "徐汇区") -> label "上海徐汇区";
+        # district query returns ("上海", "徐汇区", "田林路") -> label "上海徐汇区田林路".
+        # Both province ("上海") and city ("上海徐汇区") labels are unique.
+        assert labels.count("上海徐汇区") == 1
+        assert "上海徐汇区田林路" in labels
+
+
+# ---------------------------------------------------------------------------
+# app.db.session engine creation branches
+# ---------------------------------------------------------------------------
+@contextmanager
+def _reload_session_module(env):
+    import importlib
+    import os
+
+    for k in ("TS_DESKTOP", "DB_URL", "TS_DB_URL"):
+        os.environ.pop(k, None)
+    for k, v in env.items():
+        os.environ[k] = v
+
+    import app.db.session as session_mod
+    importlib.reload(session_mod)
+    try:
+        yield session_mod
+    finally:
+        for k in ("TS_DESKTOP", "DB_URL", "TS_DB_URL"):
+            os.environ.pop(k, None)
+
+
+class TestSessionModule:
+    def test_sqlite_branch_creates_engine_with_check_same_thread_false(self):
+        from app.core.paths import DATA_DIR
+
+        with _reload_session_module({"TS_DB_URL": f"sqlite:///{DATA_DIR}/unit-test.sqlite"}) as m:
+            assert m.IS_SQLITE is True
+            assert m.engine is not None
+            assert m.SessionLocal is not None
+
+    def test_postgres_branch_creates_engine_with_pool(self):
+        with _reload_session_module({"TS_DB_URL": "postgresql://user:pw@localhost:5432/db"}) as m:
+            assert m.IS_SQLITE is False
+            assert m.engine is not None
+            assert m.SessionLocal is not None

--- a/package/server/tests/unit/test_nightly_day_caption_llm_context_gaps_20260817.py
+++ b/package/server/tests/unit/test_nightly_day_caption_llm_context_gaps_20260817.py
@@ -1,0 +1,340 @@
+"""Unit tests for app/service/moment/day_caption_service.py.
+
+The nightly gap scan flagged this module as 53 percent covered with
+~140 missed lines. The previous round (2026-08-15) only exercised the
+``_ThinkStripper`` happy path; this file fills in the broader surface
+area used by ``generate_caption_sync`` and ``generate_caption_stream``:
+
+  * ``_ThinkStripper`` -- chunked think tags, mid-think flush,
+    overflow, remainder after open tag, lowercase variants.
+  * ``_strip_think_blocks`` -- regex sweep with multiline blocks.
+  * ``_resolve_tz`` -- empty / invalid / valid name -> ZoneInfo.
+  * ``day_bounds_utc`` -- normal and month-rollover boundaries.
+  * ``_format_materials_for_prompt`` -- with/without dedup, empty.
+  * ``_resolve_connection_and_model`` -- chat preference, analysis
+    fallback, missing-config / unknown / disabled / no-api-key errors.
+  * ``_build_llm`` -- returns FixedChatOpenAI with correct kwargs.
+"""
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+# ---------------------------------------------------------------------------
+# _ThinkStripper state machine
+# ---------------------------------------------------------------------------
+class TestThinkStripper:
+    def test_empty_input_returns_empty(self):
+        from app.service.moment.day_caption_service import _ThinkStripper
+
+        assert _ThinkStripper().feed("") == ""
+
+    def test_normal_text_passes_through(self):
+        from app.service.moment.day_caption_service import _ThinkStripper
+
+        assert _ThinkStripper().feed("hello world") == "hello world"
+
+    def test_chunked_think_tag_dropped(self):
+        from app.service.moment.day_caption_service import _ThinkStripper
+
+        s = _ThinkStripper()
+        # Tag arrives across three chunks; should be entirely stripped.
+        out1 = s.feed("<th")
+        out2 = s.feed("ink>reasoning here</th")
+        out3 = s.feed("ink>after")
+        assert out1 == ""
+        assert out2 == ""
+        assert out3 == "after"
+
+    def test_full_think_block_dropped(self):
+        from app.service.moment.day_caption_service import _ThinkStripper
+
+        s = _ThinkStripper()
+        text = "before<think>hidden</think>after"
+        assert s.feed(text) == "beforeafter"
+
+    def test_flush_returns_remainder_outside_think(self):
+        from app.service.moment.day_caption_service import _ThinkStripper
+
+        s = _ThinkStripper()
+        s.feed("<th")
+        # Still buffering the opening tag - remainder should be re-emitted on flush.
+        assert s.flush() == "<th"
+
+    def test_flush_drops_remainder_when_in_think(self):
+        from app.service.moment.day_caption_service import _ThinkStripper
+
+        s = _ThinkStripper()
+        s.feed("<think>never closed")
+        # In-think remainder must be discarded.
+        assert s.flush() == ""
+
+    def test_lowercase_think_tags_stripped(self):
+        from app.service.moment.day_caption_service import _ThinkStripper
+
+        s = _ThinkStripper()
+        assert s.feed("a<think>b</think>c") == "ac"
+
+    def test_after_close_appends_subsequent_text(self):
+        from app.service.moment.day_caption_service import _ThinkStripper
+
+        s = _ThinkStripper()
+        out = s.feed("<think>hidden</think>visible")
+        assert out == "visible"
+
+
+# ---------------------------------------------------------------------------
+# _strip_think_blocks
+# ---------------------------------------------------------------------------
+class TestStripThinkBlocks:
+    def test_empty_returns_empty(self):
+        from app.service.moment.day_caption_service import _strip_think_blocks
+
+        assert _strip_think_blocks("") == ""
+
+    def test_basic_strip(self):
+        from app.service.moment.day_caption_service import _strip_think_blocks
+
+        assert _strip_think_blocks("a<think>x</think>b") == "ab"
+
+    def test_multiline_block_stripped(self):
+        from app.service.moment.day_caption_service import _strip_think_blocks
+
+        text = "head<think>line1\nline2\nline3</think>tail"
+        assert _strip_think_blocks(text) == "headtail"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_tz
+# ---------------------------------------------------------------------------
+class TestResolveTz:
+    def test_empty_returns_utc(self):
+        from app.service.moment import day_caption_service as svc
+
+        tz = svc._resolve_tz("")
+        assert tz is timezone.utc
+
+    def test_invalid_returns_utc(self):
+        from app.service.moment import day_caption_service as svc
+
+        tz = svc._resolve_tz("Not/ARealZone")
+        assert tz is timezone.utc
+
+    def test_valid_name_returns_zoneinfo(self):
+        from app.service.moment import day_caption_service as svc
+
+        fake_zone = SimpleNamespace(key="Asia/Shanghai")
+        with patch.object(svc, "ZoneInfo", return_value=fake_zone):
+            tz = svc._resolve_tz("Asia/Shanghai")
+        assert tz is fake_zone
+
+
+# ---------------------------------------------------------------------------
+# day_bounds_utc
+# ---------------------------------------------------------------------------
+class TestDayBoundsUtc:
+    def test_normal_day_returns_naive_midnight_pair(self):
+        from app.service.moment.day_caption_service import day_bounds_utc
+
+        start, end = day_bounds_utc(date(2026, 8, 17), "UTC")
+        assert start == datetime(2026, 8, 17, 0, 0, 0)
+        assert end == datetime(2026, 8, 18, 0, 0, 0)
+        assert start.tzinfo is None
+        assert end.tzinfo is None
+
+    def test_month_rollover_end_extends_into_next_month(self):
+        from app.service.moment.day_caption_service import day_bounds_utc
+
+        start, end = day_bounds_utc(date(2026, 8, 31), "UTC")
+        assert start == datetime(2026, 8, 31, 0, 0, 0)
+        assert end == datetime(2026, 9, 1, 0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# _format_materials_for_prompt
+# ---------------------------------------------------------------------------
+class TestFormatMaterialsForPrompt:
+    def test_with_all_fields_and_no_dedup(self):
+        from app.service.moment.day_caption_service import _format_materials_for_prompt
+
+        materials = {
+            "counts": {"image": 3, "video": 1, "image_original": 3},
+            "people": ["Alice", "Bob"],
+            "locations": ["外滩"],
+            "tags": ["旅行", "citywalk"],
+            "descriptions": ["江边", "夜景"],
+        }
+        out = _format_materials_for_prompt(date(2026, 8, 17), materials, style="温和")
+
+        assert "2026-08-17" in out
+        assert "温和" in out
+        assert "Alice" in out and "Bob" in out
+        assert "外滩" in out
+        assert "旅行" in out
+        assert "3 张图" in out
+        assert "1 个视频" in out
+        assert "1) 江边" in out and "2) 夜景" in out
+
+    def test_with_dedup_records_original_count(self):
+        from app.service.moment.day_caption_service import _format_materials_for_prompt
+
+        materials = {
+            "counts": {"image": 2, "video": 0, "image_original": 10},
+            "people": [],
+            "locations": [],
+            "tags": [],
+            "descriptions": [],
+        }
+        out = _format_materials_for_prompt(date(2026, 8, 17), materials, style=None)
+        assert "2 个不同瞬间" in out
+        assert "10 张图" in out
+
+    def test_empty_materials_emits_no_photo_guidance(self):
+        from app.service.moment.day_caption_service import _format_materials_for_prompt
+
+        out = _format_materials_for_prompt(date(2026, 8, 17), {}, style=None)
+        assert "2026-08-17" in out
+        assert "未生成视觉描述" in out
+
+
+# ---------------------------------------------------------------------------
+# _resolve_connection_and_model
+# ---------------------------------------------------------------------------
+def _settings(chat_id=None, analysis_id=None, chat_model=None, analysis_model=None,
+              connections=None, prompt="prompt-text"):
+    return SimpleNamespace(
+        chat_connection_id=chat_id or "",
+        chat_model_name=chat_model or "",
+        analysis_connection_id=analysis_id or "",
+        analysis_model_name=analysis_model or "",
+        connections=connections if connections is not None else [],
+        moment_day_caption_prompt=prompt,
+    )
+
+
+class TestResolveConnectionAndModel:
+    def _config(self, ai):
+        return SimpleNamespace(ai=ai)
+
+    def test_chat_preference_picks_chat_connection(self):
+        from app.service.moment import day_caption_service as svc
+
+        chat = SimpleNamespace(id="c1", enable=True, api_key="k1", api_base="")
+        analysis = SimpleNamespace(id="a1", enable=True, api_key="k2", api_base="")
+        cfg = self._config(_settings(chat_id="c1", analysis_id="a1",
+                                     chat_model="chat-model", analysis_model="an-model",
+                                     connections=[chat, analysis]))
+
+        with patch.object(svc.config_manager, "get_user_config", return_value=cfg):
+            conn, model, prompt = svc._resolve_connection_and_model(
+                uuid4(), MagicMock(), None, None, prefer="chat"
+            )
+
+        assert conn is chat
+        assert model == "chat-model"
+        assert prompt == "prompt-text"
+
+    def test_prefer_analysis_falls_back_to_analysis(self):
+        from app.service.moment import day_caption_service as svc
+
+        chat = SimpleNamespace(id="c1", enable=True, api_key="k1", api_base="")
+        analysis = SimpleNamespace(id="a1", enable=True, api_key="k2", api_base="")
+        cfg = self._config(_settings(chat_id="c1", analysis_id="a1",
+                                     chat_model="", analysis_model="an-model",
+                                     connections=[chat, analysis]))
+
+        with patch.object(svc.config_manager, "get_user_config", return_value=cfg):
+            conn, model, _ = svc._resolve_connection_and_model(
+                uuid4(), MagicMock(), None, None, prefer="analysis"
+            )
+
+        assert conn is analysis
+        assert model == "an-model"
+
+    def test_missing_config_raises_value_error(self):
+        from app.service.moment import day_caption_service as svc
+
+        cfg = self._config(_settings())
+        with patch.object(svc.config_manager, "get_user_config", return_value=cfg):
+            with pytest.raises(ValueError, match="未配置 AI 模型"):
+                svc._resolve_connection_and_model(uuid4(), MagicMock(), None, None)
+
+    def test_unknown_connection_raises_value_error(self):
+        from app.service.moment import day_caption_service as svc
+
+        cfg = self._config(_settings(chat_id="missing", chat_model="m",
+                                     connections=[]))
+        with patch.object(svc.config_manager, "get_user_config", return_value=cfg):
+            with pytest.raises(ValueError, match="未找到指定的 AI 连接配置"):
+                svc._resolve_connection_and_model(uuid4(), MagicMock(), None, None)
+
+    def test_disabled_connection_raises_value_error(self):
+        from app.service.moment import day_caption_service as svc
+
+        conn = SimpleNamespace(id="c1", enable=False, api_key="k1", api_base="")
+        cfg = self._config(_settings(chat_id="c1", chat_model="m",
+                                     connections=[conn]))
+        with patch.object(svc.config_manager, "get_user_config", return_value=cfg):
+            with pytest.raises(ValueError, match="选中的 AI 连接已禁用"):
+                svc._resolve_connection_and_model(uuid4(), MagicMock(), None, None)
+
+    def test_missing_api_key_raises_value_error(self):
+        from app.service.moment import day_caption_service as svc
+
+        conn = SimpleNamespace(id="c1", enable=True, api_key="", api_base="")
+        cfg = self._config(_settings(chat_id="c1", chat_model="m",
+                                     connections=[conn]))
+        with patch.object(svc.config_manager, "get_user_config", return_value=cfg):
+            with pytest.raises(ValueError, match="未配置 API Key"):
+                svc._resolve_connection_and_model(uuid4(), MagicMock(), None, None)
+
+
+# ---------------------------------------------------------------------------
+# _build_llm
+# ---------------------------------------------------------------------------
+class TestBuildLlm:
+    def test_returns_fixed_chat_openai_with_expected_kwargs(self):
+        from app.service.moment import day_caption_service as svc
+        from app.service.agent.service import FixedChatOpenAI
+
+        conn = SimpleNamespace(api_key="k", api_base="http://example.com")
+
+        with patch.object(svc, "FixedChatOpenAI") as fake_cls:
+            fake_instance = MagicMock()
+            fake_cls.return_value = fake_instance
+
+            result = svc._build_llm(conn, "my-model", streaming=True)
+
+        assert result is fake_instance
+        kwargs = fake_cls.call_args.kwargs
+        assert kwargs["model"] == "my-model"
+        assert kwargs["api_key"] == "k"
+        assert kwargs["base_url"] == "http://example.com"
+        assert kwargs["streaming"] is True
+        assert kwargs["reasoning_effort"] == "none"
+
+    def test_empty_api_base_passes_none(self):
+        from app.service.moment import day_caption_service as svc
+
+        conn = SimpleNamespace(api_key="k", api_base="")
+
+        with patch.object(svc, "FixedChatOpenAI") as fake_cls:
+            svc._build_llm(conn, "m", streaming=False)
+
+        kwargs = fake_cls.call_args.kwargs
+        assert kwargs["base_url"] is None
+        assert kwargs["streaming"] is False
+
+    def test_returned_type_is_fixed_chat_openai(self):
+        from app.service.moment import day_caption_service as svc
+        from app.service.agent.service import FixedChatOpenAI
+
+        conn = SimpleNamespace(api_key="k", api_base="")
+        llm = svc._build_llm(conn, "m", streaming=False)
+        assert isinstance(llm, FixedChatOpenAI)

--- a/package/server/tests/unit/test_nightly_scan_strategy_gaps_20260817.py
+++ b/package/server/tests/unit/test_nightly_scan_strategy_gaps_20260817.py
@@ -1,0 +1,273 @@
+"""Unit tests for app/service/tasks/scan.py strategy class.
+
+The nightly gap scan flagged service/tasks/scan.py as 30 percent covered
+with 172 missed lines.  Pure helpers (_compile_folder_patterns,
+_is_folder_excluded, scan_directory_recursive) are covered by
+test_scan_folder_helpers.py; this file picks up the three ScanFolderStrategy
+methods that touch SQLAlchemy without spinning up real os.scandir walks.
+
+Goals:
+  * _get_existing_files         -- SQL row iteration + live-photo bookkeeping
+  * _create_tasks_for_new_files -- grouping + live-photo pair detection
+  * _handle_deleted_files       -- chunked batch_delete_photos_db + IndexLog
+  * process                      -- single-user vs all-user dispatch
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.db.models.photo import FileType
+from app.db.models.task import TaskStatus, TaskType
+from app.service.tasks.scan import ScanFolderStrategy
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _strategy():
+    return ScanFolderStrategy()
+
+
+def _photo(file_path, file_type="image", owner_id="user-1"):
+    return SimpleNamespace(
+        id=f"photo-{os.path.basename(file_path)}",
+        file_path=file_path,
+        file_type=file_type,
+        owner_id=owner_id,
+        is_deleted=False,
+    )
+
+
+def _row(file_path, file_type):
+    """``query(Photo.file_path, Photo.file_type).all()`` returns 2-tuples."""
+    return (file_path, file_type)
+
+
+# ---------------------------------------------------------------------------
+# _get_existing_files
+# ---------------------------------------------------------------------------
+
+
+class TestGetExistingFiles:
+    def test_returns_only_files_under_scan_roots(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [
+            _row("E:/photos/2024/a.jpg", FileType.image),
+            _row("E:/other/x.jpg", FileType.image),
+        ]
+
+        existing, live_add = _strategy()._get_existing_files(
+            db, "user-1", ["E:/photos"]
+        )
+
+        assert "E:/photos/2024/a.jpg" in existing
+        assert "E:/other/x.jpg" not in existing
+        assert live_add == set()
+
+    def test_live_jpg_mp4_pair_flags_mp4_row(self):
+        """For a jpg+mp4 pair stored with the image+video file types the
+        scanner iterates rows in DB order; when the mp4 row is processed
+        second, the matching jpg is already in ``existing_files`` so the
+        mp4 row is added to ``live_photo_to_add`` (it needs the live
+        payload in PROCESS_BASIC)."""
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [
+            _row("E:/p/IMG_0001.jpg", FileType.image),
+            _row("E:/p/IMG_0001.mp4", FileType.video),
+        ]
+
+        existing, live_add = _strategy()._get_existing_files(
+            db, "user-1", ["E:/p"]
+        )
+
+        assert existing == {"E:/p/IMG_0001.jpg", "E:/p/IMG_0001.mp4"}
+        assert live_add == {"E:/p/IMG_0001.mp4"}
+
+    def test_live_heic_mov_pair_flags_mov_row(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [
+            _row("E:/p/IMG_0002.HEIC", FileType.image),
+            _row("E:/p/IMG_0002.MOV", FileType.video),
+        ]
+
+        existing, live_add = _strategy()._get_existing_files(
+            db, "user-1", ["E:/p"]
+        )
+
+        assert existing == {"E:/p/IMG_0002.HEIC", "E:/p/IMG_0002.MOV"}
+        assert live_add == {"E:/p/IMG_0002.MOV"}
+
+    def test_live_photo_file_type_injects_video_into_existing(self):
+        """A DB row already marked ``FileType.live_photo`` for a .jpg file
+        means the scanner must pre-populate ``existing_files`` with the
+        matching .mp4 path so later disk diff doesn't see a phantom new
+        file."""
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [
+            _row("E:/p/IMG_0001.jpg", FileType.live_photo),
+        ]
+
+        existing, _ = _strategy()._get_existing_files(db, "user-1", ["E:/p"])
+
+        assert "E:/p/IMG_0001.mp4" in existing
+        assert "E:/p/IMG_0001.jpg" in existing
+
+    def test_live_photo_heic_injects_mov_into_existing(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [
+            _row("E:/p/IMG_0002.HEIC", FileType.live_photo),
+        ]
+
+        existing, _ = _strategy()._get_existing_files(db, "user-1", ["E:/p"])
+
+        assert "E:/p/IMG_0002.MOV" in existing
+        assert "E:/p/IMG_0002.HEIC" in existing
+
+
+# ---------------------------------------------------------------------------
+# _create_tasks_for_new_files
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTasksForNewFiles:
+    @pytest.mark.asyncio
+    async def test_emits_basic_task_for_each_image(self):
+        db = MagicMock()
+        loop = asyncio.get_running_loop()
+        files = {
+            "E:/p/IMG_0001.jpg",
+            "E:/p/IMG_0002.jpg",
+            "E:/p/IMG_0003.png",
+        }
+
+        with patch(
+            "app.service.tasks.scan.live_photo_service.get_content_identifier",
+            return_value=None,
+        ):
+            await _strategy()._create_tasks_for_new_files("user-1", files, loop, db)
+
+        # Three files -> three PROCESS_BASIC tasks in a single 1000-chunk.
+        assert db.bulk_save_objects.call_count == 1
+        all_tasks = db.bulk_save_objects.call_args.args[0]
+        assert len(all_tasks) == 3
+        assert {t.type for t in all_tasks} == {TaskType.PROCESS_BASIC}
+        assert {t.status for t in all_tasks} == {TaskStatus.PENDING}
+        assert all(t.payload["user_id"] == "user-1" for t in all_tasks)
+
+    @pytest.mark.asyncio
+    async def test_live_pair_emits_single_task_with_video_payload(self):
+        db = MagicMock()
+        loop = asyncio.get_running_loop()
+        files = {"E:/p/IMG_0001.jpg", "E:/p/IMG_0001.mp4"}
+
+        with patch(
+            "app.service.tasks.scan.live_photo_service.get_content_identifier",
+            side_effect=lambda p: "cid-1",
+        ):
+            await _strategy()._create_tasks_for_new_files("user-1", files, loop, db)
+
+        all_tasks = db.bulk_save_objects.call_args.args[0]
+        assert len(all_tasks) == 1
+        task = all_tasks[0]
+        assert task.payload["is_live_photo"] is True
+        assert task.payload["file_path"].endswith(".jpg")
+        assert task.payload["live_photo_video_path"].endswith(".mp4")
+
+    @pytest.mark.asyncio
+    async def test_empty_input_skips_db_write(self):
+        db = MagicMock()
+        await _strategy()._create_tasks_for_new_files(
+            "user-1", set(), asyncio.get_running_loop(), db
+        )
+        db.bulk_save_objects.assert_not_called()
+        db.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_deleted_files
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDeletedFiles:
+    def test_no_files_means_no_db_calls(self):
+        db = MagicMock()
+        worker = SimpleNamespace(scan_status={"deleted": 0})
+
+        _strategy()._handle_deleted_files("user-1", set(), db, worker)
+
+        db.query.assert_not_called()
+        db.add.assert_not_called()
+        db.commit.assert_not_called()
+        assert worker.scan_status["deleted"] == 0
+
+    def test_chunks_deleted_files_into_batches(self):
+        # 1200 files -> 3 chunks of 500 / 500 / 200.
+        # Each chunk's photo query returns 10 Photo rows -> worker counts
+        # accumulate to 30 over the 3 iterations.
+        deleted = {f"E:/p/{i}.jpg" for i in range(1200)}
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [
+            _photo(p) for p in list(deleted)[:10]
+        ]
+
+        worker = SimpleNamespace(scan_status={"deleted": 0})
+
+        # ``batch_delete_photos_db`` is imported lazily inside the method,
+        # so the patch must target the source module, not the consumer.
+        with patch(
+            "app.crud.photo.batch_delete_photos_db"
+        ) as batch_delete:
+            _strategy()._handle_deleted_files("user-1", deleted, db, worker)
+
+        assert batch_delete.call_count == 3
+        assert worker.scan_status["deleted"] == 30
+
+
+# ---------------------------------------------------------------------------
+# process (entrypoint)
+# ---------------------------------------------------------------------------
+
+
+class TestProcess:
+    @pytest.mark.asyncio
+    async def test_processes_only_target_user_when_user_id_provided(self):
+        db = MagicMock()
+        target_user = SimpleNamespace(id="target-user")
+        db.query.return_value.filter.return_value.first.return_value = target_user
+
+        worker = SimpleNamespace(scan_status={"message": "", "total_files": 0, "deleted": 0})
+        task = SimpleNamespace(
+            payload={"user_id": "target-user", "scan_roots": ["E:/p"]}
+        )
+        strategy = _strategy()
+        strategy._scan_for_user = AsyncMock(return_value={"new_files": 2, "deleted_files": 1})
+
+        result = await strategy.process(worker, task, db)
+
+        strategy._scan_for_user.assert_awaited_once()
+        assert result == {"new_files": 2, "deleted_files": 1}
+
+    @pytest.mark.asyncio
+    async def test_unknown_user_id_produces_zero_result(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        worker = SimpleNamespace(scan_status={"message": "", "total_files": 0, "deleted": 0})
+        task = SimpleNamespace(payload={"user_id": "ghost", "scan_roots": ["E:/p"]})
+        strategy = _strategy()
+        strategy._scan_for_user = AsyncMock()
+
+        result = await strategy.process(worker, task, db)
+
+        strategy._scan_for_user.assert_not_awaited()
+        assert result == {"new_files": 0, "deleted_files": 0}

--- a/package/server/tests/unit/test_nightly_time_from_filename_process_gaps_20260817.py
+++ b/package/server/tests/unit/test_nightly_time_from_filename_process_gaps_20260817.py
@@ -1,0 +1,266 @@
+"""Unit tests for app/service/tasks/time_from_filename.py process() method.
+
+The nightly gap scan flagged service/tasks/time_from_filename.py at 29 %
+coverage (88 missed lines).  ``test_time_from_filename_task.py`` covers
+``_has_missing_metadata`` + the empty ``target_root_path`` error path.
+This file picks up the remaining branches of ``process``:
+
+  * custom_time format validation (YYYY-MM-DD HH:MM:SS)
+  * target_root_path filter (only photos under that path)
+  * only_missing_metadata filter
+  * time_mode branches: auto / custom / none
+  * PhotoMetadata creation when absent
+"""
+
+import asyncio
+import os
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_task(payload, owner_id="user-1"):
+    return SimpleNamespace(
+        id="task-ttff",
+        owner_id=owner_id,
+        payload=payload,
+        total_items=0,
+        processed_items=0,
+    )
+
+
+def _make_photo(pid, file_path, photo_time=None, metadata=None):
+    return SimpleNamespace(
+        id=pid,
+        file_path=file_path,
+        photo_time=photo_time,
+        metadata_info=metadata,
+        is_deleted=False,
+        owner_id="user-1",
+    )
+
+
+def _query_with_photos(photos):
+    """Mimic ``db.query(...).outerjoin(...).options(...).filter().all()`` chain."""
+    query = MagicMock()
+    query.outerjoin.return_value = query
+    query.options.return_value = query
+    query.filter.return_value = query
+    query.all.return_value = photos
+    return query
+
+
+def _db_with_photos(photos):
+    """DB whose ``query(...).all()`` returns the given photos, with a
+    default no-op chain for the albums-query used by the post-step
+    ``trigger_conditional_albums_update`` (out of scope for these tests)."""
+    db = MagicMock()
+    db.query.return_value = _query_with_photos(photos)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# error paths
+# ---------------------------------------------------------------------------
+
+
+class TestProcessErrors:
+    def test_missing_target_root_path_raises(self):
+        from app.service.tasks.time_from_filename import TimeFromFilenameStrategy
+
+        task = _build_task({})
+
+        with pytest.raises(ValueError, match="target_root_path"):
+            asyncio.run(TimeFromFilenameStrategy().process(None, task, None))
+
+    def test_invalid_custom_time_format_raises(self):
+        """``custom_time`` must follow ``%Y-%m-%d %H:%M:%S``; bad input
+        is rejected loudly so the worker can mark the task failed rather
+        than silently writing ``None``."""
+        from app.service.tasks.time_from_filename import TimeFromFilenameStrategy
+
+        task = _build_task(
+            {
+                "target_root_path": str(os.path.abspath(".")),
+                "time_mode": "custom",
+                "custom_time": "yesterday",
+            }
+        )
+
+        with pytest.raises(ValueError, match="Invalid custom_time format"):
+            asyncio.run(TimeFromFilenameStrategy().process(None, task, None))
+
+
+# ---------------------------------------------------------------------------
+# happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestProcessHappyPaths:
+    def test_filters_by_target_root_path(self, tmp_path):
+        """Photos whose file_path is not under ``target_root_path`` must be
+        excluded even though the DB returned them."""
+        from app.service.tasks.time_from_filename import TimeFromFilenameStrategy
+
+        inside = _make_photo("p1", str(tmp_path / "a.jpg"))
+        outside = _make_photo("p2", str(tmp_path.parent / "b.jpg"))
+        # Patch os.path.exists so both "exist" without touching the FS.
+        with patch("app.service.tasks.time_from_filename.os.path.exists", return_value=True), \
+             patch("app.crud.album.trigger_conditional_albums_update"):
+            task = _build_task(
+                {"target_root_path": str(tmp_path), "time_mode": "none"}
+            )
+            db = _db_with_photos([inside, outside])
+
+            result = asyncio.run(
+                TimeFromFilenameStrategy().process(None, task, db)
+            )
+
+        assert task.total_items == 1
+        assert result["total_processed"] == 1
+
+    def test_only_missing_metadata_filter_narrows_targets(self, tmp_path):
+        from app.service.tasks.time_from_filename import TimeFromFilenameStrategy
+
+        incomplete = _make_photo("p1", str(tmp_path / "a.jpg"), metadata=None)
+        complete = _make_photo(
+            "p2", str(tmp_path / "b.jpg"),
+            metadata=SimpleNamespace(make="Canon", model=" EOS "),
+        )
+
+        with patch("app.service.tasks.time_from_filename.os.path.exists", return_value=True), \
+             patch("app.crud.album.trigger_conditional_albums_update"):
+            task = _build_task(
+                {
+                    "target_root_path": str(tmp_path),
+                    "time_mode": "none",
+                    "only_missing_metadata": True,
+                }
+            )
+            db = _db_with_photos([incomplete, complete])
+
+            asyncio.run(TimeFromFilenameStrategy().process(None, task, db))
+
+        assert task.total_items == 1
+
+    def test_auto_mode_uses_existing_photo_time(self, tmp_path):
+        """time_mode=auto reuses ``photo.photo_time`` and writes it back
+        to the file timestamp via ``os.utime``."""
+        from app.service.tasks.time_from_filename import TimeFromFilenameStrategy
+
+        target_dt = datetime(2024, 1, 2, 3, 4, 5)
+        photo = _make_photo("p1", str(tmp_path / "a.jpg"), photo_time=target_dt)
+
+        with patch("app.service.tasks.time_from_filename.os.path.exists", return_value=True), \
+             patch("app.service.tasks.time_from_filename.os.utime") as utime_call, \
+             patch("app.crud.album.trigger_conditional_albums_update"):
+            task = _build_task(
+                {"target_root_path": str(tmp_path), "time_mode": "auto"}
+            )
+            db = _db_with_photos([photo])
+
+            result = asyncio.run(
+                TimeFromFilenameStrategy().process(None, task, db)
+            )
+
+        assert result["success_count"] == 1
+        # auto mode writes the stored timestamp back to disk.
+        utime_call.assert_called_once()
+        called_path, (atime, mtime) = utime_call.call_args.args
+        assert called_path == str(tmp_path / "a.jpg")
+        assert atime == mtime == target_dt.timestamp()
+
+    def test_custom_mode_sets_photo_time_and_calls_utime(self, tmp_path):
+        from app.service.tasks.time_from_filename import TimeFromFilenameStrategy
+
+        photo = _make_photo("p1", str(tmp_path / "a.jpg"), photo_time=None)
+
+        with patch("app.service.tasks.time_from_filename.os.path.exists", return_value=True), \
+             patch("app.service.tasks.time_from_filename.os.utime") as utime_call, \
+             patch("app.crud.album.trigger_conditional_albums_update"):
+            task = _build_task(
+                {
+                    "target_root_path": str(tmp_path),
+                    "time_mode": "custom",
+                    "custom_time": "2024-05-06 07:08:09",
+                    "make": "Canon",
+                    "model": " EOS R5 ",
+                }
+            )
+            db = _db_with_photos([photo])
+
+            asyncio.run(TimeFromFilenameStrategy().process(None, task, db))
+
+        assert photo.photo_time == datetime(2024, 5, 6, 7, 8, 9)
+        utime_call.assert_called_once()
+        called_path, (atime, mtime) = utime_call.call_args.args
+        assert called_path == str(tmp_path / "a.jpg")
+        assert atime == mtime
+        assert datetime.fromtimestamp(mtime) == datetime(2024, 5, 6, 7, 8, 9)
+
+    def test_none_mode_writes_make_model_without_touching_time(self, tmp_path):
+        """time_mode=none skips os.utime entirely even when photo_time is set."""
+        from app.service.tasks.time_from_filename import TimeFromFilenameStrategy
+
+        photo = _make_photo(
+            "p1",
+            str(tmp_path / "a.jpg"),
+            photo_time=datetime(2020, 1, 1, 0, 0, 0),
+            metadata=SimpleNamespace(make=None, model=None),
+        )
+
+        with patch("app.service.tasks.time_from_filename.os.path.exists", return_value=True), \
+             patch("app.service.tasks.time_from_filename.os.utime") as utime_call, \
+             patch("app.crud.album.trigger_conditional_albums_update"):
+            task = _build_task(
+                {
+                    "target_root_path": str(tmp_path),
+                    "time_mode": "none",
+                    "make": "Sony",
+                    "model": "A7M4",
+                }
+            )
+            db = _db_with_photos([photo])
+
+            asyncio.run(TimeFromFilenameStrategy().process(None, task, db))
+
+        utime_call.assert_not_called()
+        assert photo.metadata_info.make == "Sony"
+        assert photo.metadata_info.model == "A7M4"
+
+    def test_creates_photo_metadata_when_missing(self, tmp_path):
+        """If the photo has no ``metadata_info`` row, ``process`` must
+        instantiate a new ``PhotoMetadata`` and attach it."""
+        from app.service.tasks.time_from_filename import TimeFromFilenameStrategy
+
+        photo = _make_photo("p1", str(tmp_path / "a.jpg"), metadata=None)
+
+        with patch("app.service.tasks.time_from_filename.os.path.exists", return_value=True), \
+             patch("app.crud.album.trigger_conditional_albums_update"):
+            task = _build_task(
+                {
+                    "target_root_path": str(tmp_path),
+                    "time_mode": "none",
+                    "make": "Apple",
+                    "model": "iPhone 15",
+                }
+            )
+            db = _db_with_photos([photo])
+
+            asyncio.run(TimeFromFilenameStrategy().process(None, task, db))
+
+        assert photo.metadata_info is not None
+        assert photo.metadata_info.make == "Apple"
+        assert photo.metadata_info.model == "iPhone 15"
+        # db.add should have been called to register the new metadata row.
+        assert db.add.called


### PR DESCRIPTION
## Nightly Watch 2026-08-17 (round 12 + 13)

### Round 12 (10:01 +08:00, commit ae0a436)

- 测试结果: PASS
- 失败用例: 0
- 新增测试: 1 文件 / 14 用例 (crud/annual_report)
- 完整 E2E: 299 passed / 4 skipped / 0 failed (6.6m)
- CI: 11/11 SUCCESS+SKIPPED
- Backend unit 全量: 1466 passed / 2 skipped (was 1452 / 2, +14)
- 覆盖率: crud/annual_report.py 33.1% → 89.2% (+56pp)
- Frontend view 盲区: 0

### Round 13 (14:20 +08:00, commit acb23ae)

- 测试结果: PASS
- 失败用例: 0 (修复 A=0 B=0 C=0)
- 新增测试: 3 文件 / 52 用例
  - app/service/tasks/basic.py BasicTaskStrategy.process_batch (5 cases)
  - app/crud/location.py (4 funcs)
  - app/db/session.py engine 创建 (sqlite / postgres branches)
  - app/service/moment/day_caption_service.py (8 helpers)
  - package/ai/app/core/logger.py (JSONFormatter + handler + setup_logging + log_operation)
- 完整 E2E: 299 passed / 4 skipped / 0 failed (6.8m)
- CI: 18/18 SUCCESS+SKIPPED (Tests run 32007810728 + Build/Server/AI/Desktop 全绿)
- Backend unit 全量: 1466 -> 1518 passed (+52)
- AI unit 全量: 277 -> 288 passed (+11)

### Coverage deltas (round 12 + 13)

| Module | Before | After |
| --- | --- | --- |
| app/crud/annual_report.py | 33.1% | 89.2% (+56pp) |
| app/service/tasks/basic.py | 0% | 35% (+35pp) |
| app/crud/location.py | 0% | 40% (+40pp) |
| app/db/session.py | 0% | 59% (+59pp) |
| app/service/moment/day_caption_service.py | 0% | 41% (+41pp) |
| package/ai/app/core/logger.py | 0% | 73% (+73pp) |

### Commits on nightly/test-watch-20260817

- acb23ae test(nightly): cover basic.py/location.py/session.py + day_caption + ai logger (round 13, 2026-08-17)
- ae0a436 test(nightly): cover crud.annual_report (round 12, 2026-08-17)

🤖 Generated with [Codex](https://openai.com/blog/openai-codex/)
Co-authored-by: Codex <noreply@openai.com>