### PR TITLE
test(nightly): stabilize people-p0 flake + close task_worker create_task leak

### DIFF
--- a/package/ai/tests/test_nightly_ai_runtime_boundaries_20260826.py
+++ b/package/ai/tests/test_nightly_ai_runtime_boundaries_20260826.py
@@ -1,0 +1,149 @@
+"""Boundary coverage for AI runtime paths found by the 2026-08-26 gap scan."""
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = pytest.mark.smoke
+
+
+def test_embedding_service_decodes_data_url_images(monkeypatch):
+    from app.services import embedding_service
+
+    service = embedding_service.EmbeddingService.__new__(embedding_service.EmbeddingService)
+    image = b"not-a-real-image"
+    data_url = "data:image/png;base64," + base64.b64encode(image).decode("ascii")
+    wrapper = MagicMock()
+    wrapper.encode_image.return_value.tolist.return_value = [[0.25, 0.5]]
+
+    monkeypatch.setattr(embedding_service.ai_model_manager, "is_ready", lambda _name: True)
+    monkeypatch.setattr(embedding_service.model_manager, "get_model", lambda _name: wrapper)
+    with patch("app.services.embedding_service.Image.open") as open_image:
+        open_image.return_value.convert.return_value = "decoded-image"
+        result = asyncio.run(service.embed_images([data_url]))
+
+    assert result == [[0.25, 0.5]]
+    open_image.assert_called_once()
+    open_image.return_value.convert.assert_called_once_with("RGB")
+
+
+def test_embedding_service_rejects_invalid_image(monkeypatch):
+    from app.services import embedding_service
+
+    service = embedding_service.EmbeddingService.__new__(embedding_service.EmbeddingService)
+    monkeypatch.setattr(embedding_service.ai_model_manager, "is_ready", lambda _name: True)
+    monkeypatch.setattr(embedding_service.model_manager, "get_model", lambda _name: MagicMock())
+    with pytest.raises(Exception, match="Incorrect padding"):
+        asyncio.run(service.embed_images(["not-valid-base64"]))
+
+
+def test_llm_manager_uses_configured_server_executable(monkeypatch, tmp_path):
+    from app.services import llm_manager
+
+    executable = tmp_path / "llama-server"
+    executable.write_bytes(b"x")
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(executable))
+    assert llm_manager.LLMProcessManager._llama_server_executable() == str(executable)
+
+
+def test_llm_manager_stop_releases_running_process(monkeypatch):
+    from app.services import llm_manager
+
+    manager = llm_manager.LLMProcessManager.__new__(llm_manager.LLMProcessManager)
+    manager.lock = asyncio.Lock()
+    process = manager.process = MagicMock()
+    process.poll.side_effect = [None, 0, 0]
+    process.terminate = MagicMock()
+    process.kill = MagicMock()
+
+    asyncio.run(manager.stop())
+
+    process.terminate.assert_called_once_with()
+    assert manager.process is None
+
+
+def test_unified_manager_rejects_duplicate_model_ids(tmp_path, monkeypatch):
+    from app.services.unified_model_manager import UnifiedModelManager
+
+    catalog = {
+        "tasks": {"face": {"name": "Face", "default": "face-a"}},
+        "models": [
+            {
+                "id": "face-a", "tasks": ["face"], "name": "Face A",
+                "runtimeName": "face-a", "localDir": "face-a",
+                "requiredFiles": ["face.onnx"], "repoId": "owner/face",
+            },
+            {
+                "id": "face-a", "tasks": ["face"], "name": "Duplicate",
+                "runtimeName": "duplicate", "localDir": "duplicate",
+                "requiredFiles": ["face.onnx"], "repoId": "owner/dup",
+            },
+        ],
+    }
+    (tmp_path / "catalog.json").write_text(json.dumps(catalog), encoding="utf-8")
+    monkeypatch.setenv("AI_MODEL_CATALOG_PATH", str(tmp_path / "catalog.json"))
+    monkeypatch.setenv("AI_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr("app.services.unified_model_manager.settings.MODEL_PATH", str(tmp_path / "models"))
+
+    with pytest.raises(ValueError, match="重复 id"):
+        UnifiedModelManager()
+
+
+def test_unified_manager_rejects_model_path_traversal(tmp_path, monkeypatch):
+    from app.services.unified_model_manager import UnifiedModelManager
+
+    catalog = {
+        "tasks": {"face": {"name": "Face", "default": "face-a"}},
+        "models": [{
+            "id": "face-a", "tasks": ["face"], "name": "Face A",
+            "runtimeName": "face-a", "localDir": "../escape",
+            "requiredFiles": ["face.onnx"], "repoId": "owner/face",
+        }],
+    }
+    (tmp_path / "catalog.json").write_text(json.dumps(catalog), encoding="utf-8")
+    monkeypatch.setenv("AI_MODEL_CATALOG_PATH", str(tmp_path / "catalog.json"))
+    monkeypatch.setenv("AI_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr("app.services.unified_model_manager.settings.MODEL_PATH", str(tmp_path / "models"))
+
+    with pytest.raises(ValueError, match="localDir 非法"):
+        UnifiedModelManager()
+
+
+def test_image_classification_discovers_only_category_models(tmp_path, monkeypatch):
+    from app.services.image_classification_service import ImageClassificationService
+
+    model_dir = tmp_path / "classification"
+    model_dir.mkdir()
+    (model_dir / "photo-cls-general.onnx").write_bytes(b"x")
+    (model_dir / "photo-cls-animal.onnx").write_bytes(b"x")
+    (model_dir / "notes.txt").write_text("not a model")
+    monkeypatch.setattr(
+        "app.services.image_classification_service.ai_model_manager.get_model_dir",
+        lambda *_args, **_kwargs: model_dir,
+    )
+
+    service = ImageClassificationService.__new__(ImageClassificationService)
+
+    assert service._discover_category_models() == {"animal": "photo-cls-animal.onnx"}
+
+
+def test_ticket_parser_accepts_numeric_train_fallback():
+    from app.services.ticket_parser import parse_ticket_info
+
+    texts = ["7006", "北京南站", "天津站"]
+    polys = [
+        [[0, 0], [20, 0], [20, 10], [0, 10]],
+        [[100, 0], [120, 0], [120, 10], [100, 10]],
+        [[200, 0], [220, 0], [220, 10], [200, 10]],
+    ]
+
+    result = parse_ticket_info(texts, polys)
+
+    assert result["train_code"] == "7006"
+    assert result["departure_station"] == "北京南"
+    assert result["arrival_station"] == "天津"

--- a/package/ai/tests/test_nightly_embedding_service_release_gaps_20260826.py
+++ b/package/ai/tests/test_nightly_embedding_service_release_gaps_20260826.py
@@ -1,0 +1,200 @@
+"""Boundary coverage for EmbeddingService helpers found by the 2026-08-26 gap scan.
+
+Targets the missed-line pockets in app/services/embedding_service.py that the
+existing test_embedding_service.py suite intentionally leaves alone:
+
+* ``EmbeddingService._get_model_info`` (path projection)
+* ``EmbeddingService._release_model`` (text/image/empty wrappers + gc path)
+* the ``except`` branches inside ``embed_texts`` / ``embed_images`` which must
+  log via ``logging.error`` and re-raise the original exception
+
+The heavy modelscope + onnxruntime paths inside ONNXCLIPTextWrapper /
+ONNXCLIPImageWrapper are out of scope — those need real ONNX sessions and are
+covered indirectly by ``test_runtime_lifecycle`` style contracts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+@pytest.fixture
+def embedding_service(monkeypatch):
+    """Return an EmbeddingService with all I/O collaborators stubbed.
+
+    The constructor calls ``_register_models`` which would normally re-bind
+    ``model_manager``. We monkeypatch the dependencies on the module before
+    instantiating so the side-effects stay observable from the tests.
+    """
+
+    registered = []
+
+    def fake_register(name, loader, release):
+        registered.append((name, loader, release))
+
+    fake_manager = MagicMock(register_model=MagicMock(side_effect=fake_register))
+    fake_downloader = MagicMock()
+    fake_downloader.is_ready = MagicMock(return_value=True)
+
+    monkeypatch.setattr("app.services.embedding_service.model_manager", fake_manager)
+    monkeypatch.setattr("app.services.embedding_service.ai_model_manager", fake_downloader)
+
+    from app.services.embedding_service import EmbeddingService
+
+    return EmbeddingService(), registered, fake_manager, fake_downloader
+
+
+def test_get_model_info_returns_text_and_image_subpaths(embedding_service, monkeypatch, tmp_path):
+    service, _, _, _ = embedding_service
+    base = tmp_path / "embedding"
+    text_dir = base / "text"
+    image_dir = base / "image"
+    text_dir.mkdir(parents=True)
+    image_dir.mkdir(parents=True)
+
+    fake_path_manager = MagicMock()
+    fake_path_manager.get_model_dir = MagicMock(return_value=base)
+    monkeypatch.setattr("app.services.embedding_service.ai_model_manager", fake_path_manager)
+
+    info = service._get_model_info()
+
+    assert info == {
+        "text_path": str(text_dir),
+        "image_path": str(image_dir),
+    }
+    fake_path_manager.get_model_dir.assert_called_once_with("embedding", task=True)
+
+
+def test_release_model_clears_text_session_and_tokenizer(embedding_service):
+    service, _, _, _ = embedding_service
+
+    wrapper = MagicMock(spec=["model_dir", "text_session", "tokenizer"])
+    wrapper.model_dir = "fake-text-dir"
+
+    service._release_model(wrapper)
+
+    # ``del wrapper.x`` on a MagicMock-backed spec surfaces as a missing attribute.
+    assert "text_session" not in vars(wrapper)
+    assert "tokenizer" not in vars(wrapper)
+
+
+def test_release_model_clears_vision_session_and_processor(embedding_service):
+    service, _, _, _ = embedding_service
+
+    wrapper = MagicMock(spec=["model_dir", "vision_session", "processor"])
+    wrapper.model_dir = "fake-image-dir"
+
+    service._release_model(wrapper)
+
+    assert "vision_session" not in vars(wrapper)
+    assert "processor" not in vars(wrapper)
+
+
+def test_release_model_handles_wrapper_without_resource_attributes(embedding_service):
+    service, _, _, _ = embedding_service
+
+    bare = MagicMock(spec=["model_dir"])
+    bare.model_dir = "unknown-wrapper"
+
+    # Each ``hasattr`` check on a MagicMock is True; ``del`` removes the
+    # entry from ``__dict__`` afterwards. The path must simply not raise.
+    service._release_model(bare)
+
+    assert bare.model_dir == "unknown-wrapper"
+
+
+def test_release_model_log_resource_name_for_unknown_wrapper(embedding_service, caplog):
+    service, _, _, _ = embedding_service
+
+    unknown = object()  # no .model_dir
+
+    # The production code calls the module-level ``logging.info`` which routes
+    # via the root logger, so we set the capture level there.
+    with caplog.at_level(logging.INFO):
+        service._release_model(unknown)
+
+    assert any("Releasing resources for unknown" in record.getMessage() for record in caplog.records)
+
+
+def test_embed_texts_logs_and_propagates_wrapper_errors(embedding_service, caplog):
+    service, _, fake_manager, _ = embedding_service
+
+    fake_wrapper = MagicMock()
+    fake_wrapper.encode_text = MagicMock(side_effect=RuntimeError("tensor layout mismatch"))
+    fake_manager.get_model = MagicMock(return_value=fake_wrapper)
+
+    with caplog.at_level(logging.ERROR, logger="app.services.embedding_service"):
+        with pytest.raises(RuntimeError, match="tensor layout mismatch"):
+            asyncio.run(service.embed_texts(["hello"]))
+
+    assert any(
+        "Error in text embedding" in record.getMessage() for record in caplog.records
+    )
+
+
+def test_embed_images_logs_and_propagates_wrapper_errors(embedding_service, caplog):
+    service, _, fake_manager, _ = embedding_service
+
+    fake_wrapper = MagicMock()
+    fake_wrapper.encode_image = MagicMock(side_effect=ValueError("pixel_values missing"))
+    fake_manager.get_model = MagicMock(return_value=fake_wrapper)
+
+    with caplog.at_level(logging.ERROR, logger="app.services.embedding_service"):
+        with pytest.raises(ValueError, match="pixel_values missing"):
+            # Tiny 1x1 PNG, decodes fine; the failure is injected via the wrapper.
+            asyncio.run(
+                service.embed_images(
+                    ["iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"]
+                )
+            )
+
+    assert any(
+        "Error in image embedding" in record.getMessage() for record in caplog.records
+    )
+
+
+def test_embed_images_strips_data_url_prefix(embedding_service, monkeypatch):
+    """A comma in the b64 input exercises the ``b64.split(',')[1]`` branch.
+
+    The wrapper is replaced by a MagicMock that records its b64 decoding
+    input, so the assertion verifies that the data URL prefix was stripped
+    before the encoder sees the bytes.
+    """
+    service, _, fake_manager, _ = embedding_service
+
+    sentinel_embedding = MagicMock()
+    sentinel_embedding.tolist.return_value = [[0.7, 0.8]]
+    fake_wrapper = MagicMock()
+    fake_wrapper.encode_image = MagicMock(return_value=sentinel_embedding)
+    fake_manager.get_model = MagicMock(return_value=fake_wrapper)
+
+    captured = {}
+    real_b64decode = __import__("base64").b64decode
+
+    def capturing_b64decode(data, *args, **kwargs):
+        captured["payload"] = data
+        return real_b64decode(data, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.services.embedding_service.base64.b64decode", capturing_b64decode
+    )
+
+    prefix = "data:image/png;base64,"
+    body = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ"
+        "/pLvAAAAAElFTkSuQmCC"
+    )
+
+    result = asyncio.run(service.embed_images([prefix + body]))
+
+    assert result == [[0.7, 0.8]]
+    # The data URL prefix must be stripped before reaching ``b64decode``.
+    assert captured["payload"] == body
+    assert "," not in captured["payload"]

--- a/package/server/tests/unit/test_nightly_agent_memory_gaps_20260826.py
+++ b/package/server/tests/unit/test_nightly_agent_memory_gaps_20260826.py
@@ -1,0 +1,404 @@
+"""Unit tests for app/service/agent/memory.py (2026-08-26 round).
+
+The module owns the photo-anchored long-term memory for the AI agent. The
+functions under test fall into three buckets:
+
+1. Pure helpers (no I/O): ``_parse_extraction_result``, ``_collect_photo_ids``
+2. DB-bound read/write paths we drive with ``MagicMock`` dbs
+   (``load_raw_memory``, ``get_valid_memory_anchors``, ``add_memory_anchor``,
+    ``remove_memory_anchor``, ``build_memory_prompt``)
+3. The background extraction task which talks to an LLM and a real session;
+   we short-circuit the LLM and the session to assert the per-photo dedup
+   and self-healing behaviors.
+"""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.service.agent import memory
+from app.service.agent.memory import (
+    MAX_MEMORY_ANCHORS,
+    MIN_MEMORY_SCORE,
+    _collect_photo_ids,
+    _parse_extraction_result,
+    add_memory_anchor,
+    build_memory_prompt,
+    extract_and_store_memory_task,
+    get_valid_memory_anchors,
+    load_raw_memory,
+    remove_memory_anchor,
+)
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+_PID_A = "11111111-1111-1111-1111-111111111111"
+_PID_B = "22222222-2222-2222-2222-222222222222"
+_PID_C = "33333333-3333-3333-3333-333333333333"
+
+
+# -------------------------------------------------------------------------
+# load_raw_memory / _empty_memory
+# -------------------------------------------------------------------------
+
+
+def test_load_raw_memory_returns_empty_when_no_message():
+    db = MagicMock()
+    with patch.object(memory.agent_crud, "get_memory_message", return_value=None):
+        assert load_raw_memory(db, "u1") == {"version": memory.MEMORY_VERSION, "anchors": []}
+
+
+def test_load_raw_memory_returns_empty_when_content_ext_not_dict():
+    db = MagicMock()
+    msg = SimpleNamespace(content_ext=["not", "a", "dict"])
+    with patch.object(memory.agent_crud, "get_memory_message", return_value=msg):
+        assert load_raw_memory(db, "u1") == {"version": memory.MEMORY_VERSION, "anchors": []}
+
+
+def test_load_raw_memory_returns_empty_when_no_anchors_key():
+    db = MagicMock()
+    msg = SimpleNamespace(content_ext={"foo": "bar"})
+    with patch.object(memory.agent_crud, "get_memory_message", return_value=msg):
+        assert load_raw_memory(db, "u1") == {"version": memory.MEMORY_VERSION, "anchors": []}
+
+
+def test_load_raw_memory_returns_payload_when_present():
+    db = MagicMock()
+    payload = {"version": 1, "anchors": [{"photo_id": _PID_A, "note": "n"}]}
+    msg = SimpleNamespace(content_ext=payload)
+    with patch.object(memory.agent_crud, "get_memory_message", return_value=msg):
+        assert load_raw_memory(db, "u1") is payload
+
+
+# -------------------------------------------------------------------------
+# get_valid_memory_anchors
+# -------------------------------------------------------------------------
+
+
+def test_get_valid_memory_anchors_returns_empty_when_no_anchors():
+    db = MagicMock()
+    with patch.object(memory, "load_raw_memory", return_value={"version": 1, "anchors": []}):
+        assert get_valid_memory_anchors(db, "u1") == []
+
+
+def test_get_valid_memory_anchors_filters_out_deleted_photos():
+    db = MagicMock()
+    anchors = [
+        {"photo_id": _PID_A, "note": "n1"},
+        {"photo_id": _PID_B, "note": "n2"},
+    ]
+    db.query.return_value.filter.return_value.all.return_value = [(_PID_A,)]
+    with patch.object(memory, "load_raw_memory", return_value={"version": 1, "anchors": anchors}):
+        result = get_valid_memory_anchors(db, "u1")
+    assert result == [{"photo_id": _PID_A, "note": "n1"}]
+
+
+def test_get_valid_memory_anchors_self_heals_on_partial_loss():
+    db = MagicMock()
+    anchors = [
+        {"photo_id": _PID_A, "note": "n1"},
+        {"photo_id": _PID_B, "note": "n2"},
+        {"photo_id": _PID_C, "note": "n3"},
+    ]
+    db.query.return_value.filter.return_value.all.return_value = [(_PID_A,), (_PID_C,)]
+    with patch.object(memory, "load_raw_memory", return_value={"version": 1, "anchors": anchors}), \
+         patch.object(memory.agent_crud, "upsert_memory_message") as upsert:
+        result = get_valid_memory_anchors(db, "u1")
+    assert len(result) == 2
+    assert {a["photo_id"] for a in result} == {_PID_A, _PID_C}
+    # The cleaned-up payload should be written back so the next call is fast.
+    upsert.assert_called_once()
+    call_args = upsert.call_args.args
+    assert call_args[1] == "u1"
+    assert {a["photo_id"] for a in call_args[2]["anchors"]} == {_PID_A, _PID_C}
+
+
+def test_get_valid_memory_anchors_swallows_upsert_failure():
+    db = MagicMock()
+    anchors = [
+        {"photo_id": _PID_A, "note": "n1"},
+        {"photo_id": _PID_B, "note": "n2"},
+    ]
+    db.query.return_value.filter.return_value.all.return_value = [(_PID_A,)]
+    with patch.object(memory, "load_raw_memory", return_value={"version": 1, "anchors": anchors}), \
+         patch.object(memory.agent_crud, "upsert_memory_message", side_effect=RuntimeError("db down")):
+        result = get_valid_memory_anchors(db, "u1")
+    # Even if persistence fails, in-memory filter still applies.
+    assert result == [{"photo_id": _PID_A, "note": "n1"}]
+
+
+# -------------------------------------------------------------------------
+# _parse_extraction_result
+# -------------------------------------------------------------------------
+
+
+def test_parse_extraction_result_handles_empty_string():
+    assert _parse_extraction_result("") == []
+    assert _parse_extraction_result(None) == []
+
+
+def test_parse_extraction_result_handles_plain_json():
+    text = '{"memories": [{"photo_id": "x", "note": "y"}]}'
+    assert _parse_extraction_result(text) == [{"photo_id": "x", "note": "y"}]
+
+
+def test_parse_extraction_result_handles_markdown_fence():
+    text = '```json\n{"memories": [{"photo_id": "x", "note": "y"}]}\n```'
+    assert _parse_extraction_result(text) == [{"photo_id": "x", "note": "y"}]
+
+
+def test_parse_extraction_result_handles_garbage_around_json():
+    text = 'Here you go: {"memories": [{"photo_id": "x", "note": "y"}]} cheers!'
+    assert _parse_extraction_result(text) == [{"photo_id": "x", "note": "y"}]
+
+
+def test_parse_extraction_result_returns_empty_on_broken_json():
+    assert _parse_extraction_result("not json at all") == []
+    assert _parse_extraction_result('{"foo": 1}') == []  # missing memories key
+    assert _parse_extraction_result('{"memories": "not a list"}') == []
+
+
+# -------------------------------------------------------------------------
+# _collect_photo_ids
+# -------------------------------------------------------------------------
+
+
+def test_collect_photo_ids_extracts_from_medias_url():
+    reply = f"Here is your photo: /medias/{_PID_A} and another /medias/{_PID_B}"
+    assert _collect_photo_ids(reply, None) == {_PID_A, _PID_B}
+
+
+def test_collect_photo_ids_extracts_from_tool_return_string():
+    reply = ""
+    tool_calls = [{"tool_return": f'{{"photo_id": "{_PID_A}"}},{{"photo_id":"{_PID_B}"}}'}]
+    assert _collect_photo_ids(reply, tool_calls) == {_PID_A, _PID_B}
+
+
+def test_collect_photo_ids_extracts_from_tool_return_dict():
+    reply = ""
+    tool_calls = [{"tool_return": {"photo_id": _PID_A}}]
+    assert _collect_photo_ids(reply, tool_calls) == {_PID_A}
+
+
+def test_collect_photo_ids_returns_empty_when_no_inputs():
+    assert _collect_photo_ids("", None) == set()
+    assert _collect_photo_ids(None, []) == set()
+    assert _collect_photo_ids("nothing here", None) == set()
+
+
+def test_collect_photo_ids_dedupes():
+    reply = f"/medias/{_PID_A}\n/medias/{_PID_A}\n/medias/{_PID_A}"
+    assert _collect_photo_ids(reply, None) == {_PID_A}
+
+
+# -------------------------------------------------------------------------
+# build_memory_prompt
+# -------------------------------------------------------------------------
+
+
+def test_build_memory_prompt_returns_empty_string_when_no_anchors():
+    db = MagicMock()
+    with patch.object(memory, "get_valid_memory_anchors", return_value=[]):
+        assert build_memory_prompt(db, "u1") == ""
+
+
+def test_build_memory_prompt_includes_each_anchor_line():
+    db = MagicMock()
+    anchors = [
+        {
+            "photo_id": _PID_A,
+            "note": " 登顶那天  ",
+            "photo_time": "2024-05-01 10:00:00",
+            "location": "珠穆朗玛峰",
+        },
+        {
+            "photo_id": _PID_B,
+            "note": "生日聚会",
+            "photo_time": None,
+            "location": None,
+        },
+    ]
+    with patch.object(memory, "get_valid_memory_anchors", return_value=anchors):
+        prompt = build_memory_prompt(db, "u1")
+    assert "【关于这位用户的长期记忆】" in prompt
+    assert "登顶那天" in prompt  # whitespace stripped
+    assert _PID_A in prompt
+    assert "时间未知" in prompt
+    assert "地点未知" in prompt
+    assert _PID_B in prompt
+    assert prompt.endswith("\n")
+
+
+# -------------------------------------------------------------------------
+# add_memory_anchor
+# -------------------------------------------------------------------------
+
+
+def _photo_row(photo_id=_PID_A, memory_score=80, narrative="n", address="上海"):
+    photo = SimpleNamespace(id=photo_id, photo_time=datetime(2024, 5, 1, 10, 0, 0))
+    meta = SimpleNamespace(address=address)
+    desc = SimpleNamespace(memory_score=memory_score, narrative=narrative)
+    return photo, meta, desc
+
+
+def test_add_memory_anchor_returns_false_when_photo_missing():
+    db = MagicMock()
+    db.query.return_value.outerjoin.return_value.outerjoin.return_value.filter.return_value.first.return_value = None
+    assert add_memory_anchor(db, "u1", _PID_A, "n") is False
+
+
+def test_add_memory_anchor_rejects_low_memory_score():
+    db = MagicMock()
+    photo, meta, desc = _photo_row(memory_score=MIN_MEMORY_SCORE - 1)
+    db.query.return_value.outerjoin.return_value.outerjoin.return_value.filter.return_value.first.return_value = (
+        photo, meta, desc
+    )
+    assert add_memory_anchor(db, "u1", _PID_A, "n") is False
+
+
+def test_add_memory_anchor_rejects_missing_memory_score():
+    db = MagicMock()
+    photo, meta, desc = _photo_row(memory_score=None)
+    db.query.return_value.outerjoin.return_value.outerjoin.return_value.filter.return_value.first.return_value = (
+        photo, meta, desc
+    )
+    assert add_memory_anchor(db, "u1", _PID_A, "n") is False
+
+
+def test_add_memory_anchor_appends_and_dedupes():
+    db = MagicMock()
+    photo, meta, desc = _photo_row()
+    db.query.return_value.outerjoin.return_value.outerjoin.return_value.filter.return_value.first.return_value = (
+        photo, meta, desc
+    )
+    existing = {
+        "version": memory.MEMORY_VERSION,
+        "anchors": [
+            {"photo_id": _PID_A, "note": "old note", "photo_time": "x", "location": "y"},
+            {"photo_id": _PID_B, "note": "kept", "photo_time": "x", "location": "y"},
+        ],
+    }
+    with patch.object(memory, "load_raw_memory", return_value=existing), \
+         patch.object(memory.agent_crud, "upsert_memory_message") as upsert:
+        ok = add_memory_anchor(db, "u1", _PID_A, "  new note  ")
+    assert ok is True
+    payload = upsert.call_args.args[2]
+    # _PID_A entry replaced with the new note; _PID_B kept
+    by_pid = {a["photo_id"]: a for a in payload["anchors"]}
+    assert set(by_pid.keys()) == {_PID_A, _PID_B}
+    assert by_pid[_PID_A]["note"] == "new note"
+    assert by_pid[_PID_B]["note"] == "kept"
+    # new entry carries the snapshot fields
+    assert by_pid[_PID_A]["photo_time"] == "2024-05-01 10:00:00"
+    assert by_pid[_PID_A]["location"] == "上海"
+    assert "created_at" in by_pid[_PID_A]
+
+
+def test_add_memory_anchor_evicts_oldest_when_over_cap():
+    db = MagicMock()
+    photo, meta, desc = _photo_row()
+    db.query.return_value.outerjoin.return_value.outerjoin.return_value.filter.return_value.first.return_value = (
+        photo, meta, desc
+    )
+    anchors = [
+        {"photo_id": f"pid-{i}", "note": f"n{i}", "photo_time": "t", "location": "L"}
+        for i in range(MAX_MEMORY_ANCHORS)
+    ]
+    existing = {"version": memory.MEMORY_VERSION, "anchors": list(anchors)}
+    with patch.object(memory, "load_raw_memory", return_value=existing), \
+         patch.object(memory.agent_crud, "upsert_memory_message") as upsert:
+        ok = add_memory_anchor(db, "u1", _PID_A, "new")
+    assert ok is True
+    payload = upsert.call_args.args[2]
+    assert len(payload["anchors"]) == MAX_MEMORY_ANCHORS
+    # The oldest anchor (pid-0) was evicted, the rest are FIFO-kept, and _PID_A is the new tail.
+    ids = [a["photo_id"] for a in payload["anchors"]]
+    assert ids[0] == "pid-1"
+    assert ids[-1] == _PID_A
+
+
+# -------------------------------------------------------------------------
+# remove_memory_anchor
+# -------------------------------------------------------------------------
+
+
+def test_remove_memory_anchor_returns_false_when_not_found():
+    db = MagicMock()
+    with patch.object(memory, "load_raw_memory",
+                       return_value={"version": 1, "anchors": [{"photo_id": _PID_A, "note": "n"}]}):
+        assert remove_memory_anchor(db, "u1", _PID_B) is False
+
+
+def test_remove_memory_anchor_removes_and_persists():
+    db = MagicMock()
+    anchors = [
+        {"photo_id": _PID_A, "note": "n1"},
+        {"photo_id": _PID_B, "note": "n2"},
+    ]
+    with patch.object(memory, "load_raw_memory",
+                       return_value={"version": 1, "anchors": list(anchors)}), \
+         patch.object(memory.agent_crud, "upsert_memory_message") as upsert:
+        ok = remove_memory_anchor(db, "u1", _PID_A)
+    assert ok is True
+    payload = upsert.call_args.args[2]
+    assert payload["anchors"] == [{"photo_id": _PID_B, "note": "n2"}]
+
+
+# -------------------------------------------------------------------------
+# extract_and_store_memory_task (background)
+# -------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+
+def test_extract_task_returns_early_when_no_photo_ids_in_reply():
+    with patch.object(memory, "_collect_photo_ids", return_value=set()), \
+         patch.object(memory, "SessionLocal") as sl:
+        extract_and_store_memory_task("u1", "hi", "hello there")
+    sl.assert_not_called()
+
+
+def test_extract_task_returns_early_when_llm_not_configured():
+    db = MagicMock()
+    db.__enter__.return_value = db
+    db.__exit__.return_value = False
+    with patch.object(memory, "_collect_photo_ids", return_value={_PID_A}), \
+         patch.object(memory, "SessionLocal", return_value=db), \
+         patch.object(memory, "_get_extraction_llm", return_value=(None, False)):
+        extract_and_store_memory_task("u1", "hi", f"see /medias/{_PID_A}")
+    # No LLM configured => no anchor side-effects
+    assert db.add.call_count == 0
+
+
+def test_extract_task_persists_each_anchor_through_add_memory_anchor():
+    db = MagicMock()
+    db.__enter__.return_value = db
+    db.__exit__.return_value = False
+    llm = MagicMock()
+    llm.invoke.return_value = _FakeResp(
+        f'{{"memories": [{{"photo_id": "{_PID_A}", "note": "first"}}, '
+        f'{{"photo_id": "{_PID_B}", "note": "second"}}, '
+        f'{{"photo_id": "fake-id-not-in-reply", "note": "ignored"}}]}}'
+    )
+    reply = f"first /medias/{_PID_A} then /medias/{_PID_B}"
+    with patch.object(memory, "_collect_photo_ids", return_value={_PID_A, _PID_B}), \
+         patch.object(memory, "SessionLocal", return_value=db), \
+         patch.object(memory, "_get_extraction_llm", return_value=(llm, True)), \
+         patch.object(memory, "add_memory_anchor") as add_anchor:
+        extract_and_store_memory_task("u1", "hi", reply)
+    # Only the in-reply photo_ids are persisted
+    persisted_pids = [call.args[2] for call in add_anchor.call_args_list]
+    assert persisted_pids == [_PID_A, _PID_B]
+
+
+def test_extract_task_swallows_exception():
+    with patch.object(memory, "_collect_photo_ids",
+                       side_effect=RuntimeError("regex engine broken")):
+        # The background task must not raise.
+        extract_and_store_memory_task("u1", "hi", f"/medias/{_PID_A}")

--- a/package/server/tests/unit/test_nightly_crud_photo_update_metadata_gaps_20260826.py
+++ b/package/server/tests/unit/test_nightly_crud_photo_update_metadata_gaps_20260826.py
@@ -1,0 +1,101 @@
+"""Round 2026-08-26 coverage gaps for app/crud/photo.py update_photo_metadata."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _make_photo(owner_id):
+    return SimpleNamespace(id="photo-1", owner_id=owner_id)
+
+
+def _make_metadata_obj():
+    return SimpleNamespace(photo_id=None, exif_info=None)
+
+
+def test_update_photo_metadata_updates_existing_row_and_skips_trigger_when_no_user():
+    from app.crud import photo as crud
+
+    db = MagicMock()
+    existing = _make_metadata_obj()
+    existing.exif_info = "old"
+
+    update = SimpleNamespace(
+        model_dump=lambda exclude_unset: {"exif_info": "new"},
+    )
+
+    with patch.object(crud, "get_photo_metadata", return_value=existing):
+        result = crud.update_photo_metadata(db, "photo-1", update, user_id=None)
+
+    assert result is existing
+    assert existing.exif_info == "new"
+    db.commit.assert_called_once()
+    db.refresh.assert_called_once_with(existing)
+
+
+def test_update_photo_metadata_returns_none_when_photo_missing():
+    from app.crud import photo as crud
+
+    db = MagicMock()
+
+    update = SimpleNamespace(model_dump=lambda exclude_unset: {"exif_info": "x"})
+
+    with patch.object(crud, "get_photo_metadata", return_value=None), \
+         patch.object(crud, "get_photo", return_value=None):
+        result = crud.update_photo_metadata(db, "missing", update, user_id="u")
+
+    assert result is None
+    db.commit.assert_not_called()
+
+
+def test_update_photo_metadata_creates_new_row_when_metadata_missing():
+    from app.crud import photo as crud
+
+    db = MagicMock()
+    photo_obj = _make_photo("user-x")
+
+    update = SimpleNamespace(model_dump=lambda exclude_unset: {"exif_info": "fresh"})
+
+    with patch.object(crud, "get_photo_metadata", return_value=None), \
+         patch.object(crud, "get_photo", return_value=photo_obj), \
+         patch.object(crud, "PhotoMetadata", SimpleNamespace):
+        result = crud.update_photo_metadata(db, "photo-1", update, user_id=None)
+
+    db.commit.assert_called_once()
+    db.refresh.assert_called_once()
+    assert result is not None
+
+
+def test_update_photo_metadata_returns_none_when_user_does_not_own_photo():
+    from app.crud import photo as crud
+
+    db = MagicMock()
+    photo_obj = _make_photo(owner_id="user-other")
+
+    update = SimpleNamespace(model_dump=lambda exclude_unset: {"exif_info": "x"})
+
+    with patch.object(crud, "get_photo_metadata", return_value=None), \
+         patch.object(crud, "get_photo", return_value=photo_obj):
+        result = crud.update_photo_metadata(db, "photo-1", update, user_id="user-self")
+
+    assert result is None
+    db.commit.assert_not_called()
+
+
+def test_update_photo_metadata_triggers_conditional_albums_update_for_owned_photo():
+    from app.crud import photo as crud
+
+    db = MagicMock()
+    existing = _make_metadata_obj()
+
+    update = SimpleNamespace(model_dump=lambda exclude_unset: {"exif_info": "y"})
+
+    with patch.object(crud, "get_photo_metadata", return_value=existing), \
+         patch("app.crud.album.trigger_conditional_albums_update") as trigger:
+        crud.update_photo_metadata(db, "photo-1", update, user_id="user-1")
+
+    trigger.assert_called_once_with(db, "user-1", ["photo-1"])

--- a/package/server/tests/unit/test_nightly_day_caption_lock_tz_gaps_20260826.py
+++ b/package/server/tests/unit/test_nightly_day_caption_lock_tz_gaps_20260826.py
@@ -1,0 +1,52 @@
+"""Round 2026-08-26 coverage gaps for day_caption_service."""
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_moment]
+
+
+def test_get_user_lock_creates_and_caches_per_user_id():
+    from app.service.moment import day_caption_service as svc
+
+    svc._user_locks.clear()
+
+    async def runner():
+        a1 = await svc._get_user_lock("user-a")
+        a2 = await svc._get_user_lock("user-a")
+        b1 = await svc._get_user_lock("user-b")
+        return a1, a2, b1
+
+    a1, a2, b1 = asyncio.run(runner())
+
+    assert isinstance(a1, asyncio.Lock)
+    assert a1 is a2
+    assert a1 is not b1
+
+
+def test_resolve_tz_returns_utc_for_empty_tz_name():
+    from app.service.moment import day_caption_service as svc
+
+    assert svc._resolve_tz("") == timezone.utc
+
+
+def test_resolve_tz_returns_utc_for_invalid_timezone():
+    from app.service.moment import day_caption_service as svc
+
+    assert svc._resolve_tz("Not/A_Real_Zone") == timezone.utc
+
+
+def test_day_bounds_utc_returns_naive_day_window():
+    from datetime import date
+    from app.service.moment import day_caption_service as svc
+
+    day = date(2026, 8, 26)
+    start, end = svc.day_bounds_utc(day, "Asia/Shanghai")
+
+    assert start == datetime(2026, 8, 26, 0, 0, 0)
+    assert end == datetime(2026, 8, 27, 0, 0, 0)
+    assert start.tzinfo is None
+    assert end.tzinfo is None

--- a/package/server/tests/unit/test_nightly_face_cluster_analyze_gaps_20260826.py
+++ b/package/server/tests/unit/test_nightly_face_cluster_analyze_gaps_20260826.py
@@ -1,0 +1,90 @@
+"""Round 2026-08-26 coverage for app/service/face_cluster.py analyze_identity_rescan."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+def _service(db):
+    from app.service.face_cluster import FaceClusterService
+
+    return FaceClusterService(db=db, user_id=None)
+
+
+def _face(id_, feature):
+    return SimpleNamespace(
+        id=id_,
+        face_feature=feature,
+        is_deleted=False,
+        is_manually_confirmed=False,
+        recognize_confidence=None,
+    )
+
+
+def _chain_query(all_value):
+    q = MagicMock()
+    q.filter.return_value = q
+    q.join.return_value = q
+    q.order_by.return_value = q
+    q.with_for_update.return_value = q
+    q.all.return_value = all_value
+    return q
+
+
+def test_analyze_identity_rescan_returns_no_reference_faces_summary_when_empty():
+    db = MagicMock(name="db")
+    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    db.query.return_value = _chain_query([])
+
+    svc = _service(db)
+    identity_id = "ident-1"
+    summary = svc._analyze_identity_rescan(identity_id, owner_id=None, lock=False)
+
+    assert summary["identity_id"] == identity_id
+    assert summary["reason"] == "no_reference_faces"
+    assert summary["prototypes"] == []
+    assert summary["add_candidates"] == []
+    assert summary["remove_candidates"] == []
+    assert summary["removal_threshold"] == svc.RESCAN_REMOVAL_THRESHOLD
+
+
+def test_analyze_identity_rescan_no_remove_candidates_when_under_threshold():
+    db = MagicMock(name="db")
+    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    faces = [
+        _face(101, np.array([1.0, 0.0, 0.0])),
+        _face(102, np.array([1.0, 0.0, 0.0])),
+    ]
+    db.query.return_value = _chain_query(faces)
+
+    identity = SimpleNamespace(default_face_id=None)
+
+    with patch("app.service.face_cluster.crud_face.get_identity", return_value=identity):
+        svc = _service(db)
+        out = svc._analyze_identity_rescan("ident-2", owner_id=None, lock=False)
+
+    assert out["remove_candidates"] == []
+    assert isinstance(out["prototypes"], list)
+
+
+def test_analyze_identity_rescan_with_owner_id_adds_extra_filter():
+    """owner_id set -> the query gains an extra ``.filter(Photo.owner_id == ...)``."""
+    db = MagicMock(name="db")
+    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    q = _chain_query([])
+    db.query.return_value = q
+
+    svc = _service(db)
+    # Baseline: no owner_id -> 1 filter call.
+    svc._analyze_identity_rescan("ident-3", owner_id=None, lock=False)
+    baseline = q.filter.call_count
+    # With owner_id -> the owner branch adds exactly one extra filter.
+    svc._analyze_identity_rescan("ident-4", owner_id="owner-xyz", lock=False)
+    delta = q.filter.call_count - baseline
+    # Filter by owner_id adds at least one extra filter call.
+    assert delta >= 1

--- a/package/server/tests/unit/test_nightly_organize_strategies_gaps_20260826.py
+++ b/package/server/tests/unit/test_nightly_organize_strategies_gaps_20260826.py
@@ -1,0 +1,257 @@
+"""Round 2026-08-26 coverage gaps for ``app/service/tasks/organize.py``."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def _chain(photos):
+    query = MagicMock()
+    query.filter.return_value = query
+    query.options.return_value = query
+    query.all.return_value = photos
+    return query
+
+
+def _build_task(payload):
+    return SimpleNamespace(
+        id="task-org-26",
+        type="ORGANIZE_PHOTOS",
+        owner_id="user-26",
+        payload=payload,
+        total_items=0,
+        processed_items=0,
+        result=None,
+        status=None,
+    )
+
+
+def _photo(path, **attrs):
+    filename = path.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
+    defaults = dict(
+        file_path=path,
+        filename=filename,
+        photo_time=None,
+        upload_time=None,
+        is_deleted=False,
+        faces=[],
+        tags=[],
+        metadata_info=None,
+    )
+    defaults.update(attrs)
+    return SimpleNamespace(**defaults)
+
+
+def test_time_strategy_ym_flat_builds_year_month_folder(tmp_path):
+    """time_format='flat' + time_granularity='ym' -> YYYY-MM."""
+    from app.service.tasks import organize
+
+    import datetime
+    photo = _photo(
+        str(tmp_path / "img.jpg"),
+        photo_time=datetime.datetime(2024, 5, 7),
+    )
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "time",
+        "action": "move",
+        "time_granularity": "ym",
+        "time_format": "flat",
+    })
+
+    with patch.object(organize.os.path, "exists", return_value=True), \
+         patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "move") as move:
+        import asyncio
+        result = asyncio.run(
+            organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db)
+        )
+
+    move.assert_called_once()
+    called_dst = move.call_args[0][1].replace("\\", "/")
+    parts = called_dst.split("/")
+    assert "2024-05" in parts
+    assert task.processed_items == 1
+    assert result["success_count"] == 1
+
+
+def test_time_strategy_time_range_skips_out_of_window_photo(tmp_path):
+    """Photos outside time_range advance processed_items but do not move."""
+    from app.service.tasks import organize
+
+    photo = _photo(
+        str(tmp_path / "old.jpg"),
+        photo_time=SimpleNamespace(strftime=lambda fmt: "2020-01-01 00:00:00"),
+    )
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "time",
+        "action": "move",
+        "time_range": ["2024-01-01", "2024-12-31"],
+    })
+
+    with patch.object(organize.os.path, "exists", return_value=True), \
+         patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "move") as move:
+        import asyncio
+        result = asyncio.run(
+            organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db)
+        )
+
+    move.assert_not_called()
+    assert task.processed_items == 1
+    assert result["success_count"] == 0
+
+
+def test_category_strategy_move_picks_top_confidence_tag(tmp_path):
+    """action='move' uses the highest-confidence tag for the subfolder."""
+    from app.service.tasks import organize
+
+    photo = _photo(
+        str(tmp_path / "p.jpg"),
+        tags=[
+            SimpleNamespace(tag_name="beach", confidence=0.4),
+            SimpleNamespace(tag_name="mountain", confidence=0.9),
+            SimpleNamespace(tag_name="city", confidence=0.6),
+        ],
+    )
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "category",
+        "action": "move",
+    })
+
+    with patch.object(organize.os.path, "exists", return_value=True), \
+         patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "move") as move:
+        import asyncio
+        result = asyncio.run(
+            organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db)
+        )
+
+    move.assert_called_once()
+    called_dst = move.call_args[0][1].replace("\\", "/")
+    parts = called_dst.split("/")
+    assert "mountain" in parts
+    assert result["success_count"] == 1
+
+
+def test_location_strategy_province_city_district_nested_format(tmp_path):
+    """province_city_district + nested format builds full path."""
+    from app.service.tasks import organize
+
+    photo = _photo(
+        str(tmp_path / "p.jpg"),
+        metadata_info=SimpleNamespace(
+            province="\u6e56\u5317\u7701",
+            city="\u6b66\u6c49\u5e02",
+            district="\u6b66\u660c\u533a",
+        ),
+    )
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "location",
+        "action": "move",
+        "location_granularity": "province_city_district",
+        "location_format": "nested",
+    })
+
+    with patch.object(organize.os.path, "exists", return_value=True), \
+         patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "move") as move:
+        import asyncio
+        result = asyncio.run(
+            organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db)
+        )
+
+    move.assert_called_once()
+    called_dst = move.call_args[0][1].replace("\\", "/")
+    parts = called_dst.split("/")
+    assert "\u6e56\u5317\u7701" in parts
+    assert "\u6b66\u6c49\u5e02" in parts
+    assert "\u6b66\u660c\u533a" in parts
+    assert result["success_count"] == 1
+
+
+def test_location_strategy_city_only_granularity(tmp_path):
+    """location_granularity='city' ignores province/district when building subfolder."""
+    from app.service.tasks import organize
+
+    photo = _photo(
+        str(tmp_path / "p.jpg"),
+        metadata_info=SimpleNamespace(
+            province="\u6e56\u5317\u7701",
+            city="\u6b66\u6c49\u5e02",
+            district="\u6b66\u660c\u533a",
+        ),
+    )
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "location",
+        "action": "move",
+        "location_granularity": "city",
+        "location_format": "flat",
+    })
+
+    with patch.object(organize.os.path, "exists", return_value=True), \
+         patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "move") as move:
+        import asyncio
+        asyncio.run(
+            organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db)
+        )
+
+    move.assert_called_once()
+    called_dst = move.call_args[0][1].replace("\\", "/")
+    parts = called_dst.split("/")
+    assert "\u6b66\u6c49\u5e02" in parts
+    assert "\u6e56\u5317\u7701" not in parts
+    assert "\u6b66\u660c\u533a" not in parts
+
+
+def test_location_strategy_locations_filter_drops_unmatched(tmp_path):
+    """locations whitelist restricts which subfolders survive dedup."""
+    from app.service.tasks import organize
+
+    photo = _photo(
+        str(tmp_path / "p.jpg"),
+        metadata_info=SimpleNamespace(province=None, city="\u6b66\u6c49\u5e02", district=None),
+    )
+    # The copy branch instantiates Photo(...). Provide a stub __table__.columns
+    # so the comprehension over photo.__table__.columns does not blow up.
+    fake_table_columns = [SimpleNamespace(name=k) for k in ("id", "file_path", "filename")]
+    photo.__table__ = SimpleNamespace(columns=fake_table_columns)
+    db = MagicMock()
+    db.query.return_value = _chain([photo])
+    task = _build_task({
+        "target_root_path": str(tmp_path / "out"),
+        "strategy": "location",
+        "action": "copy",
+        "location_granularity": "city",
+        "locations": ["\u5317\u4eac\u5e02"],  # does not include \u6b66\u6c49\u5e02
+    })
+
+    with patch.object(organize.os.path, "exists", return_value=True), \
+         patch.object(organize.os, "makedirs"), \
+         patch.object(organize.shutil, "copy2") as copy:
+        import asyncio
+        asyncio.run(
+            organize.OrganizePhotosStrategy().process(worker=None, task=task, db=db)
+        )
+
+    # locations=['\u5317\u4eac\u5e02'] filters out \u6b66\u6c49\u5e02 -> no copy
+    copy.assert_not_called()

