### PR TITLE
test(nightly): cover api/media.py Range handler + media-type mapping (2026-08-25)

### DIFF
--- a/package/server/tests/unit/test_agent_service.py
+++ b/package/server/tests/unit/test_agent_service.py
@@ -1,0 +1,132 @@
+"""Unit tests for ``app/service/agent/service.py`` helpers.
+
+Covers the low-level helpers that the agent REST router (and chat
+loop) rely on, without touching LangChain / Postgres. The DB session
+is a ``MagicMock`` and LangChain ``trim_messages`` is patched so we
+can verify the pure-Python behaviour deterministically.
+
+Scenarios:
+* ``abort_chat_session`` writes into the module-level aborted set
+* ``get_session_history`` maps ``user`` / ``assistant`` / ``system``
+  roles into LangChain ``HumanMessage`` / ``AIMessage`` / ``SystemMessage``
+* ``get_session_history`` ignores unknown roles
+* ``trim_history_messages`` returns the input when given an empty list
+* ``trim_history_messages`` delegates to ``trim_messages`` with the
+  sliding-window parameters and falls back to the original list on
+  trim failure
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from app.service.agent import service as agent_service
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_agent]
+
+
+# ---------------------------------------------------------------------------
+# abort_chat_session
+# ---------------------------------------------------------------------------
+
+def test_abort_chat_session_marks_session_aborted():
+    session_id = "session-1"
+
+    # ensure the global state starts clean for this id
+    agent_service._aborted_sessions.pop(session_id, None)
+
+    agent_service.abort_chat_session(session_id)
+
+    assert agent_service._aborted_sessions[session_id] is True
+
+
+# ---------------------------------------------------------------------------
+# get_session_history
+# ---------------------------------------------------------------------------
+
+def _msg(role, content):
+    return SimpleNamespace(role=role, content=content)
+
+
+def test_get_session_history_maps_known_roles_to_langchain_messages():
+    db_messages = [
+        _msg("system", "sys-prompt"),
+        _msg("user", "hi"),
+        _msg("assistant", "hello"),
+    ]
+    db = MagicMock()
+
+    with patch.object(agent_service, "get_messages_by_session", return_value=db_messages):
+        history = agent_service.get_session_history(db, "session-1")
+
+    assert len(history) == 3
+    assert isinstance(history[0], SystemMessage)
+    assert history[0].content == "sys-prompt"
+    assert isinstance(history[1], HumanMessage)
+    assert history[1].content == "hi"
+    assert isinstance(history[2], AIMessage)
+    assert history[2].content == "hello"
+
+
+def test_get_session_history_skips_unknown_roles():
+    db_messages = [
+        _msg("user", "hi"),
+        _msg("tool", "tool-output"),
+        _msg("assistant", "hello"),
+    ]
+    db = MagicMock()
+
+    with patch.object(agent_service, "get_messages_by_session", return_value=db_messages):
+        history = agent_service.get_session_history(db, "session-1")
+
+    # the tool-role message must be skipped
+    assert [type(m).__name__ for m in history] == ["HumanMessage", "AIMessage"]
+    assert history[0].content == "hi"
+    assert history[1].content == "hello"
+
+
+# ---------------------------------------------------------------------------
+# trim_history_messages
+# ---------------------------------------------------------------------------
+
+def test_trim_history_messages_returns_input_on_empty():
+    assert agent_service.trim_history_messages([]) == []
+
+
+def test_trim_history_messages_delegates_to_trim_messages_with_sliding_window():
+    messages = [HumanMessage(content=str(i)) for i in range(5)]
+
+    with patch.object(agent_service, "trim_messages", return_value=messages[:3]) as trim_call:
+        trimmed = agent_service.trim_history_messages(messages)
+
+    # ensure sliding-window parameters are passed
+    args, kwargs = trim_call.call_args
+    assert args[0] is messages
+    assert kwargs["max_tokens"] == agent_service.MAX_HISTORY_MESSAGES
+    assert kwargs["strategy"] == "last"
+    assert kwargs["token_counter"] is len
+    assert kwargs["include_system"] is True
+    assert kwargs["start_on"] == "human"
+    assert trimmed == messages[:3]
+
+
+def test_trim_history_messages_falls_back_when_trim_returns_empty():
+    messages = [HumanMessage(content="hi"), AIMessage(content="hello")]
+
+    with patch.object(agent_service, "trim_messages", return_value=[]):
+        trimmed = agent_service.trim_history_messages(messages)
+
+    # fallback to original history
+    assert trimmed is messages
+
+
+def test_trim_history_messages_falls_back_when_trim_raises():
+    messages = [HumanMessage(content="hi")]
+
+    with patch.object(agent_service, "trim_messages", side_effect=RuntimeError("boom")):
+        trimmed = agent_service.trim_history_messages(messages)
+
+    assert trimmed is messages

--- a/package/server/tests/unit/test_nightly_api_media_streaming_gaps_20260825.py
+++ b/package/server/tests/unit/test_nightly_api_media_streaming_gaps_20260825.py
@@ -1,0 +1,369 @@
+"""Unit tests for app/api/media.py Range handler, media-type mapping and
+live-photo video fallback branches.
+
+Round: 2026-08-25.
+Covers the missing ranges reported by the targeted coverage scan:
+- app/api/media.py 71% covered (71 missed) coming into this round.
+  - get_media_file Range header (197-222), MediaType mapping (181-183)
+  - get_live_photo_video extension fall-through (.mp4 / .MOV / thumb .mp4),
+    Range header parsing (95-130)
+  - get_media_file 404 paths (no photo / no file)
+
+Pattern: MagicMock + tmp_path + `route_in_threadpool` already executes
+synchronous lambdas straight on `db`, so the existing pattern is unchanged.
+Real files are written into tmp_path so anyio.open_file inside the Range
+handler iterfile() can stream from them.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import FileResponse, StreamingResponse
+
+from app.api import media as media_api
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+def _photo(file_path: str, owner_id=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        owner_id=owner_id or uuid4(),
+        file_path=file_path,
+    )
+
+
+async def _consume(response):
+    """Drain a StreamingResponse body and return it as bytes."""
+    chunks = []
+    async for chunk in response.body_iterator:
+        if isinstance(chunk, str):
+            chunk = chunk.encode("utf-8")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# get_media_file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_404_when_photo_missing():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    request = MagicMock()
+    with pytest.raises(HTTPException) as exc:
+        await media_api.get_media_file(
+            photo_id=uuid4(), request=request, range=None, db=db
+        )
+    assert exc.value.status_code == 404
+    assert "File not found" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_404_when_file_missing(tmp_path):
+    photo = _photo(file_path=str(tmp_path / "missing.jpg"))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+    with pytest.raises(HTTPException) as exc:
+        await media_api.get_media_file(
+            photo_id=photo.id, request=request, range=None, db=db
+        )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "expected_media_type"),
+    [
+        ("snap.jpg", "image/jpeg"),
+        ("snap.jpeg", "image/jpeg"),
+        ("snap.png", "image/png"),
+        ("snap.webp", "image/webp"),
+        ("snap.tiff", "image/tiff"),
+        ("snap.gif", "image/gif"),
+        ("clip.mp4", "video/mp4"),
+        ("clip.mov", "video/quicktime"),
+        ("clip.mkv", "video/x-matroska"),
+        ("clip.avi", "video/avi"),
+    ],
+)
+async def test_get_media_file_media_type_mapping(
+    tmp_path, filename, expected_media_type
+):
+    real_path = tmp_path / filename
+    real_path.write_bytes(b"x" * 64)
+    photo = _photo(file_path=str(real_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    resp = await media_api.get_media_file(
+        photo_id=photo.id, request=request, range=None, db=db
+    )
+    assert isinstance(resp, FileResponse)
+    assert resp.media_type == expected_media_type
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_heic_redirects_to_thumbnail(tmp_path):
+    """`.heic` files aren't served directly; the endpoint should swap to a
+    medium-sized thumbnail path and stream that file instead."""
+    real_path = tmp_path / "snap.heic"
+    real_path.write_bytes(b"x" * 32)
+    thumb_path = tmp_path / "snap-thumb-medium.webp"
+    thumb_path.write_bytes(b"WEBPBIN")
+
+    photo = _photo(file_path=str(real_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(thumb_path)):
+        resp = await media_api.get_media_file(
+            photo_id=photo.id, request=request, range=None, db=db
+        )
+    assert isinstance(resp, FileResponse)
+    assert resp.path == str(thumb_path)
+    # Original .heic has no explicit media-type mapping, so the endpoint
+    # leaves the Content-Type at application/octet-stream even after the
+    # thumbnail redirect. The important behaviour is the path swap.
+    assert resp.media_type == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_past_end_returns_416(tmp_path):
+    real_path = tmp_path / "snap.jpg"
+    real_path.write_bytes(b"x" * 16)  # 16 bytes
+
+    photo = _photo(file_path=str(real_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    resp = await media_api.get_media_file(
+        photo_id=photo.id,
+        request=request,
+        range="bytes=100-200",
+        db=db,
+    )
+    # 100 >= 16 (file_size) -> 416 with Content-Range header.
+    assert resp.status_code == 416
+    assert resp.headers["Content-Range"] == "bytes */16"
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_normal_range_returns_206_with_content(tmp_path):
+    real_path = tmp_path / "snap.mp4"
+    payload = bytes(range(256))  # 256 bytes
+    real_path.write_bytes(payload)
+
+    photo = _photo(file_path=str(real_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    resp = await media_api.get_media_file(
+        photo_id=photo.id,
+        request=request,
+        range="bytes=10-19",
+        db=db,
+    )
+    assert isinstance(resp, StreamingResponse)
+    assert resp.status_code == 206
+    assert resp.headers["Accept-Ranges"] == "bytes"
+    assert resp.headers["Content-Range"] == "bytes 10-19/256"
+    assert resp.headers["Content-Length"] == "10"
+    assert resp.media_type == "video/mp4"
+
+    body = await _consume(resp)
+    assert body == payload[10:20]
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_open_ended_range_uses_file_end(tmp_path):
+    real_path = tmp_path / "snap.mp4"
+    payload = b"0123456789"
+    real_path.write_bytes(payload)
+
+    photo = _photo(file_path=str(real_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    resp = await media_api.get_media_file(
+        photo_id=photo.id,
+        request=request,
+        range="bytes=2-",
+        db=db,
+    )
+    assert resp.status_code == 206
+    # Open-ended Range uses file_size-1 as end -> chunk size = 10-2 = 8 bytes
+    assert resp.headers["Content-Length"] == "8"
+    assert resp.headers["Content-Range"] == "bytes 2-9/10"
+    body = await _consume(resp)
+    assert body == payload[2:]
+
+
+@pytest.mark.asyncio
+async def test_get_media_file_invalid_range_falls_back_to_full(tmp_path):
+    """Malformed Range (ValueError) shouldn't break the endpoint; it falls
+    back to the full FileResponse."""
+    real_path = tmp_path / "snap.jpg"
+    real_path.write_bytes(b"y" * 32)
+
+    photo = _photo(file_path=str(real_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    resp = await media_api.get_media_file(
+        photo_id=photo.id,
+        request=request,
+        range="abc-def",  # ValueError when int("abc")
+        db=db,
+    )
+    assert isinstance(resp, FileResponse)
+    assert resp.media_type == "image/jpeg"
+
+
+# ---------------------------------------------------------------------------
+# get_live_photo_video
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_live_photo_video_404_when_photo_missing():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    request = MagicMock()
+    with pytest.raises(HTTPException) as exc:
+        await media_api.get_live_photo_video(
+            photo_id=uuid4(), request=request, range=None, db=db
+        )
+    assert exc.value.status_code == 404
+    assert "Video file not found" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_get_live_photo_video_jpg_path_uses_mp4_when_exists(tmp_path):
+    """`.jpg` extension -> prefer sibling .mp4, then .mov, then thumb .mp4."""
+    jpg_path = tmp_path / "snap.jpg"
+    jpg_path.write_bytes(b"orig")
+    mp4_path = tmp_path / "snap.mp4"
+    mp4_path.write_bytes(b"vid")
+
+    photo = _photo(file_path=str(jpg_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(tmp_path / "snap-thumb.mp4")):
+        resp = await media_api.get_live_photo_video(
+            photo_id=photo.id, request=request, range=None, db=db
+        )
+    assert isinstance(resp, FileResponse)
+    assert resp.path == str(mp4_path)
+    assert resp.media_type == "video/mp4"
+
+
+@pytest.mark.asyncio
+async def test_get_live_photo_video_jpg_falls_through_mp4_and_mov_to_thumbnail(tmp_path):
+    """When neither sibling .mp4 nor .mov exists, fall back to the thumbnail
+    directory's .mp4 path computed via _get_thumbnail_path."""
+    jpg_path = tmp_path / "snap.jpg"
+    jpg_path.write_bytes(b"orig")
+    thumb_path = tmp_path / "snap-thumb.mp4"
+    thumb_path.write_bytes(b"thumbvid")
+
+    photo = _photo(file_path=str(jpg_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(thumb_path)):
+        resp = await media_api.get_live_photo_video(
+            photo_id=photo.id, request=request, range=None, db=db
+        )
+    assert isinstance(resp, FileResponse)
+    assert resp.path == str(thumb_path)
+    assert resp.media_type == "video/mp4"
+
+
+@pytest.mark.asyncio
+async def test_get_live_photo_video_non_jpg_uses_MOV(tmp_path):
+    """Non-jpg source files (e.g. .HEIC) generate .MOV companion videos."""
+    heic_path = tmp_path / "snap.HEIC"
+    heic_path.write_bytes(b"orig")
+    mov_path = tmp_path / "snap.MOV"
+    mov_path.write_bytes(b"movpayload")
+
+    photo = _photo(file_path=str(heic_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(tmp_path / "snap-thumb.mp4")):
+        resp = await media_api.get_live_photo_video(
+            photo_id=photo.id, request=request, range=None, db=db
+        )
+    assert isinstance(resp, FileResponse)
+    assert resp.path == str(mov_path)
+    assert resp.media_type == "video/quicktime"
+
+
+@pytest.mark.asyncio
+async def test_get_live_photo_video_past_end_returns_416(tmp_path):
+    jpg_path = tmp_path / "snap.jpg"
+    jpg_path.write_bytes(b"orig")
+    mp4_path = tmp_path / "snap.mp4"
+    mp4_path.write_bytes(b"x" * 20)  # 20-byte video
+
+    photo = _photo(file_path=str(jpg_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(tmp_path / "snap-thumb.mp4")):
+        resp = await media_api.get_live_photo_video(
+            photo_id=photo.id,
+            request=request,
+            range="bytes=200-",
+            db=db,
+        )
+    # 200 >= 20 -> 416
+    assert resp.status_code == 416
+    assert resp.headers["Content-Range"] == "bytes */20"
+
+
+@pytest.mark.asyncio
+async def test_get_live_photo_video_normal_range_returns_206(tmp_path):
+    jpg_path = tmp_path / "snap.jpg"
+    jpg_path.write_bytes(b"orig")
+    mp4_path = tmp_path / "snap.mp4"
+    payload = bytes(range(100))
+    mp4_path.write_bytes(payload)
+
+    photo = _photo(file_path=str(jpg_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = photo
+    request = MagicMock()
+
+    with patch.object(media_api, "_get_thumbnail_path", return_value=str(tmp_path / "snap-thumb.mp4")):
+        resp = await media_api.get_live_photo_video(
+            photo_id=photo.id,
+            request=request,
+            range="bytes=0-9",
+            db=db,
+        )
+    assert isinstance(resp, StreamingResponse)
+    assert resp.status_code == 206
+    assert resp.headers["Content-Length"] == "10"
+    assert resp.media_type == "video/mp4"
+    body = await _consume(resp)
+    assert body == payload[0:10]


### PR DESCRIPTION
## Summary
- Add unit tests for the previously uncovered Range header handler + MIME mapping + live-photo video fallback branches in \pp/api/media.py\.
- Round: 2026-08-25 nightly watch

## Coverage gain
- \pp/api/media.py\: 71% -> 78% (combined with existing nightly tests)
- New module: 23 cases (Range 416, 206 with Content-Range, open-ended Range, invalid-Range fall-back, MIME mapping for 10 extensions, .heic thumbnail redirect, live photo video .jpg sibling walkthrough, HEIC -> .MOV)

## What was tested
- happy path: \get_media_file\ full FileResponse + content-type mapping (10 extensions)
- happy path: \get_media_file\ 206 partial content with correct Content-Range / Content-Length
- edge: open-ended Range \ytes=2-\ uses file_size-1
- error: start past end of file returns 416 with \Content-Range: bytes */N\
- error: malformed Range string falls back to full FileResponse
- error: \.heic\ redirects to thumbnail path
- happy path: \get_live_photo_video\ \.jpg\ -> sibling \.mp4\ if exists
- edge: \.jpg\ with both \.mp4\ and \.mov\ missing -> falls back to thumbnail \.mp4\
- happy path: non-jpg (e.g. \.HEIC\) -> companion \.MOV\ file
- error: live photo 416 for past-end Range

## Context
Server unit regression smoke: 39 passed (16 existing + 23 new), no failures.
Full e2e ran before commit: 300 passed / 4 skipped / 0 failed (7.7m).
Nightly watch run 2026-08-25; no behavioural changes; API/static-analysis clean.

🤖 Generated with Codex