### PR TITLE
test(nightly): cover LocationMap scene-level + TicketPage page-level handlers (2026-08-27)

### DIFF
--- a/package/ai/tests/test_nightly_ai_config_router_errors_20260827.py
+++ b/package/ai/tests/test_nightly_ai_config_router_errors_20260827.py
@@ -1,0 +1,189 @@
+"""Unit tests for the error-path branches in app/routers/ai_config.py.
+
+Why this file exists:
+
+* The nightly gap scan flagged app/routers/ai_config.py as 76 percent
+  covered (12 missed lines out of 50). The pre-existing
+  test_ai_config_router.py covers the happy paths only -- the KeyError,
+  ValueError, RuntimeError and generic Exception branches that translate
+  into HTTPException(4xx/5xx) are untested, so a regression on the
+  status code would slip through.
+
+Each router_module.<endpoint> is exercised with a manager that raises
+the targeted exception class. We then assert the HTTPException
+propagates with the expected status code.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers import ai_config as router_module
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_ai]
+
+
+# ---------------------------------------------------------------------------
+# POST /models/{model_id}/download -- 404 (KeyError) / 409 (ValueError)
+# ---------------------------------------------------------------------------
+
+
+def test_download_managed_model_404_when_model_unknown():
+    """Unknown model id -> HTTPException(404) raised from KeyError."""
+    with patch.object(
+        router_module.ai_model_manager,
+        "trigger_download",
+        side_effect=KeyError("model-not-found"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            import asyncio
+            asyncio.run(router_module.download_managed_model("model-not-found"))
+    assert exc.value.status_code == 404
+
+
+def test_download_managed_model_409_when_already_downloading():
+    """Already-downloading model -> HTTPException(409) from ValueError."""
+    with patch.object(
+        router_module.ai_model_manager,
+        "trigger_download",
+        side_effect=ValueError("already downloading"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            import asyncio
+            asyncio.run(router_module.download_managed_model("face-buffalo-l"))
+    assert exc.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# DELETE /models/{model_id} -- 404 (KeyError) / 409 (RuntimeError)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_managed_model_404_when_model_unknown():
+    """Unknown model id -> HTTPException(404) raised from KeyError."""
+    with patch.object(
+        router_module.ai_model_manager,
+        "get_spec",
+        return_value={"tasks": ["face"]},
+    ), patch.object(
+        router_module.ai_model_manager,
+        "delete_model",
+        side_effect=KeyError("missing"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            import asyncio
+            asyncio.run(router_module.delete_managed_model("nope"))
+    assert exc.value.status_code == 404
+
+
+def test_delete_managed_model_409_when_runtime_error():
+    """Active runtime -> HTTPException(409) from RuntimeError."""
+    with patch.object(
+        router_module.ai_model_manager,
+        "get_spec",
+        return_value={"tasks": ["face"]},
+    ), patch.object(
+        router_module.ai_model_manager,
+        "delete_model",
+        side_effect=RuntimeError("model in use"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            import asyncio
+            asyncio.run(router_module.delete_managed_model("face-buffalo-l"))
+    assert exc.value.status_code == 409
+
+
+def test_delete_managed_model_calls_llm_stop_for_llm_task():
+    """When the deleted model advertises an llm task, llm_manager.stop
+    must be awaited BEFORE deletion."""
+    with patch.object(
+        router_module.ai_model_manager,
+        "get_spec",
+        return_value={"tasks": ["llm"]},
+    ), patch.object(
+        router_module.ai_model_manager,
+        "delete_model",
+        return_value={"llm": "other-llm"},
+    ), patch.object(
+        router_module.llm_manager,
+        "stop",
+        new=AsyncMock(),
+    ) as stop:
+        import asyncio
+        result = asyncio.run(router_module.delete_managed_model("MiniCPM-V"))
+
+    stop.assert_awaited_once()
+    assert result["status"] == "deleted"
+    assert result["switched"] == {"llm": "other-llm"}
+
+
+# ---------------------------------------------------------------------------
+# POST /config/model -- 400 (ValueError/KeyError) / 500 (generic Exception)
+# ---------------------------------------------------------------------------
+
+
+def test_set_model_400_on_value_error():
+    """Bad task/model combo -> HTTPException(400) from ValueError."""
+    request = SimpleNamespace(task="face", model="bad-model")
+    with patch.object(
+        router_module.ai_model_manager,
+        "select_model",
+        side_effect=ValueError("invalid combo"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            import asyncio
+            asyncio.run(router_module.set_model(request))
+    assert exc.value.status_code == 400
+
+
+def test_set_model_400_on_key_error():
+    """Unknown model id -> HTTPException(400) from KeyError."""
+    request = SimpleNamespace(task="face", model="nope")
+    with patch.object(
+        router_module.ai_model_manager,
+        "select_model",
+        side_effect=KeyError("missing"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            import asyncio
+            asyncio.run(router_module.set_model(request))
+    assert exc.value.status_code == 400
+
+
+def test_set_model_500_on_unexpected_exception():
+    """Anything else -> HTTPException(500) and logger.exception is called."""
+    request = SimpleNamespace(task="face", model="x")
+    with patch.object(
+        router_module.ai_model_manager,
+        "select_model",
+        side_effect=RuntimeError("disk full"),
+    ), patch.object(router_module, "logger") as logger:
+        with pytest.raises(HTTPException) as exc:
+            import asyncio
+            asyncio.run(router_module.set_model(request))
+    assert exc.value.status_code == 500
+    logger.exception.assert_called_once()
+
+
+def test_set_model_calls_llm_stop_when_task_is_llm():
+    """Switching the LLM model must stop the current subprocess first."""
+    request = SimpleNamespace(task="llm", model="new-llm")
+    with patch.object(
+        router_module.ai_model_manager,
+        "select_model",
+        return_value=True,
+    ), patch.object(
+        router_module.llm_manager,
+        "stop",
+        new=AsyncMock(),
+    ) as stop:
+        import asyncio
+        result = asyncio.run(router_module.set_model(request))
+
+    stop.assert_awaited_once()
+    assert result["changed"] is True
+    assert result["task"] == "llm"
+    assert result["model"] == "new-llm"

--- a/package/server/tests/unit/test_nightly_agent_tools_summary_gaps_20260827.py
+++ b/package/server/tests/unit/test_nightly_agent_tools_summary_gaps_20260827.py
@@ -1,0 +1,100 @@
+"""Unit tests for the gap-remaining branches in app/service/agent/tools.py.
+
+Why this file exists:
+
+* The nightly gap scan flagged app/service/agent/tools.py as 64.3 percent
+  covered (81 missed lines out of 227). The pre-existing
+  test_nightly_agent_tools_gaps_20260814.py covers the happy paths for
+  search_photos_tool and the other tool wrappers. This file fills the
+  remaining uncovered surface in _build_search_summary.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.service.agent import tools as tools_module
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_agent]
+
+
+def _chained(*, first=None, all_rows=None):
+    """Chainable MagicMock with optional first()/all() terminals."""
+    q = MagicMock()
+    q.filter.return_value = q
+    q.join.return_value = q
+    q.group_by.return_value = q
+    q.order_by.return_value = q
+    q.limit.return_value = q
+    if first is not None:
+        q.first.return_value = first
+    if all_rows is not None:
+        q.all.return_value = all_rows
+    return q
+
+
+# _build_search_summary -- success path
+# ---------------------------------------------------------------------------
+
+
+def test_build_search_summary_populates_all_three_sub_aggregations():
+    """When every sub-query returns rows the summary dict carries all three."""
+    db = MagicMock()
+    id_subq = MagicMock(name="id_subq")
+    id_subq.c.id = MagicMock(name="id")
+    filtered_query = MagicMock(name="filtered_query")
+    filtered_query.with_entities.return_value.order_by.return_value.subquery.return_value = id_subq
+
+    # 6 db.query() calls per execution: each of date_range / top_locations /
+    # top_tags builds a query with a .in_(subquery) filter, so each block
+    # produces two db.query() calls (outer + the in_() subquery).
+    date_q = _chained(first=(datetime(2026, 1, 1), datetime(2026, 12, 31)))
+    in_subq_a = _chained()
+    loc_q = _chained(all_rows=[("Wuhan", 10), ("Beijing", 5)])
+    in_subq_b = _chained()
+    tag_q = _chained(all_rows=[("travel", 8), ("citywalk", 3)])
+    in_subq_c = _chained()
+    queue = [date_q, in_subq_a, loc_q, in_subq_b, tag_q, in_subq_c]
+    db.query.side_effect = lambda *_a, **_kw: queue.pop(0)
+
+    summary = tools_module._build_search_summary(db, filtered_query, distance=None)
+
+    assert summary["date_range"] == ["2026-01-01", "2026-12-31"]
+    assert summary["top_locations"] == {"Wuhan": 10, "Beijing": 5}
+    assert summary["top_tags"] == {"travel": 8, "citywalk": 3}
+
+
+def test_build_search_summary_swallows_top_level_exception():
+    """If the outer db.query itself raises, the function returns an empty dict."""
+    db = MagicMock()
+    filtered_query = MagicMock(name="filtered_query")
+    filtered_query.with_entities.return_value.order_by.return_value.subquery.side_effect = RuntimeError("boom")
+
+    summary = tools_module._build_search_summary(db, filtered_query, distance=None)
+
+    assert summary == {}
+
+
+def test_build_search_summary_skips_date_range_when_no_rows():
+    """When the date_range query returns None the key is not added."""
+    db = MagicMock()
+    id_subq = MagicMock(name="id_subq")
+    id_subq.c.id = MagicMock(name="id")
+    filtered_query = MagicMock(name="filtered_query")
+    filtered_query.with_entities.return_value.order_by.return_value.subquery.return_value = id_subq
+    date_q = _chained(first=None)
+    in_subq_a = _chained()
+    loc_q = _chained(all_rows=[("Wuhan", 10)])
+    in_subq_b = _chained()
+    tag_q = _chained(all_rows=[("travel", 5)])
+    in_subq_c = _chained()
+    queue = [date_q, in_subq_a, loc_q, in_subq_b, tag_q, in_subq_c]
+    db.query.side_effect = lambda *_a, **_kw: queue.pop(0)
+
+    summary = tools_module._build_search_summary(db, filtered_query, distance=None)
+
+    assert "date_range" not in summary
+    assert summary["top_locations"] == {"Wuhan": 10}
+    assert summary["top_tags"] == {"travel": 5}

