### PR TITLE
docs: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ docker-compose up -d
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LC044/TrailSnap&type=Date)](https://star-history.com/?utm_source=bestxtools.com#LC044/TrailSnap&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=LC044/TrailSnap&type=Date)](https://star-history.dera.page/#LC044/TrailSnap&Date)
 
 ## 🤝 贡献者
 

--- a/doc/README_en.md
+++ b/doc/README_en.md
@@ -244,7 +244,7 @@ For more detailed technical documentation, please refer to the `doc/` directory 
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LC044/TrailSnap&type=Date)](https://star-history.com/?utm_source=bestxtools.com#LC044/TrailSnap&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=LC044/TrailSnap&type=Date)](https://star-history.dera.page/#LC044/TrailSnap&Date)
 
 ## 🤝 Contributors
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已经损坏，原因是 GitHub stargazer API 的限制导致原有数据源无法访问。

本次修改将中文版与英文版 README 中的 Star History 图表链接迁移到新的数据源（star-history.dera.page），该方案无需 API token 即可工作，能确保图表正常显示。

此修复非常必要：star 趋势图是展示项目成长的重要元素，目前处于不可用状态。