--- a/package/server/tests/unit/test_nightly_task_worker_gaps_20260815.py
+++ b/package/server/tests/unit/test_nightly_task_worker_gaps_20260815.py
@@ -187,11 +187,18 @@ async def test_start_creates_process_and_thread_pools_and_recover():
     fake_thread = MagicMock()
 
     # Avoid touching the real DB during _recover_unfinished_tasks.
+    # Patched ``asyncio.create_task`` must close the coroutine it receives, otherwise the
+    # un-awaited ``worker_loop`` / ``result_loop`` / ``consumer_loop`` coroutines linger
+    # in pytest-asyncio's event loop and hang pytest teardown (memory 2026-08-19, 5 rounds).
+    def _drop_and_mock_task(coro):
+        coro.close()
+        return MagicMock()
+
     with patch.object(worker, "_recover_unfinished_tasks"), \
          patch.object(worker, "_load_system_state", return_value=False), \
          patch.object(task_worker.concurrent.futures, "ProcessPoolExecutor", return_value=fake_pool), \
          patch.object(task_worker.concurrent.futures, "ThreadPoolExecutor", return_value=fake_thread), \
-         patch("asyncio.create_task", return_value=MagicMock()):
+         patch("asyncio.create_task", side_effect=_drop_and_mock_task):
         worker.start()
 
     assert worker.running is True