--- a/package/server/tests/unit/test_nightly_crud_location_public_gaps_20260827.py
+++ b/package/server/tests/unit/test_nightly_crud_location_public_gaps_20260827.py
@@ -1,0 +1,273 @@
+"""Unit tests for the gap-remaining public functions in crud/location.
+
+Why this file exists:
+
+* The nightly gap scan flagged ``app/crud/location.py`` as 59.2% covered
+  (75 missed lines out of 184). The previous round
+  (``test_nightly_crud_photo_location_album_gaps_20260812.py``) covers
+  ``get_location_years`` + the invalid-level fallbacks for
+  ``get_locations`` / ``get_location_photos`` /
+  ``get_location_distribution`` + ``search_locations`` happy path.
+  This file fills the remaining uncovered surface:
+
+  - ``get_locations`` valid-level cover fetch (city / province / district /
+    scene -- including the cover-map fallback when ``.all()`` returns no
+    rows the second time)
+  - ``get_location_photos`` valid-level filter (city / scene branches)
+  - ``get_map_markers`` happy path + the date-filter branch
+  - ``get_timeline_nodes`` -- city level with consecutive same-location
+    rows (merge) and a fresh location append; also the scene level branch
+    that returns the full coalesce/case expression.
+"""
+
+from datetime import date as _date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.crud import location as crud_loc
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_location]
+
+
+def _chained(*, terminal=None, all_rows=None):
+    q = MagicMock(name="query")
+    q.filter.return_value = q
+    q.join.return_value = q
+    q.outerjoin.return_value = q
+    q.group_by.return_value = q
+    q.order_by.return_value = q
+    q.distinct.return_value = q
+    q.offset.return_value = q
+    q.limit.return_value = q
+    q.subquery.return_value = MagicMock(name="subq")
+    q.scalar.return_value = terminal if terminal is not None else 0
+    if all_rows is not None:
+        q.all.return_value = all_rows
+    return q
+
+
+def _photo(**kw):
+    base = {"id": uuid4(), "file_path": "/photos/x.jpg", "photo_time": None}
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# get_locations -- valid-level cover fetch
+# ---------------------------------------------------------------------------
+
+
+def test_get_locations_city_level_returns_locations_with_cover():
+    """City level -> each row carries the cover photo looked up by name."""
+    db = MagicMock()
+    cover_photo = _photo(id=uuid4(), file_path="/photos/cover.jpg")
+    main_q = _chained(all_rows=[("Wuhan", 10), ("Beijing", 5)])
+    cover_q = _chained(all_rows=[(cover_photo, "Wuhan"), (_photo(file_path="/photos/b.jpg"), "Beijing")])
+    db.query.side_effect = [main_q, cover_q]
+
+    out = crud_loc.get_locations(db, owner_id=uuid4(), level="city")
+
+    assert len(out) == 2
+    by_name = {loc["name"]: loc for loc in out}
+    assert by_name["Wuhan"]["count"] == 10
+    assert by_name["Wuhan"]["level"] == "city"
+    assert by_name["Wuhan"]["cover"] is cover_photo
+
+
+def test_get_locations_scene_level_returns_id_and_is_custom():
+    """Scene level -> result includes the Scene.id and is_custom flag."""
+    db = MagicMock()
+    scene_id = uuid4()
+    main_q = _chained(all_rows=[("Bund", scene_id, False, 7)])
+    cover_q = _chained(all_rows=[])
+    db.query.side_effect = [main_q, cover_q]
+
+    out = crud_loc.get_locations(db, owner_id=uuid4(), level="scene")
+
+    assert len(out) == 1
+    assert out[0]["name"] == "Bund"
+    assert out[0]["id"] == str(scene_id)
+    assert out[0]["is_custom"] is False
+    assert out[0]["count"] == 7
+
+
+def test_get_locations_empty_results_returns_empty_list():
+    """If the main query yields no rows, no cover lookup runs and the
+    function returns ``[]`` immediately."""
+    db = MagicMock()
+    db.query.return_value = _chained(all_rows=[])
+
+    out = crud_loc.get_locations(db, owner_id=uuid4(), level="city")
+
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# get_location_photos -- valid-level branches
+# ---------------------------------------------------------------------------
+
+
+def test_get_location_photos_city_level_returns_photos():
+    """city level: filter on PhotoMetadata.city == name."""
+    db = MagicMock()
+    photos = [_photo(), _photo(), _photo()]
+    db.query.return_value = _chained(all_rows=photos)
+
+    out = crud_loc.get_location_photos(db, owner_id=uuid4(), name="Wuhan", level="city")
+
+    assert out == photos
+
+
+def test_get_location_photos_scene_level_joins_scene_table():
+    """scene level joins Scene via PhotoMetadata.scene_id (separate branch)."""
+    db = MagicMock()
+    photos = [_photo()]
+    db.query.return_value = _chained(all_rows=photos)
+
+    out = crud_loc.get_location_photos(db, owner_id=uuid4(), name="Bund", level="scene")
+
+    assert out == photos
+
+
+# ---------------------------------------------------------------------------
+# get_map_markers
+# ---------------------------------------------------------------------------
+
+
+def test_get_map_markers_returns_dicts_with_float_coords():
+    """Each row's lat/lng become float dict values keyed by photo id string."""
+    db = MagicMock()
+    pid1 = uuid4()
+    pid2 = uuid4()
+    db.query.return_value = _chained(all_rows=[
+        (pid1, 30.5, 114.3),
+        (pid2, 31.2, 121.5),
+    ])
+
+    out = crud_loc.get_map_markers(db, owner_id=uuid4())
+
+    assert out == [
+        {"id": str(pid1), "lat": 30.5, "lng": 114.3},
+        {"id": str(pid2), "lat": 31.2, "lng": 121.5},
+    ]
+
+
+def test_get_map_markers_with_date_range_passes_filter_args():
+    """Date range params route through the same chain (covered by ``.all````)."""
+    db = MagicMock()
+    db.query.return_value = _chained(all_rows=[])
+
+    out = crud_loc.get_map_markers(
+        db, owner_id=uuid4(), start_date="2026-01-01", end_date="2026-12-31"
+    )
+
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# get_timeline_nodes
+# ---------------------------------------------------------------------------
+
+
+def test_get_timeline_nodes_city_level_merges_consecutive_same_location():
+    """Two consecutive rows with the same ``loc_name`` collapse into one
+    TimelineNode whose ``photoCount`` is the sum and lat/lng are averaged."""
+    db = MagicMock()
+    db.query.return_value = _chained(all_rows=[
+        SimpleNamespace(
+            date=_date(2026, 8, 10),
+            loc_name="Wuhan",
+            level="city",
+            photo_count=3,
+            lat=30.5,
+            lng=114.3,
+            cover_id=str(uuid4()),
+        ),
+        SimpleNamespace(
+            date=_date(2026, 8, 12),
+            loc_name="Wuhan",
+            level="city",
+            photo_count=5,
+            lat=30.6,
+            lng=114.4,
+            cover_id=str(uuid4()),
+        ),
+    ])
+
+    out = crud_loc.get_timeline_nodes(db, owner_id=uuid4(), level="city")
+
+    assert out.total == 1
+    node = out.nodes[0]
+    assert node.locationName == "Wuhan"
+    assert node.photoCount == 8
+    # Weighted average of (30.5 with 3) and (30.6 with 5).
+    assert abs(node.lat - (30.5 * 3 + 30.6 * 5) / 8) < 1e-9
+
+
+def test_get_timeline_nodes_appends_new_node_on_location_change():
+    """A second row with a different ``loc_name`` creates a new node."""
+    db = MagicMock()
+    db.query.return_value = _chained(all_rows=[
+        SimpleNamespace(
+            date=_date(2026, 8, 10),
+            loc_name="Wuhan",
+            level="city",
+            photo_count=3,
+            lat=30.5,
+            lng=114.3,
+            cover_id=str(uuid4()),
+        ),
+        SimpleNamespace(
+            date=_date(2026, 9, 1),
+            loc_name="Beijing",
+            level="city",
+            photo_count=2,
+            lat=39.9,
+            lng=116.4,
+            cover_id=str(uuid4()),
+        ),
+    ])
+
+    out = crud_loc.get_timeline_nodes(db, owner_id=uuid4(), level="city")
+
+    assert out.total == 2
+    assert [n.locationName for n in out.nodes] == ["Wuhan", "Beijing"]
+
+
+def test_get_timeline_nodes_scene_level_returns_response():
+    """Scene level exercises the full coalesce/case expression."""
+    db = MagicMock()
+    db.query.return_value = _chained(all_rows=[])
+
+    out = crud_loc.get_timeline_nodes(db, owner_id=uuid4(), level="scene")
+
+    assert out.total == 0
+    assert out.nodes == []
+
+
+def test_get_timeline_nodes_respects_skip_and_limit():
+    """``skip`` slices from the front; ``limit`` slices the result."""
+    db = MagicMock()
+    rows = []
+    for idx, (name, day) in enumerate([
+        ("Wuhan", 1), ("Beijing", 5), ("Shanghai", 10), ("Urumqi", 15),
+    ]):
+        rows.append(SimpleNamespace(
+            date=_date(2026, 8, day),
+            loc_name=name,
+            level="city",
+            photo_count=idx + 1,
+            lat=30.0 + idx,
+            lng=110.0 + idx,
+            cover_id=str(uuid4()),
+        ))
+    db.query.return_value = _chained(all_rows=rows)
+
+    out = crud_loc.get_timeline_nodes(db, owner_id=uuid4(), level="city", skip=1, limit=2)
+
+    assert out.total == 4
+    assert [n.locationName for n in out.nodes] == ["Beijing", "Shanghai"]

--- a/package/server/tests/unit/test_nightly_crud_location_stats_public_gaps_20260827.py
+++ b/package/server/tests/unit/test_nightly_crud_location_stats_public_gaps_20260827.py
@@ -1,0 +1,315 @@
+"""Unit tests for the public ORM-bound functions in crud/location_stats.
+
+Why this file exists:
+
+* The nightly gap scan flagged ``app/crud/location_stats.py`` as 58.2%
+  covered (56 missed lines out of 134). The pure helpers (``_haversine``,
+  ``_apply_date_filter``, ``_travel_distance``) are covered in
+  ``test_nightly_crud_location_stats_helpers_gaps_20260812.py``. This file
+  focuses on the public surface that aggregates DB results into API
+  responses: ``get_overview``, ``get_annual_trend``, ``get_monthly_radar``,
+  ``get_places`` (with multiple level branches), and ``get_heatmap_range``.
+
+We mock SQLAlchemy chain assembly with ``MagicMock`` so no Postgres is
+required. Each function is exercised through its full control-flow path:
+empty result set, populated result set, and the level-specific branches
+in ``get_places``.
+"""
+
+from datetime import date as _date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.crud import location_stats as crud_ls
+from app.schemas.location_stats import (
+    OverviewStats,
+    AnnualTrendItem,
+    MonthlyRadarItem,
+    PlacesResponse,
+    HeatmapItem,
+    HeatmapRangeResponse,
+)
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_stats]
+
+
+def _chained_query(*, terminal=None, all_rows=None):
+    """Build a MagicMock whose every chainable call returns itself."""
+    q = MagicMock(name="query")
+    q.filter.return_value = q
+    q.join.return_value = q
+    q.outerjoin.return_value = q
+    q.group_by.return_value = q
+    q.order_by.return_value = q
+    q.distinct.return_value = q
+    q.offset.return_value = q
+    q.limit.return_value = q
+    q.scalar.return_value = terminal if terminal is not None else 0
+    if all_rows is not None:
+        q.all.return_value = all_rows
+    return q
+
+
+def _row(**kw):
+    base = {
+        "lat": 30.5,
+        "lng": 114.3,
+        "cnt": 1,
+        "c": "Wuhan",
+        "name": "Wuhan",
+        "d": _date(2026, 8, 15),
+        "y": 2026,
+        "m": 8,
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# get_overview
+# ---------------------------------------------------------------------------
+
+
+def test_get_overview_returns_zeroed_stats_when_no_photos():
+    """Empty DB -> OverviewStats with zero counts and has_location=False."""
+    db = MagicMock()
+    db.query.return_value = _chained_query()
+
+    result = crud_ls.get_overview(db, owner_id="00000000-0000-0000-0000-000000000001")
+
+    assert isinstance(result, OverviewStats)
+    assert result.total_distance_km == 0
+    assert result.province_count == 0
+    assert result.city_count == 0
+    assert result.scene_count == 0
+    assert result.travel_days == 0
+    assert result.farthest_place is None
+    assert result.farthest_distance_km == 0
+    assert result.has_location is False
+
+
+def test_get_overview_with_location_picks_farthest_city():
+    """When has_location>0, farthest_place is the city farthest from busiest centroid."""
+    db = MagicMock()
+
+    # has_location must be > 0 to enter the distance/farthest block.
+    scalar_q = _chained_query(terminal=2)
+    centroids_q = _chained_query(all_rows=[
+        _row(c="Wuhan", lat=30.5, lng=114.3),
+        _row(c="Beijing", lat=39.9, lng=116.4),
+        _row(c="Urumqi", lat=43.8, lng=87.6),
+    ])
+    city_centroids = _chained_query(all_rows=[
+        SimpleNamespace(c="Wuhan", lat=30.5, lng=114.3, cnt=10),
+        SimpleNamespace(c="Urumqi", lat=43.8, lng=87.6, cnt=3),
+    ])
+
+    # Order: has_location (scalar), province_count, city_count, scene_count,
+    # travel_days (all scalar), _day_city_centroids -> all rows, city_centroids.
+    seq = [scalar_q, scalar_q, scalar_q, scalar_q, scalar_q, centroids_q, city_centroids]
+    def _side_effect(*a, **kw):
+        return seq.pop(0) if seq else _chained_query(terminal=0)
+    db.query.side_effect = _side_effect
+
+    result = crud_ls.get_overview(db, owner_id="00000000-0000-0000-0000-000000000001")
+
+    assert result.has_location is True
+    assert result.farthest_place == "Urumqi"
+    assert result.farthest_distance_km > 2500
+
+
+# ---------------------------------------------------------------------------
+# get_annual_trend
+# ---------------------------------------------------------------------------
+
+
+def test_get_annual_trend_returns_year_and_distance():
+    """Each year row yields an AnnualTrendItem with year/photo_count/distance."""
+    db = MagicMock()
+    year_q = _chained_query(all_rows=[
+        _row(y=2024, cnt=120),
+        _row(y=2025, cnt=200),
+    ])
+    centroids_q = _chained_query(all_rows=[])
+
+    seq = [year_q, centroids_q]
+    def _side_effect(*a, **kw):
+        return seq.pop(0) if seq else _chained_query(terminal=0)
+    db.query.side_effect = _side_effect
+
+    result = crud_ls.get_annual_trend(db, owner_id="00000000-0000-0000-0000-000000000001")
+
+    assert [item.year for item in result] == [2024, 2025]
+    assert all(isinstance(item, AnnualTrendItem) for item in result)
+    # Without centroids the per-year distance is 0.
+    assert result[0].distance_km == 0
+
+
+# ---------------------------------------------------------------------------
+# get_monthly_radar
+# ---------------------------------------------------------------------------
+
+
+def test_get_monthly_radar_emits_all_twelve_months_with_zero_fill():
+    """Months with no photos appear in the radar with count=0 and score=0."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[
+        _row(m=3, cnt=5),
+        _row(m=7, cnt=10),
+    ])
+
+    result = crud_ls.get_monthly_radar(db, owner_id="00000000-0000-0000-0000-000000000001")
+
+    assert len(result) == 12
+    by_month = {item.month: item for item in result}
+    assert by_month[1].photo_count == 0
+    assert by_month[1].activity_score == 0
+    assert by_month[3].photo_count == 5
+    assert by_month[7].photo_count == 10
+    assert by_month[7].activity_score == 100
+    assert by_month[3].activity_score == 50
+
+
+def test_get_monthly_radar_empty_db_returns_all_zero():
+    """Empty DB -> 12 zeroed MonthlyRadarItems (max_count==0 path)."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[])
+
+    result = crud_ls.get_monthly_radar(db, owner_id="00000000-0000-0000-0000-000000000001")
+
+    assert len(result) == 12
+    assert all(item.photo_count == 0 for item in result)
+    assert all(item.activity_score == 0 for item in result)
+
+
+# ---------------------------------------------------------------------------
+# get_places -- level branches
+# ---------------------------------------------------------------------------
+
+
+def _named_row(name, date_obj, cnt=1):
+    return SimpleNamespace(name=name, d=date_obj, cnt=cnt)
+
+
+def test_get_places_city_level_groups_by_name_and_returns_top_n():
+    """city level: top_places capped by limit, revisits from visit_count>1."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[
+        _named_row("Wuhan", _date(2026, 8, 15), cnt=5),
+        _named_row("Wuhan", _date(2026, 9, 1), cnt=2),
+        _named_row("Beijing", _date(2026, 9, 10), cnt=3),
+    ])
+
+    result = crud_ls.get_places(
+        db, owner_id="00000000-0000-0000-0000-000000000001", level="city", limit=5
+    )
+
+    assert isinstance(result, PlacesResponse)
+    assert len(result.top_places) == 2
+    assert len(result.revisits) == 1
+    assert result.revisits[0].name == "Wuhan"
+    assert result.revisits[0].visit_count == 2
+    assert result.top_places[0].name == "Wuhan"
+    assert result.top_places[0].photo_count == 7
+
+
+def test_get_places_province_level_returns_response():
+    """province level uses PhotoMetadata.province and skips the Scene join."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[])
+
+    result = crud_ls.get_places(
+        db, owner_id="00000000-0000-0000-0000-000000000001", level="province"
+    )
+
+    assert isinstance(result, PlacesResponse)
+    assert result.top_places == []
+    assert result.revisits == []
+
+
+def test_get_places_scene_level_joins_scene_table():
+    """scene level joins Scene via PhotoMetadata.scene_id and groups by Scene.name."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[
+        _named_row("Bund", _date(2026, 10, 1), cnt=4),
+    ])
+
+    result = crud_ls.get_places(
+        db, owner_id="00000000-0000-0000-0000-000000000001", level="scene"
+    )
+
+    assert len(result.top_places) == 1
+    assert result.top_places[0].name == "Bund"
+    assert result.top_places[0].level == "scene"
+
+
+def test_get_places_invalid_level_falls_back_to_city():
+    """Unknown level -> defaults to PhotoMetadata.city grouping."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[])
+
+    result = crud_ls.get_places(
+        db, owner_id="00000000-0000-0000-0000-000000000001", level="galaxy"
+    )
+
+    assert isinstance(result, PlacesResponse)
+
+
+def test_get_places_respects_limit_argument():
+    """limit caps top_places length."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[
+        _named_row("Wuhan", _date(2026, 8, 1), cnt=10),
+        _named_row("Beijing", _date(2026, 8, 2), cnt=5),
+        _named_row("Shanghai", _date(2026, 8, 3), cnt=3),
+    ])
+
+    result = crud_ls.get_places(
+        db,
+        owner_id="00000000-0000-0000-0000-000000000001",
+        level="city",
+        limit=2,
+    )
+
+    assert len(result.top_places) == 2
+
+
+# ---------------------------------------------------------------------------
+# get_heatmap_range
+# ---------------------------------------------------------------------------
+
+
+def test_get_heatmap_range_sums_total_photos_and_returns_data():
+    """The function iterates rows, sums total_photos, and emits HeatmapItems."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[
+        SimpleNamespace(d=_date(2026, 8, 15), cnt=3),
+        SimpleNamespace(d=_date(2026, 8, 16), cnt=5),
+        SimpleNamespace(d=_date(2026, 8, 17), cnt=2),
+    ])
+
+    result = crud_ls.get_heatmap_range(
+        db, owner_id="00000000-0000-0000-0000-000000000001"
+    )
+
+    assert isinstance(result, HeatmapRangeResponse)
+    assert result.total_photos == 10
+    assert result.total_days == 3
+    assert all(isinstance(item, HeatmapItem) for item in result.data)
+
+
+def test_get_heatmap_range_empty_db_returns_zero():
+    """Empty DB -> total_photos=0, total_days=0, empty data list."""
+    db = MagicMock()
+    db.query.return_value = _chained_query(all_rows=[])
+
+    result = crud_ls.get_heatmap_range(
+        db, owner_id="00000000-0000-0000-0000-000000000001"
+    )
+
+    assert result.total_photos == 0
+    assert result.total_days == 0
+    assert result.data == []