--- a/package/server/tests/unit/test_nightly_update_checker_gaps_20260826.py
+++ b/package/server/tests/unit/test_nightly_update_checker_gaps_20260826.py
@@ -1,0 +1,371 @@
+"""Unit tests for app/service/update_checker.py (2026-08-26 round).
+
+Covers the version compare helper, the aiohttp fetch path, and the
+``UpdateCheckScheduler.tick`` body that persists UPDATE notifications.
+
+The module is essentially side-effect free at the function-call level:
+  * ``compare_versions`` is pure
+  * ``fetch_remote_update_info`` only talks to aiohttp
+  * ``tick`` delegates to ``SessionLocal`` / ``crud_notification`` /
+    ``crud_user`` / ``NotificationManager`` / ``SystemState``.
+
+We mock the network and DB seams to drive the positive and negative
+branches without touching Postgres.
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.service import update_checker
+from app.service.update_checker import (
+    DEFAULT_UPDATE_URL,
+    LAST_NOTIFIED_KEY,
+    UpdateCheckScheduler,
+    compare_versions,
+    fetch_remote_update_info,
+)
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+# -------------------------------------------------------------------------
+# compare_versions
+# -------------------------------------------------------------------------
+
+
+def test_compare_versions_returns_zero_for_empty_inputs():
+    assert compare_versions("", "") == 0
+    assert compare_versions("1.0.0", "") == 0
+    assert compare_versions("", "1.0.0") == 0
+
+
+def test_compare_versions_returns_zero_for_invalid_format():
+    assert compare_versions("a.b.c", "1.0.0") == 0
+    assert compare_versions("1.0.0", "1.0.0-rc.1") == 0
+
+
+def test_compare_versions_handles_equal_strings():
+    assert compare_versions("1.2.3", "1.2.3") == 0
+
+
+def test_compare_versions_major_minor_patch():
+    assert compare_versions("2.0.0", "1.99.99") == 1
+    assert compare_versions("1.99.99", "2.0.0") == -1
+    assert compare_versions("1.2.3", "1.2.4") == -1
+    assert compare_versions("1.2.4", "1.2.3") == 1
+
+
+def test_compare_versions_pads_shorter_segment():
+    assert compare_versions("1.0", "1.0.0") == 0
+    assert compare_versions("1.0.1", "1.0") == 1
+    assert compare_versions("1.0", "1.0.1") == -1
+
+
+# -------------------------------------------------------------------------
+# fetch_remote_update_info (async)
+# -------------------------------------------------------------------------
+
+
+def _build_response(status, payload):
+    response = AsyncMock()
+    response.status = status
+    response.__aenter__.return_value = response
+    response.__aexit__.return_value = False
+    response.json = AsyncMock(return_value=payload)
+    return response
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_fetch_remote_returns_none_on_non_200():
+    session = MagicMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = False
+    session.get = MagicMock(return_value=_build_response(500, {}))
+
+    with patch.object(update_checker.aiohttp, "ClientSession", return_value=session):
+        result = _run(fetch_remote_update_info(url="https://example.com/v.json"))
+
+    assert result is None
+
+
+def test_fetch_remote_returns_none_on_non_list_payload():
+    session = MagicMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = False
+    session.get = MagicMock(return_value=_build_response(200, {"version": "1.0"}))
+
+    with patch.object(update_checker.aiohttp, "ClientSession", return_value=session):
+        result = _run(fetch_remote_update_info(url="https://example.com/v.json"))
+
+    assert result is None
+
+
+def test_fetch_remote_returns_none_on_empty_list():
+    session = MagicMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = False
+    session.get = MagicMock(return_value=_build_response(200, []))
+
+    with patch.object(update_checker.aiohttp, "ClientSession", return_value=session):
+        result = _run(fetch_remote_update_info(url="https://example.com/v.json"))
+
+    assert result is None
+
+
+def test_fetch_remote_returns_no_update_when_remote_not_newer():
+    payload = [{"version": "0.9.0", "download_url": "x", "update_info": "old"}]
+    session = MagicMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = False
+    session.get = MagicMock(return_value=_build_response(200, payload))
+
+    with patch.object(update_checker.aiohttp, "ClientSession", return_value=session):
+        result = _run(
+            fetch_remote_update_info(url="https://example.com/v.json", current_version="1.0.0")
+        )
+
+    assert result is not None
+    assert result["latest_version"] == "0.9.0"
+    assert result["has_update"] is False
+    assert result["update_info"] == ""
+    assert result["download_url"] == "x"
+
+
+def test_fetch_remote_returns_update_payload_with_changelog():
+    payload = [
+        {"version": "1.0.0", "download_url": "u1", "update_info": "old notes"},
+        {"version": "1.1.0", "download_url": "u2", "update_info": "new in 1.1"},
+        {"version": "1.2.0", "download_url": "u3", "update_info": "new in 1.2"},
+    ]
+    session = MagicMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = False
+    session.get = MagicMock(return_value=_build_response(200, payload))
+
+    with patch.object(update_checker.aiohttp, "ClientSession", return_value=session):
+        result = _run(
+            fetch_remote_update_info(url="https://example.com/v.json", current_version="1.0.0")
+        )
+
+    assert result is not None
+    assert result["latest_version"] == "1.2.0"
+    assert result["has_update"] is True
+    assert "1.1.0" in result["update_info"]
+    assert "1.2.0" in result["update_info"]
+    assert result["download_url"] == "u3"
+
+
+def test_fetch_remote_returns_none_on_exception():
+    session = MagicMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.side_effect = RuntimeError("boom")
+
+    with patch.object(update_checker.aiohttp, "ClientSession", return_value=session):
+        result = _run(fetch_remote_update_info(url="https://example.com/v.json"))
+
+    assert result is None
+
+
+# -------------------------------------------------------------------------
+# UpdateCheckScheduler.tick
+# -------------------------------------------------------------------------
+
+
+def test_tick_returns_early_when_fetch_returns_none():
+    sched = UpdateCheckScheduler(url="https://example.com/v.json")
+    with patch.object(update_checker.asyncio, "run", return_value=None):
+        sched.tick()
+
+
+def test_tick_returns_early_when_fetch_raises():
+    sched = UpdateCheckScheduler(url="https://example.com/v.json")
+    with patch.object(update_checker.asyncio, "run", side_effect=RuntimeError("net down")):
+        sched.tick()
+
+
+def test_tick_returns_early_when_no_update():
+    sched = UpdateCheckScheduler(url="https://example.com/v.json")
+    info = {"latest_version": "0.9.0", "has_update": False,
+            "update_info": "", "download_url": None}
+    with patch.object(update_checker.asyncio, "run", return_value=info), \
+         patch.object(update_checker, "SessionLocal") as session_local:
+        sched.tick()
+    session_local.assert_not_called()
+
+
+def test_tick_returns_early_when_latest_version_empty():
+    sched = UpdateCheckScheduler(url="https://example.com/v.json")
+    info = {"latest_version": "", "has_update": True,
+            "update_info": "x", "download_url": None}
+    with patch.object(update_checker.asyncio, "run", return_value=info), \
+         patch.object(update_checker, "SessionLocal") as session_local:
+        sched.tick()
+    session_local.assert_not_called()
+
+
+def test_tick_returns_early_when_already_notified_newer_version():
+    sched = UpdateCheckScheduler(url="https://example.com/v.json")
+    info = {"latest_version": "1.2.0", "has_update": True,
+            "update_info": "x", "download_url": "u"}
+    db = MagicMock()
+    with patch.object(update_checker.asyncio, "run", return_value=info), \
+         patch.object(update_checker, "SessionLocal", return_value=db), \
+         patch.object(update_checker, "_load_last_notified", return_value="1.5.0"), \
+         patch.object(update_checker, "crud_user") as crud_user, \
+         patch.object(update_checker, "crud_notification") as crud_n:
+        sched.tick()
+    crud_user.get_all_users.assert_not_called()
+    crud_n.create_notification.assert_not_called()
+    db.close.assert_not_called()
+
+
+def test_tick_notifies_each_user_and_persists_last_notified():
+    sched = UpdateCheckScheduler(url="https://example.com/v.json")
+    info = {
+        "latest_version": "1.2.0",
+        "has_update": True,
+        "update_info": "stuff",
+        "download_url": "https://dl",
+    }
+    db = MagicMock()
+    u1 = SimpleNamespace(id="u1")
+    u2 = SimpleNamespace(id="u2")
+    notification_obj = SimpleNamespace(id="n1")
+    serialized = {"id": "n1", "title": "x"}
+    manager = MagicMock()
+
+    with patch.object(update_checker.asyncio, "run", return_value=info), \
+         patch.object(update_checker, "SessionLocal", return_value=db), \
+         patch.object(update_checker, "_load_last_notified", return_value=None), \
+         patch.object(update_checker, "crud_user") as crud_user, \
+         patch.object(update_checker, "crud_notification") as crud_n, \
+         patch.object(update_checker, "NotificationManager") as nm_cls, \
+         patch.object(update_checker, "_save_last_notified") as save_last:
+        crud_user.get_all_users.return_value = [u1, u2]
+        crud_n.create_notification.return_value = notification_obj
+        crud_n._serialize.return_value = serialized
+        nm_cls.get_instance.return_value = manager
+
+        sched.tick()
+
+    assert crud_n.create_notification.call_count == 2
+    assert manager.publish_to_user.call_count == 2
+    save_last.assert_called_once_with("1.2.0")
+    db.commit.assert_called()
+    db.close.assert_called_once()
+
+
+def test_tick_returns_early_when_no_users():
+    sched = UpdateCheckScheduler(url="https://example.com/v.json")
+    info = {
+        "latest_version": "1.2.0",
+        "has_update": True,
+        "update_info": "stuff",
+        "download_url": None,
+    }
+    db = MagicMock()
+    with patch.object(update_checker.asyncio, "run", return_value=info), \
+         patch.object(update_checker, "SessionLocal", return_value=db), \
+         patch.object(update_checker, "_load_last_notified", return_value=None), \
+         patch.object(update_checker, "crud_user") as crud_user, \
+         patch.object(update_checker, "crud_notification") as crud_n, \
+         patch.object(update_checker, "NotificationManager") as nm_cls, \
+         patch.object(update_checker, "_save_last_notified") as save_last:
+        crud_user.get_all_users.return_value = []
+        sched.tick()
+    crud_n.create_notification.assert_not_called()
+    save_last.assert_not_called()
+    db.close.assert_called_once()
+
+
+def test_tick_swallows_per_user_failure_and_still_persists():
+    sched = UpdateCheckScheduler(url="https://example.com/v.json")
+    info = {
+        "latest_version": "1.2.0",
+        "has_update": True,
+        "update_info": "x",
+        "download_url": None,
+    }
+    db = MagicMock()
+    u1 = SimpleNamespace(id="u1")
+    u2 = SimpleNamespace(id="u2")
+    n1 = SimpleNamespace(id="n1")
+    manager = MagicMock()
+
+    with patch.object(update_checker.asyncio, "run", return_value=info), \
+         patch.object(update_checker, "SessionLocal", return_value=db), \
+         patch.object(update_checker, "_load_last_notified", return_value=None), \
+         patch.object(update_checker, "crud_user") as crud_user, \
+         patch.object(update_checker, "crud_notification") as crud_n, \
+         patch.object(update_checker, "NotificationManager") as nm_cls, \
+         patch.object(update_checker, "_save_last_notified") as save_last:
+        crud_user.get_all_users.return_value = [u1, u2]
+        crud_n.create_notification.side_effect = [RuntimeError("u1 boom"), n1]
+        crud_n._serialize.return_value = {"id": "n1"}
+        nm_cls.get_instance.return_value = manager
+
+        sched.tick()
+
+    assert crud_n.create_notification.call_count == 2
+    save_last.assert_called_once_with("1.2.0")
+
+
+# -------------------------------------------------------------------------
+# _load_last_notified / _save_last_notified
+# -------------------------------------------------------------------------
+
+
+def test_load_last_notified_returns_value_when_row_present():
+    db = MagicMock()
+    row = SimpleNamespace(value="1.2.0")
+    db.query.return_value.filter.return_value.first.return_value = row
+    with patch.object(update_checker, "SessionLocal", return_value=db):
+        assert update_checker._load_last_notified() == "1.2.0"
+    db.close.assert_called_once()
+
+
+def test_load_last_notified_returns_none_when_no_row():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    with patch.object(update_checker, "SessionLocal", return_value=db):
+        assert update_checker._load_last_notified() is None
+    db.close.assert_called_once()
+
+
+def test_load_last_notified_returns_none_on_exception():
+    with patch.object(update_checker, "SessionLocal", side_effect=RuntimeError("db down")):
+        assert update_checker._load_last_notified() is None
+
+
+def test_save_last_notified_updates_existing_row():
+    db = MagicMock()
+    existing = SimpleNamespace(value="1.0.0")
+    db.query.return_value.filter.return_value.first.return_value = existing
+    with patch.object(update_checker, "SessionLocal", return_value=db):
+        update_checker._save_last_notified("1.2.0")
+    assert existing.value == "1.2.0"
+    db.commit.assert_called_once()
+    db.close.assert_called_once()
+
+
+def test_save_last_notified_inserts_when_no_row():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    with patch.object(update_checker, "SessionLocal", return_value=db), \
+         patch.object(update_checker, "SystemState") as ss:
+        update_checker._save_last_notified("1.2.0")
+    ss.assert_called_once_with(key=LAST_NOTIFIED_KEY, value="1.2.0")
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    db.close.assert_called_once()
+
+
+def test_save_last_notified_swallows_exception():
+    with patch.object(update_checker, "SessionLocal", side_effect=RuntimeError("db down")):
+        update_checker._save_last_notified("1.2.0")

--- a/package/server/tests/unit/test_nightly_utils_exif_gaps_20260826.py
+++ b/package/server/tests/unit/test_nightly_utils_exif_gaps_20260826.py
@@ -1,0 +1,288 @@
+"""Unit tests for app/utils/exif.py (2026-08-26 round).
+
+Coverage gaps were concentrated in three functions we can drive with plain
+inputs:
+  * ``_convert_to_degrees`` -- pure helper for the GPS tuple arithmetic
+  * ``get_gps_info`` -- shaped EXIF dict -> (lat, lng) or None
+  * ``get_file_time_form_system`` -- os.stat wrapper with a fallback
+
+``extract_metadata`` touches PIL + reverse_geocoder, so we exercise it with
+a stub image and a stub reverse-geocoder.
+"""
+import os
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utils import exif
+from app.utils.exif import (
+    _convert_to_degrees,
+    extract_metadata,
+    get_exif_data,
+    get_file_time_form_system,
+    get_gps_info,
+    reverse_geocode,
+)
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+# -------------------------------------------------------------------------
+# _convert_to_degrees
+# -------------------------------------------------------------------------
+
+
+def test_convert_handles_simple_floats():
+    assert _convert_to_degrees((30, 0, 0)) == 30.0
+
+
+def test_convert_handles_dms_tuple():
+    # 30 deg 15 min 45 sec = 30 + 15/60 + 45/3600 = 30.2625
+    assert _convert_to_degrees((30, 15, 45)) == pytest.approx(30.2625)
+
+
+def test_convert_handles_fraction_tuples():
+    # EXIF stores 30 deg 15 min 45/2 sec
+    # 30 + 15/60 + (45/2)/3600 = 30 + 0.25 + 0.00625 = 30.25625
+    assert _convert_to_degrees(((30, 1), (15, 1), (45, 2))) == pytest.approx(30.25625)
+
+
+def test_convert_handles_zero_denominator():
+    # Guard against division by zero on malformed EXIF.
+    assert _convert_to_degrees(((1, 0), (2, 1), (3, 1))) == pytest.approx(2.0 / 60 + 3.0 / 3600)
+
+
+def test_convert_handles_ifd_rational_fallback():
+    class _Rat:
+        def __init__(self, num, den):
+            self.numerator = num
+            self.denominator = den
+
+    val = (_Rat(30, 1), _Rat(15, 1), _Rat(0, 1))
+    assert _convert_to_degrees(val) == pytest.approx(30.25)
+
+
+# -------------------------------------------------------------------------
+# get_gps_info
+# -------------------------------------------------------------------------
+
+
+def test_get_gps_info_returns_none_when_no_gps_section():
+    assert get_gps_info({"DateTimeOriginal": "2024:01:01 12:00:00"}) is None
+
+
+def test_get_gps_info_returns_lat_lng_in_north_east_hemi():
+    exif_dict = {
+        "GPSInfo": {
+            "GPSLatitude": (30, 0, 0),
+            "GPSLatitudeRef": "N",
+            "GPSLongitude": (120, 0, 0),
+            "GPSLongitudeRef": "E",
+        }
+    }
+    assert get_gps_info(exif_dict) == {"latitude": 30.0, "longitude": 120.0}
+
+
+def test_get_gps_info_negates_for_south_or_west_hemi():
+    exif_dict = {
+        "GPSInfo": {
+            "GPSLatitude": (30, 0, 0),
+            "GPSLatitudeRef": "S",
+            "GPSLongitude": (120, 0, 0),
+            "GPSLongitudeRef": "W",
+        }
+    }
+    result = get_gps_info(exif_dict)
+    assert result["latitude"] == -30.0
+    assert result["longitude"] == -120.0
+
+
+def test_get_gps_info_returns_none_when_partial():
+    exif_dict = {
+        "GPSInfo": {
+            "GPSLatitude": (30, 0, 0),
+            "GPSLatitudeRef": "N",
+        }
+    }
+    assert get_gps_info(exif_dict) is None
+
+
+# -------------------------------------------------------------------------
+# get_file_time_form_system
+# -------------------------------------------------------------------------
+
+
+def test_get_file_time_returns_stat_mtime(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("x")
+    mtime = os.stat(p).st_mtime
+    assert get_file_time_form_system(str(p)) == datetime.fromtimestamp(mtime)
+
+
+def test_get_file_time_falls_back_to_now_on_missing(tmp_path):
+    missing = tmp_path / "does_not_exist"
+    with patch("app.utils.exif.datetime") as dt_mod:
+        dt_mod.now.return_value = datetime(2024, 1, 2, 3, 4, 5)
+        result = get_file_time_form_system(str(missing))
+    assert result == datetime(2024, 1, 2, 3, 4, 5)
+
+
+# -------------------------------------------------------------------------
+# get_exif_data
+# -------------------------------------------------------------------------
+
+
+class _FakeExif(dict):
+    pass
+
+
+def test_get_exif_data_returns_empty_when_image_has_no_exif():
+    img = SimpleNamespace(
+        getexif=MagicMock(return_value=None),
+        _getexif=MagicMock(return_value=None),
+    )
+    assert get_exif_data(img) == {}
+
+
+def test_get_exif_data_uses_getexif_for_top_level_tags():
+    info = {256: 100, 257: 200}
+    fake_exif = _FakeExif(info)
+    fake_exif.get_ifd = MagicMock(return_value={})
+    img = SimpleNamespace(
+        getexif=MagicMock(return_value=fake_exif),
+        _getexif=MagicMock(return_value=None),
+    )
+    result = get_exif_data(img)
+    assert result["ImageWidth"] == 100
+    assert result["ImageLength"] == 200
+
+
+def test_get_exif_data_decodes_bytes_to_str():
+    info = {306: b"2024:01:01 12:00:00"}
+    fake_exif = _FakeExif(info)
+    fake_exif.get_ifd = MagicMock(return_value={})
+    img = SimpleNamespace(
+        getexif=MagicMock(return_value=fake_exif),
+        _getexif=MagicMock(return_value=None),
+    )
+    result = get_exif_data(img)
+    assert result["DateTime"] == "2024:01:01 12:00:00"
+
+
+def test_get_exif_data_falls_back_to_legacy_getexif():
+    legacy = {256: 1024, 257: 768}
+    img = SimpleNamespace(
+        getexif=MagicMock(return_value=None),
+        _getexif=MagicMock(return_value=legacy),
+    )
+    result = get_exif_data(img)
+    assert result["ImageWidth"] == 1024
+    assert result["ImageLength"] == 768
+
+
+# -------------------------------------------------------------------------
+# extract_metadata (uses image_obj to avoid PIL)
+# -------------------------------------------------------------------------
+
+
+def _img_with_exif(width, height, exif_dict, exif_ifd=None):
+    """Build a MagicMock image whose getexif() returns a populated EXIF.
+
+    The top-level dict must be non-empty so ``if info:`` is truthy; we add a
+    placeholder key 36867 (DateTimeOriginal) and override the value with
+    whatever lives in the ExifIFD 0x8769.
+    """
+    img = MagicMock()
+    img.width = width
+    img.height = height
+    top_level = _FakeExif({36867: b"placeholder"})
+    top_level.get_ifd = MagicMock(return_value=exif_ifd or {})
+    img.getexif.return_value = top_level
+    return img
+
+
+def test_extract_metadata_uses_exif_datetime_when_present(tmp_path):
+    image_path = tmp_path / "x.jpg"
+    image_path.write_bytes(b"\x00")
+    # DateTimeOriginal (36867) lives in ExifIFD 0x8769.
+    img = _img_with_exif(100, 200, {}, exif_ifd={36867: b"2024:05:01 10:00:00"})
+    with patch.object(exif, "reverse_geocode", return_value={}):
+        result = extract_metadata(
+            str(image_path), image_path.name, image_obj=img, extract_location_details=False
+        )
+    assert result["photo_time"] == datetime(2024, 5, 1, 10, 0, 0)
+    assert result["width"] == 100
+    assert result["height"] == 200
+    assert result["exif_info"] is not None
+
+
+def test_extract_metadata_falls_back_to_filename_time(tmp_path):
+    image_path = tmp_path / "x.jpg"
+    image_path.write_bytes(b"\x00")
+    img = _img_with_exif(50, 60, {})
+    with patch.object(exif, "reverse_geocode", return_value={}), \
+         patch.object(exif, "get_file_time_form_system",
+                       return_value=datetime(2024, 6, 1, 0, 0, 0)):
+        result = extract_metadata(
+            str(image_path), "IMG_20240601_120000.jpg",
+            image_obj=img, extract_location_details=False,
+        )
+    assert result["photo_time"] == datetime(2024, 6, 1, 12, 0, 0)
+
+
+def test_extract_metadata_passes_location_through_when_present(tmp_path):
+    image_path = tmp_path / "x.jpg"
+    image_path.write_bytes(b"\x00")
+    img = _img_with_exif(10, 20, {}, exif_ifd={36867: b"2024:05:01 10:00:00"})
+    with patch.object(exif, "reverse_geocode", return_value={"address": "上海"}):
+        result = extract_metadata(
+            str(image_path), image_path.name,
+            image_obj=img, extract_location_details=True,
+        )
+    assert "photo_time" in result
+    assert result["photo_time"] == datetime(2024, 5, 1, 10, 0, 0)
+
+
+def test_extract_metadata_falls_back_to_now(tmp_path):
+    image_path = tmp_path / "x.jpg"
+    image_path.write_bytes(b"\x00")
+    img = _img_with_exif(1, 1, {})
+    with patch.object(exif, "reverse_geocode", return_value={}), \
+         patch.object(exif, "get_file_time_form_system", return_value=None), \
+         patch("app.utils.exif.datetime") as dt_mod:
+        dt_mod.strptime.side_effect = ValueError
+        dt_mod.now.return_value = datetime(2030, 1, 1, 0, 0, 0)
+        result = extract_metadata(
+            str(image_path), "no_time_in_name.jpg", image_obj=img
+        )
+    assert result["photo_time"] == datetime(2030, 1, 1, 0, 0, 0)
+
+
+# -------------------------------------------------------------------------
+# reverse_geocode (smoke)
+# -------------------------------------------------------------------------
+
+
+def test_reverse_geocode_returns_address_dict():
+    fake_row = {
+        "admin_1": "上海市",
+        "admin_2": "市辖区",
+        "admin_3": "黄浦区",
+        "admin_4": "",
+        "name": "外滩",
+        "country": "中国",
+    }
+    with patch.object(exif.rg, "search", return_value=[fake_row]):
+        result = reverse_geocode(31.23, 121.47)
+    assert result["province"] == "上海市"
+    assert result["city"] == "市辖区"
+    assert result["district"] == "黄浦区"
+    assert "外滩" in result["address"]
+
+
+def test_reverse_geocode_returns_empty_on_exception():
+    with patch.object(exif.rg, "search", side_effect=RuntimeError("rg broken")):
+        assert reverse_geocode(0, 0) == {}

--- a/package/website/tests/e2e/specs/album/people-p0.spec.ts
+++ b/package/website/tests/e2e/specs/album/people-p0.spec.ts
@@ -437,11 +437,14 @@ test.describe.serial('P0 - 人物相册', () => {
     const backBtn = page.locator('.unified-photo-page button:has(svg.lucide-arrow-left)').first()
     await expect(backBtn).toBeVisible({ timeout: 10_000 })
     await backBtn.click()
+    // dev 模式 4 worker 并发 + Vite HMR 偶尔会让 router.back() 慢于 5s；
+    // 先等列表页主要请求完成再断 URL，避免在 history push 过程中判失败。
+    await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => undefined)
 
     // 路由回到 /album/people（不带 /:id 后缀）
-    await page.waitForURL(/\/album\/people$/, { timeout: 5_000 })
+    await page.waitForURL(/\/album\/people$/, { timeout: 10_000 })
     // 列表的 h1 "人物" 应再次可见
-    await expect(page.getByRole('heading', { name: '人物', level: 1 })).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByRole('heading', { name: '人物', level: 1 })).toBeVisible({ timeout: 10_000 })
   })
 
   test('2.5.9 编辑对话框取消 - 取消按钮不修改原姓名 @p0', async ({ page, request }, testInfo) => {

--- a/package/website/tests/e2e/specs/views-coverage/views-deeper-p9.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/views-deeper-p9.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test, type Page, type Route } from '@playwright/test'
+
+const response = (data: unknown) => ({ code: 0, message: 'success', data })
+
+async function useFakeSession(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('user_token', 'fake-e2e-token')
+    localStorage.setItem('username', 'e2e-mock')
+    localStorage.setItem(
+      'user_info',
+      JSON.stringify({ id: 'u-e2e', username: 'e2e-mock', is_active: true, is_superuser: true }),
+    )
+  })
+  await page.route('**/api/auth/me**', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'u-e2e', username: 'e2e-mock', is_active: true, is_superuser: true }),
+    })
+  })
+}
+
+async function clickTab(page: Page, key: string) {
+  await page.locator(`[data-tab="${key}"]`).first().click()
+}
+
+test.describe('AI desktop view contracts @views-coverage', () => {
+  test.use({ storageState: { cookies: [], origins: [] } })
+
+  test('DesktopAIExtensions renders the unavailable desktop state', async ({ page }) => {
+    await useFakeSession(page)
+    await page.goto('/settings?tab=ai-extensions')
+    await clickTab(page, 'ai-extensions')
+
+    await expect(page.getByRole('heading', { name: 'AI 扩展包' })).toBeVisible()
+    await expect(page.getByText('仅 TrailSnap 桌面版支持扩展包管理')).toBeVisible()
+    await expect(page.getByText('当前页面未连接到桌面扩展管理接口。')).toBeVisible()
+  })
+
+  test('AIModelManagement renders models and the download action', async ({ page }) => {
+    await useFakeSession(page)
+    await page.route('**/api/settings/ai-models**', async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response({
+          models: [{
+            id: 'clip-test', name: '测试向量模型', status: 'pending',
+            description: 'Nightly view contract', requirements: { memoryMB: 128 },
+          }],
+          tasks: {
+            embedding: {
+              name: '语义向量与搜索', selected: 'clip-test', available: ['clip-test'],
+            },
+          },
+        })),
+      })
+    })
+    await page.goto('/settings?tab=ai-models')
+    await clickTab(page, 'ai-models')
+
+    await expect(page.getByRole('heading', { name: 'AI 模型管理' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: '语义向量与搜索' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '下载', exact: true })).toBeEnabled()
+  })
+})


### PR DESCRIPTION
## 测试值守 2026-08-26（5 个 commit，0 业务代码改动）

本 PR 是 NIGHTLY-TEST-WATCH 自动测试值守 2026-08-26 当日累积，共 5 个 commit，全部为测试 / 覆盖率补齐。**0 行业务代码改动**，仅新增测试文件 + 1 个测试修复。

### Commit 列表（按时间顺序）

| SHA       | 类型 | 模块 | 新增/修复 |
|-----------|------|------|----------|
| 15e9b41 | fix [A] | album people-p0 e2e / task_worker | 2 处测试修复（router.back networkidle + asyncio.create_task coroutine close） |
| 9a233f9 | test(nightly) | AI runtime + AI desktop views | +8 后端测试 / +2 前端 e2e spec |
| 119e7eb | test(ai) | AI EmbeddingService | +8 测试，app/services/embedding_service.py 66.3% → 74% (+7.7pp) |
| 55cc661 | test(nightly) | update_checker / agent memory / exif | +77 测试（25+31+21） |
| b7b8107 | test(nightly) | crud/photo update_metadata / day_caption / face_cluster / organize | +18 测试（4+3+4+7） |

**累计新增测试：+113 用例**

### 修复明细（commit 15e9b41）

#### 1. `package/website/tests/e2e/specs/album/people-p0.spec.ts::2.5.8` [A]
dev 模式 4 worker 并发 + Vite HMR 偶尔让 `router.back()` 慢于 5s，导致 `page.waitForURL` 超时。
- 点击返回按钮后先 `waitForLoadState('networkidle')` 等列表页主请求完成
- `waitForURL` 与后续 `toBeVisible` 超时从 5s 放宽到 10s（与同文件 2.5.1 一致）

#### 2. `package/server/tests/unit/test_nightly_task_worker_gaps_20260815.py::test_start_creates_process_and_thread_pools_and_recover` [A]
2026-08-19 起 5 轮未解的 pytest 99% hang 部分根因。该测试用 `patch('asyncio.create_task', return_value=MagicMock())` 让 5 个 `TaskWorker.{worker_loop,result_loop,consumer_loop}` coroutine 创建后从未被 await，也未 `close()`，卡住 pytest-asyncio 事件循环。
- 改为 `side_effect=lambda coro: (coro.close(), MagicMock())[1]`，确保 coroutine 被显式释放

### 新增测试明细

| 文件 | 模块 | 用例数 | 重点 |
|------|------|--------|------|
| `package/server/tests/unit/test_nightly_task_worker_gaps_20260815.py` (修复) | task_worker | +0 | coroutine close |
| `package/ai/tests/test_nightly_ai_runtime_boundaries_20260826.py` | AI runtime | +8 | idle shutdown / model release / LLM spawn |
| `package/website/tests/e2e/specs/views-coverage/views-deeper-p9.spec.ts` | frontend | +2 | AI desktop 视图触达 |
| `package/ai/tests/test_nightly_embedding_service_release_gaps_20260826.py` | AI EmbeddingService | +8 | _get_model_info / _release_model / b64 split |
| `package/server/tests/unit/test_nightly_update_checker_gaps_20260826.py` | update_checker | +25 | compare_versions / tick / persistence |
| `package/server/tests/unit/test_nightly_agent_memory_gaps_20260826.py` | agent memory | +31 | anchors / extraction / dedup |
| `package/server/tests/unit/test_nightly_utils_exif_gaps_20260826.py` | exif utils | +21 | IFDRational / GPS / reverse geocode |
| `package/server/tests/unit/test_nightly_crud_photo_update_metadata_gaps_20260826.py` | crud/photo | +4 | update_photo_metadata branches |
| `package/server/tests/unit/test_nightly_day_caption_lock_tz_gaps_20260826.py` | day_caption_service | +3 | lock cache / tz fallback |
| `package/server/tests/unit/test_nightly_face_cluster_analyze_gaps_20260826.py` | face_cluster | +4 | rescan branches |
| `package/server/tests/unit/test_nightly_organize_strategies_gaps_20260826.py` | tasks/organize | +7 | time/location strategies |

### 验证

- **r5（55cc661）本地后端单测**：1948 passed / 3 skipped（基线 1871 → +77）
- **r5（55cc661）本地完整 e2e**：302 passed / 4 skipped / 0 failed（10.6m）
- **r6（b7b8107）本地新增 18 测试**：18 passed（1.55s）
- **r6（b7b8107）本地后端单测全量**：100% 完成（Pytest 末段 SQLite pollution hang P1 已知；无 FAILED/ERROR marker）
- **r6（b7b8107）本地 AI 单测全量**：100% 完成（同 P1，无 FAILED/ERROR marker）
- **目标模块 targeted cov 已确认新测试命中目标行**

### CI

- 提交 15e9b41 之后 CI 全绿（11 SUCCESS + 1 release SKIPPED，22m43s）
- b7b8107 推送后 CI 重跑中（详见 PR checks）

### 影响范围

仅触及（均在 §0 白名单内）：
- `tests/`
- `package/server/app/`
- `package/server/tests/`
- `package/ai/app/`、`package/ai/tests/`
- `package/website/tests/`

### Checklist

- [x] 影响范围仅在白名单路径
- [x] 提交信息符合 Conventional Commits
- [x] 仅测试 fix / 新增，不修业务代码
- [x] label: `codex`, `codex-automation`
- [ ] CLA: I have read and agree to the CLA (AGPLv3)

🤖 Generated with [Codex](https://openai.com/blog/index/openai-codex/)
Co-authored-by: Codex <noreply@openai.com>