--- a/package/server/tests/unit/test_nightly_motion_photo_gaps_20260827.py
+++ b/package/server/tests/unit/test_nightly_motion_photo_gaps_20260827.py
@@ -1,0 +1,153 @@
+"""Unit tests covering 2026-08-27 nightly coverage gap scan.
+
+Targets uncovered branches in app.utils.motion_photo (66 percent covered,
+18 of 62 lines missed). The earlier test_motion_photo_utils.py (2026-08-04
+round) only exercises the happy paths for get_video_offset and extract_video;
+this file complements it by driving the remaining branches:
+  * XMP tag-style MicroVideoOffset (line 35)
+  * Empty file fallback (line 42)
+  * ftyp atom at start (line 50) and ftyp with out-of-range size (line 54)
+  * ftyp inside the size window at file start (line 62)
+  * mmap ValueError fallback (lines 64-66)
+  * generic exception swallowed by get_video_offset (lines 70-71)
+  * extract_video auto-detects offset (lines 81-83)
+  * extract_video defaults to .mp4 sibling (line 89)
+  * extract_video reuses an existing .mp4 file without rewriting (line 92)
+  * extract_video rejection of bad offsets (line 103) and exception cleanup
+    path that removes a partial output file (lines 112-119)
+"""
+import builtins
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.utils import motion_photo
+from app.utils.motion_photo import extract_video, get_video_offset
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+def test_get_video_offset_reads_tag_style_microvideo(tmp_path):
+    path = tmp_path / 'motion.jpg'
+    path.write_bytes(b'<rdf:GCamera:MicroVideoOffset>12345</rdf:GCamera:MicroVideoOffset>')
+    assert get_video_offset(str(path)) == 12345
+
+def test_get_video_offset_returns_none_for_empty_file(tmp_path):
+    path = tmp_path / 'empty.jpg'
+    path.write_bytes(b'')
+    assert get_video_offset(str(path)) is None
+
+def test_get_video_offset_skips_ftyp_within_first_four_bytes(tmp_path):
+    # ftyp at file byte 0..3 has no preceding size header; pos < 4 skips it.
+    path = tmp_path / 'motion.jpg'
+    path.write_bytes(b'ftyp-prefix' + b'x' * 32)
+    assert get_video_offset(str(path)) is None
+
+def test_get_video_offset_skips_ftyp_with_size_outside_window(tmp_path):
+    # An ftyp atom whose declared size is outside 8..128 is ignored.
+    payload = (256).to_bytes(4, 'big') + b'ftyp' + b'x' * 128
+    path = tmp_path / 'motion.jpg'
+    path.write_bytes(b'prefix' + payload)
+    assert get_video_offset(str(path)) is None
+
+def test_get_video_offset_returns_none_for_ftyp_at_file_start(tmp_path):
+    # ftyp at byte 0 is dropped by the atom_start > 0 guard.
+    payload = (16).to_bytes(4, 'big') + b'ftyp' + b'x' * 8
+    path = tmp_path / 'edge.jpg'
+    path.write_bytes(payload)
+    assert get_video_offset(str(path)) is None
+
+def test_get_video_offset_swallows_value_error_from_mmap(tmp_path):
+    # mmap raises ValueError for an empty stream; we return None (lines 64-66).
+    path = tmp_path / 'boom.jpg'
+    path.write_bytes(b'x' * 16)
+
+    def fake_mmap(_fd, _length, access):
+        raise ValueError('simulated mmap error')
+
+    original = motion_photo.mmap.mmap
+    motion_photo.mmap.mmap = fake_mmap
+    try:
+        result = motion_photo.get_video_offset(str(path))
+    finally:
+        motion_photo.mmap.mmap = original
+    assert result is None
+
+def test_get_video_offset_swallows_generic_exception(tmp_path):
+    # Anything raised inside the try block is swallowed by line 70-71.
+    path = tmp_path / 'any.jpg'
+    path.write_bytes(b'some')
+    bad_os = SimpleNamespace(getsize=lambda _p: 1 // 0)
+    with patch.object(motion_photo, 'os', bad_os):
+        assert motion_photo.get_video_offset(str(path)) is None
+
+def test_extract_video_auto_detects_offset_when_missing(tmp_path):
+    # extract_video(file) without offset auto-detects via get_video_offset.
+    src = tmp_path / 'clip.jpg'
+    image = b'image-bytes'
+    atom = (24).to_bytes(4, 'big') + b'ftyp' + b'isom' + (b'x' * 16)
+    src.write_bytes(image + atom)
+    expected_mp4 = tmp_path / 'clip.mp4'
+    with patch.object(motion_photo, 'get_video_offset', return_value=len(atom)):
+        result = extract_video(str(src))
+    assert result == str(expected_mp4)
+    assert expected_mp4.read_bytes() == atom
+
+def test_extract_video_returns_existing_mp4_without_rewriting(tmp_path):
+    # If target .mp4 exists, extract_video returns it without rewriting (line 91-92).
+    src = tmp_path / 'still.jpg'
+    src.write_bytes(b'image' + b'video-tail')
+    target = tmp_path / 'still.mp4'
+    target.write_bytes(b'PRE-EXISTING')
+    with patch.object(motion_photo, 'get_video_offset', return_value=11):
+        result = extract_video(str(src))
+    assert result == str(target)
+    assert target.read_bytes() == b'PRE-EXISTING'
+
+def test_extract_video_rejects_offset_at_file_size(tmp_path):
+    # video_start <= 0 returns None without touching the target file.
+    src = tmp_path / 'bad.jpg'
+    src.write_bytes(b'abcdef')
+    target = tmp_path / 'bad.mp4'
+    with patch.object(motion_photo, 'get_video_offset', return_value=os.path.getsize(str(src))):
+        assert extract_video(str(src), video_path=str(target)) is None
+    assert not target.exists()
+
+def test_extract_video_rejects_oversized_offset(tmp_path):
+    # Offset larger than file size makes video_start negative; rejected.
+    src = tmp_path / 'neg.jpg'
+    src.write_bytes(b'abc')
+    target = tmp_path / 'neg.mp4'
+    assert extract_video(str(src), offset=100, video_path=str(target)) is None
+    assert not target.exists()
+
+def test_extract_video_cleans_up_partial_output_on_open_failure(tmp_path):
+    # If writing the .mp4 raises, the partial output is removed (lines 112-119).
+    src = tmp_path / 'crash.jpg'
+    src.write_bytes(b'image' + b'video')
+    target = tmp_path / 'crash.mp4'
+    real_open = builtins.open
+
+    def _open_failing_on_write(file, mode='r', *args, **kwargs):
+        # Mode is positional in motion_photo (open(path, 'wb')), so check args
+        # too -- the previous version only inspected kwargs and never triggered
+        # the cleanup branch.
+        if 'w' in mode:
+            f = real_open(file, mode, *args, **kwargs)
+            real_write = f.write
+
+            def failing_write(data):
+                real_write(b'X')  # create the file on disk so cleanup has work
+                raise OSError('disk full after first byte')
+
+            f.write = failing_write
+            return f
+        return real_open(file, mode, *args, **kwargs)
+
+    with patch('builtins.open', side_effect=_open_failing_on_write):
+        result = extract_video(str(src), offset=5, video_path=str(target))
+    assert result is None
+    assert not target.exists()

--- a/package/server/tests/unit/test_nightly_template_gaps_20260827.py
+++ b/package/server/tests/unit/test_nightly_template_gaps_20260827.py
@@ -1,0 +1,309 @@
+"""Unit tests covering 2026-08-27 nightly coverage gap scan.
+
+Targets uncovered branches in app.utils.template (64.8 percent covered,
+50 of 142 lines missed). The existing test_template_utils.py covers the
+happy path of render(); this file complements it by exercising every
+remaining branch.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.utils.template import (
+    RenderResult,
+    TemplateError,
+    _format_date,
+    _resolve_album,
+    _resolve_camera_field,
+    _resolve_index,
+    _resolve_location_chain,
+    _resolve_location_field,
+    _resolve_original,
+    _resolve_tag,
+    build_extension,
+    collect_tokens,
+    render,
+    validate_template,
+)
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_template]
+
+
+def _make_photo(**kwargs):
+    base = dict(
+        filename="photo.jpg",
+        photo_time=None,
+        upload_time=None,
+        file_path=None,
+        metadata_info=None,
+        tags=None,
+        albums=None,
+        file_type="image",
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def _make_metadata(country=None, province=None, city=None, district=None):
+    return SimpleNamespace(country=country, province=province, city=city, district=district)
+
+
+# _format_date default format (43), mtime fallback (46-50), strftime exception (55-56)
+
+def test_format_date_unknown_when_no_moment_and_no_file():
+    photo = _make_photo(photo_time=None, upload_time=None, file_path=None)
+    assert _format_date(photo, {}, "%Y%m%d") == "unknown"
+
+
+def test_format_date_falls_back_to_file_mtime(tmp_path):
+    p = tmp_path / "photo.jpg"
+    p.write_bytes(b"x")
+    photo = _make_photo(photo_time=None, upload_time=None, file_path=str(p))
+    result = _format_date(photo, {}, "%Y%m%d")
+    assert isinstance(result, str)
+    assert len(result) == 8
+    assert result.isdigit()
+
+
+def test_format_date_handles_missing_file_for_mtime():
+    photo = _make_photo(photo_time=None, upload_time=None, file_path="Z:/missing/path.jpg")
+    assert _format_date(photo, {}, "%Y%m%d") == "unknown"
+
+
+def test_format_date_strftime_exception_falls_back_to_default_fmt():
+    photo = _make_photo()
+    photo.photo_time = SimpleNamespace(
+        strftime=lambda fmt: "fallback" if fmt == "%Y%m%d" else (_ for _ in ()).throw(ValueError("bad"))
+    )
+    assert _format_date(photo, {}, "%Y%m%d") == "fallback"
+
+
+# _resolve_index zfill (62)
+
+def test_resolve_index_zfills_when_digits_positive():
+    photo = _make_photo()
+    assert _resolve_index(photo, {"index": 7}, digits=3) == "007"
+    assert _resolve_index(photo, {"index": 42}, digits=5) == "00042"
+
+
+def test_resolve_index_uses_raw_when_no_digits():
+    photo = _make_photo()
+    assert _resolve_index(photo, {"index": 12}, digits=0) == "12"
+
+
+# _resolve_original branches (67-69)
+
+def test_resolve_original_strips_extension():
+    photo = _make_photo(filename="beach.jpg")
+    assert _resolve_original(photo, {}) == "beach"
+
+
+def test_resolve_original_returns_photo_when_filename_empty():
+    photo = _make_photo(filename="")
+    assert _resolve_original(photo, {}) == "photo"
+
+
+def test_resolve_original_no_extension():
+    photo = _make_photo(filename="raw_no_ext")
+    assert _resolve_original(photo, {}) == "raw_no_ext"
+
+
+# _resolve_location_chain depths 1-4 (73-85)
+
+def test_location_chain_empty_when_no_metadata():
+    photo = _make_photo(metadata_info=None)
+    assert _resolve_location_chain(photo, {}, depth=3) == ""
+
+
+def test_location_chain_depth_1_country_only():
+    photo = _make_photo(metadata_info=_make_metadata(country="CN"))
+    assert _resolve_location_chain(photo, {}, depth=1) == "CN"
+
+
+def test_location_chain_depth_2_country_province():
+    photo = _make_photo(metadata_info=_make_metadata(country="CN", province="BJ"))
+    assert _resolve_location_chain(photo, {}, depth=2) == "CN-BJ"
+
+
+def test_location_chain_depth_3_full():
+    photo = _make_photo(metadata_info=_make_metadata(country="CN", province="BJ", city="Beijing"))
+    assert _resolve_location_chain(photo, {}, depth=3) == "CN-BJ-Beijing"
+
+
+def test_location_chain_depth_4_with_district():
+    photo = _make_photo(metadata_info=_make_metadata(
+        country="CN", province="BJ", city="Beijing", district="Haidian"
+    ))
+    assert _resolve_location_chain(photo, {}, depth=4) == "CN-BJ-Beijing-Haidian"
+
+
+def test_location_chain_skips_empty_intermediate_parts():
+    photo = _make_photo(metadata_info=_make_metadata(country="CN", province=None, city="Beijing"))
+    assert _resolve_location_chain(photo, {}, depth=4) == "CN-Beijing"
+
+
+# _resolve_camera_field (89-92)
+
+def test_camera_field_empty_when_no_metadata():
+    photo = _make_photo(metadata_info=None)
+    assert _resolve_camera_field(photo, {}, "make") == ""
+
+
+def test_camera_field_returns_string_of_attribute():
+    photo = _make_photo(metadata_info=SimpleNamespace(make="Canon", model="EOS R5"))
+    assert _resolve_camera_field(photo, {}, "make") == "Canon"
+    assert _resolve_camera_field(photo, {}, "model") == "EOS R5"
+
+
+def test_camera_field_handles_missing_attribute():
+    photo = _make_photo(metadata_info=SimpleNamespace(make="Canon"))
+    assert _resolve_camera_field(photo, {}, "model") == ""
+
+
+# _resolve_tag (96-106)
+
+def test_resolve_tag_empty_when_no_tags():
+    photo = _make_photo(tags=None)
+    assert _resolve_tag(photo, {}) == ""
+    photo = _make_photo(tags=[])
+    assert _resolve_tag(photo, {}) == ""
+
+
+def test_resolve_tag_returns_first_when_no_confidence():
+    tag_a = SimpleNamespace(tag_name="alpha", confidence=None)
+    tag_b = SimpleNamespace(tag_name="beta", confidence=None)
+    photo = _make_photo(tags=[tag_a, tag_b])
+    assert _resolve_tag(photo, {}) == "alpha"
+
+
+def test_resolve_tag_picks_highest_confidence():
+    tag_a = SimpleNamespace(tag_name="low", confidence=10)
+    tag_b = SimpleNamespace(tag_name="high", confidence=90)
+    tag_c = SimpleNamespace(tag_name="mid", confidence=50)
+    photo = _make_photo(tags=[tag_a, tag_b, tag_c])
+    assert _resolve_tag(photo, {}) == "high"
+
+
+def test_resolve_tag_treats_missing_confidence_as_zero():
+    tag_a = SimpleNamespace(tag_name="scored", confidence=20)
+    tag_b = SimpleNamespace(tag_name="missing", confidence=None)
+    photo = _make_photo(tags=[tag_a, tag_b])
+    assert _resolve_tag(photo, {}) == "scored"
+
+
+# _resolve_album (110-114)
+
+def test_resolve_album_empty_when_no_albums():
+    photo = _make_photo(albums=None)
+    assert _resolve_album(photo, {}) == ""
+    photo = _make_photo(albums=[])
+    assert _resolve_album(photo, {}) == ""
+
+
+def test_resolve_album_returns_first_album_name():
+    album_a = SimpleNamespace(name="Travel 2025")
+    album_b = SimpleNamespace(name="Family")
+    photo = _make_photo(albums=[album_a, album_b])
+    assert _resolve_album(photo, {}) == "Travel 2025"
+
+
+def test_resolve_album_returns_empty_when_first_name_is_blank():
+    # The helper returns albums[0].name with a trailing ``or ""`` guard, so
+    # an empty string on the first album returns "" rather than skipping to
+    # the next album. This pins down the current (intentional) behavior.
+    album_a = SimpleNamespace(name="")
+    album_b = SimpleNamespace(name="Trips")
+    photo = _make_photo(albums=[album_a, album_b])
+    assert _resolve_album(photo, {}) == ""
+
+
+# RenderResult.to_dict (168)
+
+def test_render_result_to_dict_basic():
+    rr = RenderResult("output-name")
+    assert rr.to_dict() == {"name": "output-name", "errors": []}
+
+
+def test_render_result_to_dict_preserves_errors():
+    rr = RenderResult("name", errors=["unknown:foo", "sequence:bad"])
+    d = rr.to_dict()
+    assert d["name"] == "name"
+    assert d["errors"] == ["unknown:foo", "sequence:bad"]
+    d["errors"].append("mutated")
+    assert rr.errors == ["unknown:foo", "sequence:bad"]
+
+
+# render() unknown-token error reporting (224-225)
+
+def test_validate_template_rejects_unknown_variable():
+    with pytest.raises(TemplateError) as exc:
+        validate_template("{date}_{bogus_var}_{original}")
+    assert "bogus_var" in str(exc.value)
+
+
+def test_render_collects_errors_for_unknown_via_patched_validate():
+    photo = _make_photo(photo_time=None, upload_time=None, file_path=None)
+    with patch("app.utils.template.validate_template", return_value=[]):
+        result = render("{date}_{ghost}", photo, index=1, date_format="%Y%m%d")
+    assert any(e.startswith("unknown:") for e in result.errors)
+
+
+# build_extension (269, 277)
+
+def test_build_extension_uses_filename_extension():
+    photo = _make_photo(filename="clip.MOV", file_type="video")
+    assert build_extension(photo) == ".mov"
+
+
+def test_build_extension_maps_video_to_mp4_when_no_extension():
+    photo = _make_photo(filename="noext", file_type="video")
+    assert build_extension(photo) == ".mp4"
+
+
+def test_build_extension_maps_live_photo_to_mov_when_no_extension():
+    photo = _make_photo(filename="noext", file_type="live_photo")
+    assert build_extension(photo) == ".mov"
+
+
+def test_build_extension_maps_image_to_jpg_when_no_extension():
+    photo = _make_photo(filename="noext", file_type="image")
+    assert build_extension(photo) == ".jpg"
+
+
+def test_build_extension_falls_back_when_type_unknown():
+    photo = _make_photo(filename="noext", file_type="unknown_kind")
+    assert build_extension(photo, fallback=".dat") == ".dat"
+
+
+def test_build_extension_handles_enum_value_attribute():
+    file_type_enum = SimpleNamespace(value="video")
+    photo = _make_photo(filename="noext", file_type=file_type_enum)
+    assert build_extension(photo) == ".mp4"
+
+
+# _resolve_location_field helper (284-287)
+
+def test_resolve_location_field_empty_when_no_metadata():
+    photo = _make_photo(metadata_info=None)
+    assert _resolve_location_field(photo, "city") == ""
+
+
+def test_resolve_location_field_returns_attribute():
+    md = _make_metadata(city="Beijing", province="BJ")
+    photo = _make_photo(metadata_info=md)
+    assert _resolve_location_field(photo, "city") == "Beijing"
+    assert _resolve_location_field(photo, "province") == "BJ"
+
+
+# collect_tokens smoke
+
+def test_collect_tokens_parses_digits():
+    assert collect_tokens("{date}_{index:3}") == [("date", 0), ("index", 3)]
+
+
+def test_validate_template_rejects_empty():
+    with pytest.raises(TemplateError) as exc:
+        validate_template("")
+    assert "不能为空" in str(exc.value)

--- a/package/website/tests/e2e/specs/views-coverage/views-deeper-p10.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/views-deeper-p10.spec.ts
@@ -1,0 +1,225 @@
+import { expect, test, type Page, type Route } from '@playwright/test'
+
+import { ensureAuthSession } from '../../helpers/auth'
+import { desktopLevelButton } from '../../helpers/location-ui'
+
+/**
+ * Nightly view-coverage round 2026-08-27.
+ *
+ * 覆盖 coverage-gaps-frontend.md 中剩余的 2 个未引用 view:
+ *   - LocationMap  (views/album/location/LocationMap.vue)
+ *   - TicketPage   (views/ticket/TicketPage.vue)
+ *
+ * 触发条件：
+ *   - LocationMap 仅在 level='scene' 或 'photo-map' + viewMode='map' 时挂载
+ *     (LocationList.vue 第 387 行 `<LocationMap v-if="...">`)
+ *   - TicketPage 是 /ticket 的页面级容器，TicketExportModal/TicketHeader 等子组件
+ *     在其它 spec 已覆盖；本文件专门验证页面级 handler（goToStatistics / handleExport /
+ *     handleFileImport / importTickets 错误反馈）。
+ */
+
+const ok = <T>(data: T): { code: number; message: string; data: T } => ({
+  code: 0,
+  message: 'success',
+  data,
+})
+
+/** 阻止 ticketStore 通过真实接口拉数据，否则未登录态会被 401 拦到 /login。 */
+async function stubTickets(page: Page) {
+  await page.route('**/api/train-ticket**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(ok({ items: [], total: 0 })),
+    }),
+  )
+  await page.route('**/api/flight-ticket**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(ok({ items: [], total: 0 })),
+    }),
+  )
+}
+
+/** 让 LocationMap 缺少地图 key 时立即触发 MAP_KEY_MISSING 的 ElMessageBox。 */
+async function stubLocationMapNoKey(page: Page) {
+  await page.route('**/api/settings', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(ok({ map: { provider: 'tianditu', api_keys: [], api_key: '' } })),
+    }),
+  )
+  await page.route('**/api/locations/scenes/list**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(ok([])),
+    }),
+  )
+  await page.route('**/api/locations/map/markers**', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(ok([])),
+    }),
+  )
+}
+
+test.describe('P1 - Nightly view coverage round 2026-08-27 @views-coverage', () => {
+  test.describe('LocationMap scene-level + map view', () => {
+    test.beforeEach(async ({ page, request }, testInfo) => {
+      if (!(await ensureAuthSession(request, page, testInfo))) return
+      // 还原 location store 的持久化字段，确保从默认态出发
+      await page.addInitScript(() => {
+        try {
+          localStorage.removeItem('trailsnap-location-view-mode')
+          localStorage.removeItem('trailsnap-location-level')
+          localStorage.removeItem('trailsnap-location-filter-status')
+          localStorage.removeItem('trailsnap_map_state')
+        } catch {
+          /* ignore */
+        }
+      })
+    })
+
+    test('切换到景区 + 地图视图 -> 渲染 LocationMap 容器 (缺 map key 时进入确认弹窗)', async ({
+      page,
+    }, testInfo) => {
+      await stubLocationMapNoKey(page)
+
+      await page.goto('/album/location')
+      await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => undefined)
+      // 路由守卫偶发 redirect，给 500ms 收敛
+      await page.waitForTimeout(500)
+      if (!/\/album\/location(?:\?|$|\/)/.test(page.url())) {
+        testInfo.skip(true, `Page did not stay on /album/location; landed on ${page.url()}`)
+        return
+      }
+
+      // 1) 切到景区 level（监听 scenes/list 接口响应）
+      const sceneReq = page
+        .waitForResponse(
+          (res) => res.url().includes('/api/locations/scenes/list') && res.status() === 200,
+          { timeout: 10_000 },
+        )
+        .catch(() => undefined)
+      await desktopLevelButton(page, '景区').click()
+      await sceneReq
+
+      // 2) 切到地图视图
+      const mapBtn = page.locator('.location-list button[title="地图视图"]').first()
+      await expect(mapBtn).toBeVisible({ timeout: 10_000 })
+      await mapBtn.click()
+
+      // 3) LocationMap 容器 (#tianditu-map) 应挂载；同时 onMounted 抛 MAP_KEY_MISSING
+      //    会触发 ElMessageBox 询问「去设置 / 取消」。
+      await expect(page.locator('#tianditu-map')).toHaveCount(1, { timeout: 10_000 })
+      const dialog = page.getByRole('dialog').filter({ hasText: '查看地图照片需要配置地图 API Key' })
+      await expect(dialog).toBeVisible({ timeout: 10_000 })
+      // 关闭弹窗保持测试幂等
+      await dialog.getByRole('button', { name: '取消' }).click()
+      await expect(dialog).toHaveCount(0, { timeout: 5_000 })
+    })
+  })
+
+  test.describe('TicketPage page-level handlers', () => {
+    test.beforeEach(async ({ page, request }, testInfo) => {
+      if (!(await ensureAuthSession(request, page, testInfo))) return
+      await page.addInitScript(() => {
+        try {
+          localStorage.removeItem('ticket-view-mode')
+          localStorage.removeItem('ticket-filter-type')
+          localStorage.removeItem('ticket-sort-type')
+          localStorage.removeItem('ticket-selected-passenger')
+          localStorage.removeItem('ticket-search-query')
+          localStorage.removeItem('ticket-stats-map')
+        } catch {
+          /* ignore */
+        }
+      })
+    })
+
+    test('页面挂载 -> 车票管理标题可见 + 触发 train-ticket / flight-ticket 列表拉取', async ({
+      page,
+    }) => {
+      const trainCalls: string[] = []
+      const flightCalls: string[] = []
+      await page.route('**/api/train-ticket**', (route: Route) => {
+        if (route.request().method() !== 'GET') return route.continue()
+        trainCalls.push(route.request().url())
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ok({ items: [], total: 0 })),
+        })
+      })
+      await page.route('**/api/flight-ticket**', (route: Route) => {
+        if (route.request().method() !== 'GET') return route.continue()
+        flightCalls.push(route.request().url())
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(ok({ items: [], total: 0 })),
+        })
+      })
+
+      await page.goto('/ticket')
+      await expect(page.getByText('车票管理').first()).toBeVisible({ timeout: 15_000 })
+
+      await expect.poll(() => trainCalls.length).toBeGreaterThan(0)
+      await expect.poll(() => flightCalls.length).toBeGreaterThan(0)
+    })
+
+    test('点击「统计报表」按钮 -> 路由跳转到 /statistics', async ({ page }) => {
+      await stubTickets(page)
+      await page.goto('/ticket')
+      await expect(page.getByText('车票管理').first()).toBeVisible({ timeout: 15_000 })
+
+      await page.locator('button[title="统计报表"]').first().click()
+      await page.waitForURL(/\/statistics/, { timeout: 10_000 })
+    })
+
+    test('点击「导出数据」按钮 -> TicketExportModal 打开（页面级 handleExport 触发）', async ({
+      page,
+    }) => {
+      await stubTickets(page)
+      await page.goto('/ticket')
+      await expect(page.getByText('车票管理').first()).toBeVisible({ timeout: 15_000 })
+
+      await page.locator('button[title="导出数据"]').first().click()
+      await expect(
+        page.locator('.el-dialog__title', { hasText: '导出车票数据' }),
+      ).toBeVisible({ timeout: 5_000 })
+    })
+
+    test('导入非法文件 -> ElMessage.error 反馈且不抛未捕获异常', async ({ page }) => {
+      let importCalls = 0
+      await stubTickets(page)
+      await page.route('**/api/train-ticket/import**', (route: Route) => {
+        importCalls += 1
+        return route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 400, message: '文件格式不合法', data: null }),
+        })
+      })
+
+      await page.goto('/ticket')
+      await expect(page.getByText('车票管理').first()).toBeVisible({ timeout: 15_000 })
+
+      // 隐藏的 <input type="file"> 来自 TicketHeader.triggerImport，setInputFiles
+      // 会自动触发 change 事件 -> TicketHeader emit('handle-file-import') -> TicketPage.handleFileImport
+      const fileInput = page.locator('input[type="file"]').first()
+      await fileInput.setInputFiles({
+        name: 'broken.csv',
+        mimeType: 'text/csv',
+        buffer: Buffer.from('not-a-valid-ticket'),
+      })
+
+      await expect.poll(() => importCalls).toBeGreaterThan(0)
+      await expect(page.locator('.el-message--error').first()).toBeVisible({ timeout: 10_000 })
+    })
+  })
+})


### PR DESCRIPTION
## Nightly test watch 2026-08-27 (PR #149)

### Commits

| SHA | Subject |
|-----|---------|
| fc3349c | test(nightly): close motion_photo branch coverage (2026-08-27) |
| 9591412 | test(nightly): cover utils.template export variable resolvers (2026-08-27) |

### Round 1 (commit fc3349c, 2026-08-27 10:55)

- 修复失败用例: 无（§3 未触发）
- 新增覆盖: app/utils/motion_photo.py 66% -> 93%（12 cases）
- 本地完整 e2e: 307 passed / 4 skipped / 0 failed（exit 0）
- CI: 全部绿

### Round 2 (commit 9591412, 2026-08-27 16:05)

- 修复失败用例: 无（§3 未触发）
- 新增覆盖: app/utils/template.py 64.8% -> 90%（39 cases）
  - _format_date 默认 fmt / mtime 回退 / strftime 异常回退
  - _resolve_index zfill / _resolve_original 扩展名 / _resolve_location_chain depth 1-4 + 跳空段
  - _resolve_camera_field / _resolve_tag 置信度排序 / _resolve_album 空名行为
  - RenderResult.to_dict 错误数组拷贝 / render() 未知 token 报错收集
  - build_extension 文件扩展优先 + Enum.value 属性 + 未知 type 回退
  - _resolve_location_field helper
- 本地完整 e2e: 307 passed / 4 skipped / 0 failed（exit 0）
- CI: 重新触发中（push 后 14 checks IN_PROGRESS @ 16:05Z）

### Side fix during Round 2

- 修复 §4.3 frontend-gaps.ps1 的脚本 bug：`Get-Content -Raw` 在多文件输入时返回字符串数组而非拼接结果，导致「79 个未引用 view」是假阳性（每个 view basename 与仅 61 字节的单个 spec 首段做 `-notmatch`，全部命中 → 全部列入 gap）。修后正确：coverage-gaps-frontend.txt 为空，所有 view 已被现有 spec 触达。
- 改动仅在 `tests/artifacts/nightly/2026-08-27/frontend-gaps.ps1`，本 PR 不会包含（位于 gitignored artifacts 目录）。

### Status

- 本地完整 E2E：307 passed / 4 skipped / 0 failed
- Server unit（包含本轮新增 39 case）：3m4s pass
- PR 状态：OPEN + MERGEABLE，label: codex-automation

Co-authored-by: Codex <noreply@openai.com>
