### PR TITLE
feat(photo): 记录断舍离处理进度并支持离线同步

### DIFF
--- a/package/server/alembic/versions/6d9f2a4c8e17_0031_add_photo_declutter_records.py
+++ b/package/server/alembic/versions/6d9f2a4c8e17_0031_add_photo_declutter_records.py
@@ -1,0 +1,41 @@
+"""Add durable photo declutter decisions.
+
+Revision ID: 6d9f2a4c8e17
+Revises: f4b7c1d9e203
+Create Date: 2026-08-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.types import UUID
+
+
+revision = "6d9f2a4c8e17"
+down_revision = "f4b7c1d9e203"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "photo_declutter_records",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("owner_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("photo_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("decision", sa.String(length=16), nullable=False),
+        sa.Column("processed_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("decision IN ('keep', 'delete')", name="ck_photo_declutter_decision"),
+        sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["photo_id"], ["photos.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("owner_id", "photo_id", name="uq_photo_declutter_owner_photo"),
+    )
+    op.create_index("ix_photo_declutter_records_owner_id", "photo_declutter_records", ["owner_id"])
+    op.create_index("ix_photo_declutter_records_photo_id", "photo_declutter_records", ["photo_id"])
+    op.create_index("ix_photo_declutter_owner_decision", "photo_declutter_records", ["owner_id", "decision"])
+
+
+def downgrade() -> None:
+    op.drop_table("photo_declutter_records")

--- a/package/server/alembic_sqlite/versions/0005_add_photo_declutter_records.py
+++ b/package/server/alembic_sqlite/versions/0005_add_photo_declutter_records.py
@@ -1,0 +1,41 @@
+"""Add durable photo declutter decisions to SQLite.
+
+Revision ID: sqlite_0005
+Revises: sqlite_0004
+Create Date: 2026-08-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.types import UUID
+
+
+revision = "sqlite_0005"
+down_revision = "sqlite_0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "photo_declutter_records",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("owner_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("photo_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("decision", sa.String(length=16), nullable=False),
+        sa.Column("processed_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("decision IN ('keep', 'delete')", name="ck_photo_declutter_decision"),
+        sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["photo_id"], ["photos.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("owner_id", "photo_id", name="uq_photo_declutter_owner_photo"),
+    )
+    op.create_index("ix_photo_declutter_records_owner_id", "photo_declutter_records", ["owner_id"])
+    op.create_index("ix_photo_declutter_records_photo_id", "photo_declutter_records", ["photo_id"])
+    op.create_index("ix_photo_declutter_owner_decision", "photo_declutter_records", ["owner_id", "decision"])
+
+
+def downgrade() -> None:
+    op.drop_table("photo_declutter_records")

--- a/package/server/app/api/swipe_filter.py
+++ b/package/server/app/api/swipe_filter.py
@@ -1,0 +1,61 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.crud import swipe_filter as crud
+from app.db.models.user import User
+from app.dependencies import BaseResponse, get_db
+from app.schemas.swipe_filter import (
+    SwipeFilterBatch,
+    SwipeFilterDecisionRequest,
+    SwipeFilterDecisionResult,
+    SwipeFilterResetResult,
+    SwipeFilterUndoResult,
+)
+
+
+router = APIRouter()
+
+
+@router.get("", response_model=BaseResponse[SwipeFilterBatch], summary="获取断舍离待处理照片")
+def get_swipe_filter_batch(
+    limit: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    photos, stats = crud.get_batch(db, current_user.id, limit)
+    return BaseResponse.success(data={"photos": photos, "stats": stats})
+
+
+@router.put("/decisions", response_model=BaseResponse[SwipeFilterDecisionResult], summary="保存断舍离结果")
+def save_swipe_filter_decisions(
+    payload: SwipeFilterDecisionRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    try:
+        updated = crud.save_decisions(db, current_user.id, payload.items)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return BaseResponse.success(data={"updated": updated})
+
+
+@router.delete("/decisions/{photo_id}", response_model=BaseResponse[SwipeFilterUndoResult], summary="撤销断舍离结果")
+def undo_swipe_filter_decision(
+    photo_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return BaseResponse.success(data={"undone": crud.undo_decision(db, current_user.id, photo_id)})
+
+
+@router.delete("/decisions", response_model=BaseResponse[SwipeFilterResetResult], summary="重置断舍离处理记录")
+def reset_swipe_filter_decisions(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return BaseResponse.success(data={"reset": crud.reset_decisions(db, current_user.id)})

--- a/package/server/app/crud/photo.py
+++ b/package/server/app/crud/photo.py
@@ -21,7 +21,7 @@ from app.crud import face as crud_face
 from app.crud.album import get_album, _build_album_query, _update_album_photo_count
 from app.crud.cluster import remove_photo_from_clusters
 from app.crud.search_vector import POSITIVE_SENTIMENT_VECTOR
-from app.db.models import Photo, PhotoMetadata, ImageVector, Album, Face, PhotoTag, ImageDescription, Scene
+from app.db.models import Photo, PhotoMetadata, ImageVector, Album, Face, PhotoTag, ImageDescription, Scene, PhotoDeclutterRecord
 from app.db.models.photo import FileType, ImageType
 from app.schemas import photo as photo_schemas
 from app.schemas.metadata import PhotoMetadataUpdate
@@ -1041,6 +1041,19 @@ def restore_photos(db: Session, photo_ids: List[UUID], user_id: UUID = None):
     for photo in photos:
         photo.is_deleted = False
         photo.deleted_at = None
+
+    # Restoring a photo discarded by the swipe filter reverses that decision,
+    # so the photo can be considered again. Keep decisions are intentionally
+    # preserved when a photo happened to be deleted through another workflow.
+    restored_ids = [photo.id for photo in photos]
+    if restored_ids:
+        decision_query = db.query(PhotoDeclutterRecord).filter(
+            PhotoDeclutterRecord.photo_id.in_(restored_ids),
+            PhotoDeclutterRecord.decision == "delete",
+        )
+        if user_id is not None:
+            decision_query = decision_query.filter(PhotoDeclutterRecord.owner_id == user_id)
+        decision_query.delete(synchronize_session=False)
         
     db.commit()
     

--- a/package/server/app/crud/swipe_filter.py
+++ b/package/server/app/crud/swipe_filter.py
@@ -1,0 +1,150 @@
+from datetime import datetime
+from typing import Iterable, List, Tuple
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
+
+from app.crud.album import _update_album_photo_count, trigger_conditional_albums_update
+from app.db.models.album import Album
+from app.db.models.photo import Photo
+from app.db.models.photo_declutter_record import PhotoDeclutterRecord
+
+
+def _available_query(db: Session, owner_id: UUID):
+    handled_ids = db.query(PhotoDeclutterRecord.photo_id).filter(
+        PhotoDeclutterRecord.owner_id == owner_id
+    )
+    return db.query(Photo).filter(
+        Photo.owner_id == owner_id,
+        Photo.is_deleted.is_(False),
+        ~Photo.id.in_(handled_ids),
+    )
+
+
+def get_stats(db: Session, owner_id: UUID) -> dict:
+    decisions = db.query(
+        PhotoDeclutterRecord.decision,
+        func.count(PhotoDeclutterRecord.id),
+    ).filter(
+        PhotoDeclutterRecord.owner_id == owner_id
+    ).group_by(PhotoDeclutterRecord.decision).all()
+    counts = {decision: count for decision, count in decisions}
+    kept = counts.get("keep", 0)
+    deleted = counts.get("delete", 0)
+    processed = kept + deleted
+    remaining = _available_query(db, owner_id).count()
+    return {
+        "processed": processed,
+        "remaining": remaining,
+        "total": processed + remaining,
+        "kept": kept,
+        "deleted": deleted,
+    }
+
+
+def get_batch(db: Session, owner_id: UUID, limit: int) -> Tuple[List[Photo], dict]:
+    photos = _available_query(db, owner_id).options(
+        joinedload(Photo.metadata_info),
+        joinedload(Photo.image_description),
+    ).order_by(func.random()).limit(limit).all()
+    return photos, get_stats(db, owner_id)
+
+
+def _refresh_albums(db: Session, owner_id: UUID, albums: Iterable[Album], photo_id: UUID) -> None:
+    for album_id in {album.id for album in albums}:
+        _update_album_photo_count(db, album_id)
+    trigger_conditional_albums_update(db, owner_id, [photo_id])
+
+
+def save_decisions(db: Session, owner_id: UUID, items) -> int:
+    changed_albums = []
+    changed_photo_ids = []
+
+    try:
+        for item in items:
+            photo = db.query(Photo).options(joinedload(Photo.albums)).filter(
+                Photo.id == item.photo_id,
+                Photo.owner_id == owner_id,
+            ).first()
+            if not photo:
+                raise LookupError(f"Photo {item.photo_id} not found")
+
+            record = db.query(PhotoDeclutterRecord).filter(
+                PhotoDeclutterRecord.owner_id == owner_id,
+                PhotoDeclutterRecord.photo_id == item.photo_id,
+            ).first()
+
+            if item.decision == "keep" and photo.is_deleted:
+                # Switching an existing swipe-delete decision to keep is a valid,
+                # idempotent recovery path. Other deleted photos are not eligible.
+                if not record or record.decision != "delete":
+                    raise ValueError(f"Photo {item.photo_id} is in the recycle bin")
+                photo.is_deleted = False
+                photo.deleted_at = None
+                changed_albums.append(list(photo.albums))
+                changed_photo_ids.append(photo.id)
+            elif item.decision == "delete" and not photo.is_deleted:
+                photo.is_deleted = True
+                photo.deleted_at = datetime.now()
+                changed_albums.append(list(photo.albums))
+                changed_photo_ids.append(photo.id)
+
+            if record:
+                record.decision = item.decision
+                record.updated_at = datetime.now()
+            else:
+                db.add(PhotoDeclutterRecord(
+                    owner_id=owner_id,
+                    photo_id=item.photo_id,
+                    decision=item.decision,
+                ))
+
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    for albums, photo_id in zip(changed_albums, changed_photo_ids):
+        _refresh_albums(db, owner_id, albums, photo_id)
+    return len(items)
+
+
+def undo_decision(db: Session, owner_id: UUID, photo_id: UUID) -> bool:
+    record = db.query(PhotoDeclutterRecord).filter(
+        PhotoDeclutterRecord.owner_id == owner_id,
+        PhotoDeclutterRecord.photo_id == photo_id,
+    ).first()
+    if not record:
+        return False
+
+    photo = db.query(Photo).options(joinedload(Photo.albums)).filter(
+        Photo.id == photo_id,
+        Photo.owner_id == owner_id,
+    ).first()
+    albums = []
+    restored = False
+    if record.decision == "delete" and photo and photo.is_deleted:
+        photo.is_deleted = False
+        photo.deleted_at = None
+        albums = list(photo.albums)
+        restored = True
+
+    try:
+        db.delete(record)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    if restored:
+        _refresh_albums(db, owner_id, albums, photo_id)
+    return True
+
+
+def reset_decisions(db: Session, owner_id: UUID) -> int:
+    count = db.query(PhotoDeclutterRecord).filter(
+        PhotoDeclutterRecord.owner_id == owner_id
+    ).delete(synchronize_session=False)
+    db.commit()
+    return count

--- a/package/server/app/db/models/__init__.py
+++ b/package/server/app/db/models/__init__.py
@@ -16,5 +16,6 @@ from .cluster import ImageCluster, PhotoCluster
 from .agent import AgentSession, AgentMessage
 from .agent_token import AgentToken
 from .photo_color import PhotoColor
+from .photo_declutter_record import PhotoDeclutterRecord
 from .notification import Notification, NotificationType, NotificationLevel
 from .moment_day_caption import MomentDayCaption

--- a/package/server/app/db/models/photo_declutter_record.py
+++ b/package/server/app/db/models/photo_declutter_record.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Index, String, UniqueConstraint
+
+from app.db.base import Base
+from app.db.types import UUID
+
+
+class PhotoDeclutterRecord(Base):
+    """A user's durable keep/delete decision in the swipe-filter workflow."""
+
+    __tablename__ = "photo_declutter_records"
+    __table_args__ = (
+        UniqueConstraint("owner_id", "photo_id", name="uq_photo_declutter_owner_photo"),
+        CheckConstraint("decision IN ('keep', 'delete')", name="ck_photo_declutter_decision"),
+        Index("ix_photo_declutter_owner_decision", "owner_id", "decision"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    owner_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    photo_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("photos.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    decision = Column(String(16), nullable=False)
+    processed_at = Column(DateTime, nullable=False, default=datetime.now)
+    updated_at = Column(DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)

--- a/package/server/app/schemas/swipe_filter.py
+++ b/package/server/app/schemas/swipe_filter.py
@@ -1,0 +1,43 @@
+from typing import List, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from app.schemas.metadata import PhotoDetail
+
+
+Decision = Literal["keep", "delete"]
+
+
+class SwipeFilterStats(BaseModel):
+    processed: int
+    remaining: int
+    total: int
+    kept: int
+    deleted: int
+
+
+class SwipeFilterBatch(BaseModel):
+    photos: List[PhotoDetail]
+    stats: SwipeFilterStats
+
+
+class SwipeFilterDecisionItem(BaseModel):
+    photo_id: UUID
+    decision: Decision
+
+
+class SwipeFilterDecisionRequest(BaseModel):
+    items: List[SwipeFilterDecisionItem] = Field(min_length=1, max_length=100)
+
+
+class SwipeFilterDecisionResult(BaseModel):
+    updated: int
+
+
+class SwipeFilterUndoResult(BaseModel):
+    undone: bool
+
+
+class SwipeFilterResetResult(BaseModel):
+    reset: int

--- a/package/server/main.py
+++ b/package/server/main.py
@@ -32,7 +32,7 @@ from app.api import (
     user, train_ticket, flight_ticket, album, index, settings, face, ocr,
     location, location_stats, search, classification, system, media, stats, photo, tasks,
     annual_report, auth, deps, agent, agent_token, toolbox, metadata, nav, guess_city, storage,
-    notification, moment
+    notification, moment, swipe_filter
 )
 from railway.api import router as railway_router
 from app.core.logger import setup_logging
@@ -289,6 +289,7 @@ app.include_router(user.router, prefix="/users", tags=["Users"])
 app.include_router(train_ticket.router, prefix="/train-ticket", tags=["train-ticket"])
 app.include_router(flight_ticket.router, prefix="/flight-ticket", tags=["flight-ticket"])
 app.include_router(railway_router, prefix="/railway", tags=["railway"])
+app.include_router(swipe_filter.router, prefix="/photos/swipe-filter", tags=["SwipeFilter"])
 app.include_router(photo.router, prefix="/photos", tags=["Photos"])
 app.include_router(metadata.router, prefix="/metadata", tags=["Metadata"])
 app.include_router(album.router,prefix="/albums", tags=["Albums"])

--- a/package/server/tests/unit/test_sqlite_migration_schema.py
+++ b/package/server/tests/unit/test_sqlite_migration_schema.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 import pytest
 from sqlalchemy import create_engine, inspect, text
 
@@ -47,6 +48,7 @@ def test_frozen_sqlite_migrations_match_current_metadata(tmp_path, monkeypatch):
             assert actual_indexes == expected_indexes, table_name
 
         with engine.connect() as connection:
-            assert connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one() == "sqlite_0004"
+            database_revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+            assert database_revision == ScriptDirectory.from_config(config).get_current_head()
     finally:
         engine.dispose()

--- a/package/server/tests/unit/test_swipe_filter.py
+++ b/package/server/tests/unit/test_swipe_filter.py
@@ -1,0 +1,157 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api import swipe_filter as swipe_filter_api
+from app.crud import photo as photo_crud
+from app.crud import swipe_filter as swipe_filter_crud
+from app.db.base import Base
+from app.db.models.photo import FileType, Photo
+from app.db.models.photo_declutter_record import PhotoDeclutterRecord
+from app.db.models.user import User
+from app.schemas.swipe_filter import SwipeFilterDecisionItem, SwipeFilterDecisionRequest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)
+
+
+def _user(db, username: str) -> User:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password="test",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _photo(db, owner: User, name: str) -> Photo:
+    photo = Photo(
+        filename=name,
+        file_path=f"/{owner.id}/{name}",
+        file_type=FileType.image,
+        size=1,
+        owner_id=owner.id,
+        is_deleted=False,
+    )
+    db.add(photo)
+    db.commit()
+    db.refresh(photo)
+    return photo
+
+
+def _item(photo: Photo, decision: str) -> SwipeFilterDecisionItem:
+    return SwipeFilterDecisionItem(photo_id=photo.id, decision=decision)
+
+
+def test_decisions_are_durable_excluded_idempotent_and_user_scoped(db):
+    owner = _user(db, "owner")
+    other = _user(db, "other")
+    first = _photo(db, owner, "first.jpg")
+    second = _photo(db, owner, "second.jpg")
+    third = _photo(db, owner, "third.jpg")
+    other_photo = _photo(db, other, "other.jpg")
+
+    with patch.object(swipe_filter_crud, "_refresh_albums"):
+        assert swipe_filter_crud.save_decisions(
+            db, owner.id, [_item(first, "keep"), _item(second, "delete")]
+        ) == 2
+        # Repeating the same decision updates the existing row instead of
+        # creating a duplicate or failing because the photo is now deleted.
+        assert swipe_filter_crud.save_decisions(db, owner.id, [_item(second, "delete")]) == 1
+
+    records = db.query(PhotoDeclutterRecord).filter_by(owner_id=owner.id).all()
+    assert len(records) == 2
+    assert db.get(Photo, second.id).is_deleted is True
+
+    batch, stats = swipe_filter_crud.get_batch(db, owner.id, limit=20)
+    assert [photo.id for photo in batch] == [third.id]
+    assert other_photo.id not in {photo.id for photo in batch}
+    assert stats == {
+        "processed": 2,
+        "remaining": 1,
+        "total": 3,
+        "kept": 1,
+        "deleted": 1,
+    }
+
+
+def test_undo_restores_delete_and_reset_only_clears_records(db):
+    owner = _user(db, "undo-owner")
+    kept = _photo(db, owner, "kept.jpg")
+    deleted = _photo(db, owner, "deleted.jpg")
+
+    with patch.object(swipe_filter_crud, "_refresh_albums"):
+        swipe_filter_crud.save_decisions(
+            db, owner.id, [_item(kept, "keep"), _item(deleted, "delete")]
+        )
+        assert swipe_filter_crud.undo_decision(db, owner.id, deleted.id) is True
+
+    assert db.get(Photo, deleted.id).is_deleted is False
+    assert db.query(PhotoDeclutterRecord).filter_by(photo_id=deleted.id).first() is None
+    assert swipe_filter_crud.reset_decisions(db, owner.id) == 1
+    assert db.query(PhotoDeclutterRecord).filter_by(owner_id=owner.id).count() == 0
+    assert db.get(Photo, kept.id).is_deleted is False
+
+
+def test_recycle_bin_restore_reopens_swipe_deleted_photo(db):
+    owner = _user(db, "restore-owner")
+    photo = _photo(db, owner, "restore.jpg")
+
+    with patch.object(swipe_filter_crud, "_refresh_albums"):
+        swipe_filter_crud.save_decisions(db, owner.id, [_item(photo, "delete")])
+
+    with patch.object(photo_crud, "_update_album_photo_count"), patch(
+        "app.crud.album.trigger_conditional_albums_update"
+    ):
+        assert photo_crud.restore_photos(db, [photo.id], user_id=owner.id) == 1
+
+    assert db.get(Photo, photo.id).is_deleted is False
+    assert db.query(PhotoDeclutterRecord).filter_by(photo_id=photo.id).first() is None
+    batch, stats = swipe_filter_crud.get_batch(db, owner.id, limit=20)
+    assert [item.id for item in batch] == [photo.id]
+    assert stats["remaining"] == 1
+
+
+def test_api_wraps_batch_and_maps_decisions():
+    db = MagicMock()
+    user = SimpleNamespace(id=uuid4())
+    photo = SimpleNamespace(id=uuid4())
+    stats = {"processed": 0, "remaining": 1, "total": 1, "kept": 0, "deleted": 0}
+
+    with patch.object(swipe_filter_api.crud, "get_batch", return_value=([photo], stats)):
+        response = swipe_filter_api.get_swipe_filter_batch(limit=20, db=db, current_user=user)
+    assert response.code == 0
+    assert response.data["photos"] == [photo]
+    assert response.data["stats"] == stats
+
+    payload = SwipeFilterDecisionRequest(items=[
+        SwipeFilterDecisionItem(photo_id=photo.id, decision="keep")
+    ])
+    with patch.object(swipe_filter_api.crud, "save_decisions", return_value=1) as save:
+        response = swipe_filter_api.save_swipe_filter_decisions(payload, db=db, current_user=user)
+    save.assert_called_once_with(db, user.id, payload.items)
+    assert response.data == {"updated": 1}

--- a/package/website/src/api/photo.ts
+++ b/package/website/src/api/photo.ts
@@ -2,6 +2,21 @@ import request from '@/utils/request'
 import type { AlbumImage,Photo, SimilarPhoto } from '@/types/album'
 import type { Task as TaskResponse } from '@/api/tasks'
 
+export type SwipeFilterDecision = 'keep' | 'delete'
+
+export interface SwipeFilterStats {
+  processed: number
+  remaining: number
+  total: number
+  kept: number
+  deleted: number
+}
+
+export interface SwipeFilterBatch {
+  photos: Photo[]
+  stats: SwipeFilterStats
+}
+
 export const photoApi = {
   // Similar Photo Task API
   async createSimilarTask(threshold: number = 0.9) {
@@ -74,6 +89,26 @@ export const photoApi = {
       params: { limit }
     });
     return data.data;
+  },
+
+  async getSwipeFilterBatch(limit: number = 20): Promise<SwipeFilterBatch> {
+    const data = await request.get('/api/photos/swipe-filter', { params: { limit } })
+    return data.data
+  },
+
+  async saveSwipeFilterDecisions(items: Array<{ photo_id: string; decision: SwipeFilterDecision }>) {
+    const data = await request.put('/api/photos/swipe-filter/decisions', { items })
+    return data.data as { updated: number }
+  },
+
+  async undoSwipeFilterDecision(photoId: string) {
+    const data = await request.delete(`/api/photos/swipe-filter/decisions/${photoId}`)
+    return data.data as { undone: boolean }
+  },
+
+  async resetSwipeFilterDecisions() {
+    const data = await request.delete('/api/photos/swipe-filter/decisions')
+    return data.data as { reset: number }
   },
 
   async batchDownload(photoIds: string[]) {

--- a/package/website/src/views/settings/ExternalGallery.vue
+++ b/package/website/src/views/settings/ExternalGallery.vue
@@ -1,11 +1,14 @@
 <template>
-  <div class="p-4 md:p-6 bg-white rounded-lg shadow-sm border border-gray-100 dark:bg-gray-800 dark:border-gray-700">
-    <h2 class="text-xl md:text-2xl font-semibold mb-4 border-b pb-2 dark:text-white">外部图库管理</h2>
+  <div class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 md:p-6">
+    <div class="mb-5">
+      <h2 class="text-xl font-semibold text-gray-900 dark:text-white md:text-2xl">外部图库</h2>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">接入已有照片文件夹，TrailSnap 会为照片建立索引，不会移动或修改源文件。</p>
+    </div>
 
     <el-tabs v-model="activeTab" class="demo-tabs">
       <el-tab-pane label="目录管理" name="directories">
         <!-- 管理员可切换目标用户 -->
-        <div v-if="userStore.userInfo?.is_superuser" class="mb-4 p-4 bg-gray-50 dark:bg-gray-900 rounded border border-gray-200 dark:border-gray-700">
+        <div v-if="userStore.userInfo?.is_superuser && !desktopMode" class="mb-4 p-4 bg-gray-50 dark:bg-gray-900 rounded border border-gray-200 dark:border-gray-700">
           <span class="text-sm font-medium mr-2 dark:text-gray-300">管理用户目录:</span>
           <el-select v-model="selectedUserId" placeholder="选择用户" class="w-64">
             <el-option
@@ -17,12 +20,66 @@
           </el-select>
         </div>
 
-        <!-- 候选发现区（仅管理员） -->
-        <div v-if="isSuperuser" class="mb-6">
-          <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
-            <h3 class="text-base font-medium dark:text-gray-200">照片目录接入</h3>
+        <!-- 桌面端以系统目录选择器作为主入口 -->
+        <section
+          v-if="isSuperuser && desktopMode"
+          class="mb-6 overflow-hidden rounded-xl border p-5 md:p-6"
+          style="border-color: rgba(var(--theme-rgb), 0.2); background-color: rgba(var(--theme-rgb), 0.05)"
+        >
+          <div class="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+            <div class="flex min-w-0 items-start gap-4">
+              <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary-500 text-white shadow-primary-500/20">
+                <FolderPlus class="h-5 w-5" />
+              </div>
+              <div>
+                <h3 class="font-semibold text-gray-900 dark:text-white">添加本机照片文件夹</h3>
+                <p class="mt-1 text-sm leading-6 text-gray-500 dark:text-gray-400">选择电脑上的照片目录，添加后会立即在后台扫描。以后新增的照片可通过“重新扫描”同步。</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-primary-500 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition hover:bg-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+              @click="chooseFolder"
+            >
+              <FolderOpen class="h-4 w-4" />
+              选择照片文件夹
+            </button>
+          </div>
+
+          <div v-if="manualPath" class="mt-5 rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center">
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                  <HardDrive class="h-3.5 w-3.5" /> 已选择
+                </div>
+                <p class="mt-1 truncate text-sm font-medium text-gray-900 dark:text-gray-100" :title="manualPath">{{ manualPath }}</p>
+                <p v-if="manualMsg" class="mt-1 text-xs" :class="manualValid ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'">{{ manualMsg }}</p>
+              </div>
+              <div class="flex shrink-0 gap-2">
+                <el-button class="focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" @click="chooseFolder">重新选择</el-button>
+                <el-button class="focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" type="primary" :loading="submitting || validating" :disabled="!manualValid" @click="addManual">添加并扫描</el-button>
+              </div>
+            </div>
+          </div>
+
+          <details class="mt-4 text-sm">
+            <summary class="cursor-pointer select-none text-gray-500 hover:text-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-gray-400">无法选择？手动输入目录路径</summary>
+            <div class="mt-3 flex flex-col gap-2 sm:flex-row">
+              <el-input ref="manualInputRef" v-model="manualPath" placeholder="例如 D:/Photos/family" @input="resetManualValidation" />
+              <el-button class="focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" :loading="validating" @click="validateManual">校验路径</el-button>
+            </div>
+          </details>
+        </section>
+
+        <!-- 服务端部署以挂载目录自动发现作为主入口 -->
+        <div v-if="isSuperuser && !desktopMode" class="mb-6">
+          <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <h3 class="font-medium text-gray-900 dark:text-gray-200">添加照片目录</h3>
+              <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">自动发现服务端已挂载的照片文件夹，也可以手动指定路径。</p>
+            </div>
             <div class="flex gap-2">
-              <el-button size="small" @click="showDockerGuide = true">查看 Docker 配置</el-button>
+              <el-button size="small" @click="showDockerGuide = true">Docker 挂载说明</el-button>
               <el-button size="small" type="primary" plain :loading="detecting" @click="loadCandidates">重新检测</el-button>
             </div>
           </div>
@@ -39,7 +96,7 @@
               下自动发现照片图库，当前该目录不存在。可直接手动添加本机任意照片文件夹路径；若使用 Docker 部署，也可按挂载示例把照片目录挂到该路径下。
             </p>
             <div class="flex justify-center gap-2 flex-wrap">
-              <el-button type="primary" @click="focusManual">手动添加路径</el-button>
+              <el-button type="primary" @click="focusManual">手动指定路径</el-button>
               <el-button @click="showDockerGuide = true">查看 Docker 配置</el-button>
             </div>
           </div>
@@ -101,28 +158,42 @@
         </div>
 
         <!-- 已接入图库 -->
-        <div class="mb-6">
-          <h3 class="text-base font-medium mb-3 dark:text-gray-200">已接入图库</h3>
-          <el-table :data="registeredDirs" style="width: 100%" border>
-            <el-table-column label="目录路径" min-width="240">
-              <template #default="{ row }">
-                <div class="break-all text-sm">{{ row.path }}</div>
-                <el-tag v-if="!isUnderRoot(row.path)" type="info" size="small" class="mt-1">自定义路径</el-tag>
-              </template>
-            </el-table-column>
-            <el-table-column v-if="isSuperuser" label="操作" width="200">
-              <template #default="{ row }">
-                <el-button size="small" @click="scanDir(row.path)">重新扫描</el-button>
-                <el-button type="danger" size="small" @click="removeDir(row.path)">移除</el-button>
-              </template>
-            </el-table-column>
-          </el-table>
-          <p v-if="registeredDirs.length === 0" class="text-sm text-gray-400 dark:text-gray-500 mt-2">尚未接入任何图库。</p>
+        <section class="mb-6">
+          <div class="mb-3 flex items-center justify-between">
+            <h3 class="font-medium text-gray-900 dark:text-gray-200">已添加的文件夹</h3>
+            <span v-if="registeredDirs.length" class="rounded-full bg-gray-100 px-2.5 py-1 text-xs text-gray-500 dark:bg-gray-700 dark:text-gray-400">{{ registeredDirs.length }} 个</span>
+          </div>
+          <div v-if="registeredDirs.length" class="grid gap-3">
+            <article v-for="row in registeredDirs" :key="row.path" class="flex flex-col gap-3 rounded-xl border border-gray-200 p-4 dark:border-gray-700 sm:flex-row sm:items-center">
+              <div class="flex min-w-0 flex-1 items-center gap-3">
+                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-primary-500 dark:bg-gray-700">
+                  <FolderOpen class="h-5 w-5" />
+                </div>
+                <div class="min-w-0">
+                  <div class="flex items-center gap-2">
+                    <p class="truncate text-sm font-medium text-gray-900 dark:text-gray-100" :title="row.path">{{ directoryName(row.path) }}</p>
+                    <el-tag v-if="!desktopMode && !isUnderRoot(row.path)" type="info" size="small">自定义</el-tag>
+                  </div>
+                  <p class="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400" :title="row.path">{{ row.path }}</p>
+                </div>
+              </div>
+              <div v-if="isSuperuser" class="flex shrink-0 gap-2 pl-[52px] sm:pl-0">
+                <el-button class="focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" size="small" @click="scanDir(row.path)"><RefreshCw class="mr-1 h-3.5 w-3.5" />重新扫描</el-button>
+                <el-button class="focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" type="danger" plain size="small" @click="removeDir(row.path)">移除</el-button>
+              </div>
+            </article>
+          </div>
+          <div v-else class="rounded-xl border border-dashed border-gray-300 px-5 py-9 text-center dark:border-gray-600">
+            <FolderOpen class="mx-auto h-8 w-8 text-gray-300 dark:text-gray-600" />
+            <p class="mt-3 text-sm font-medium text-gray-700 dark:text-gray-300">还没有添加照片文件夹</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">添加后，照片会陆续出现在图库中。</p>
+            <el-button v-if="isSuperuser && desktopMode" class="mt-4 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" type="primary" @click="chooseFolder">选择照片文件夹</el-button>
+          </div>
           <p v-if="!isSuperuser" class="text-xs text-gray-400 dark:text-gray-500 mt-2">仅管理员可管理图库，如需添加或移除请联系管理员。</p>
-        </div>
+        </section>
 
-        <!-- 手动添加（高级，仅管理员） -->
-        <el-collapse v-if="isSuperuser" v-model="manualCollapse" class="mb-2">
+        <!-- 服务端部署的自定义路径入口 -->
+        <el-collapse v-if="isSuperuser && !desktopMode" v-model="manualCollapse" class="mb-2">
           <el-collapse-item title="高级：手动输入路径" name="manual">
             <p class="text-sm text-gray-500 mb-2 dark:text-gray-400">
               填写照片文件夹的绝对路径。本机部署如 <code class="px-1 bg-gray-200 dark:bg-gray-700 rounded">D:/Photos/family</code>，Docker 部署如 <code class="px-1 bg-gray-200 dark:bg-gray-700 rounded">/app/Photos/family</code>。
@@ -142,9 +213,10 @@
           </el-collapse-item>
         </el-collapse>
 
-        <p class="text-xs text-gray-400 dark:text-gray-500 mt-2">
-          TrailSnap 不会主动移动或修改源文件，缩略图与索引存放在 TrailSnap 数据目录。
-        </p>
+        <div class="mt-4 flex items-start gap-2 rounded-lg bg-gray-50 px-3 py-2.5 text-xs text-gray-500 dark:bg-gray-900 dark:text-gray-400">
+          <ShieldCheck class="mt-0.5 h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
+          <span>源文件保持原位，移除文件夹时只会清理 TrailSnap 中的索引和缩略图。</span>
+        </div>
       </el-tab-pane>
 
       <el-tab-pane label="图片文件过滤" name="filter">
@@ -247,6 +319,7 @@ import { userService, type User } from '@/api/user'
 import { useUserStore } from '@/stores/user'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Delete } from '@element-plus/icons-vue'
+import { FolderPlus, FolderOpen, HardDrive, RefreshCw, ShieldCheck } from 'lucide-vue-next'
 import ExternalGalleryPickerDialog from '@/components/ExternalGalleryPickerDialog.vue'
 import { isTauriApp } from '@/config/server'
 
@@ -265,6 +338,7 @@ const userStore = useUserStore()
 const users = ref<User[]>([])
 const selectedUserId = ref('')
 const isSuperuser = computed(() => !!userStore.userInfo?.is_superuser)
+const desktopMode = isTauriApp()
 
 // 候选发现
 const detecting = ref(false)
@@ -298,6 +372,13 @@ const filterConfig = reactive({
 })
 
 const selectedPaths = computed(() => Array.from(selectedSet))
+
+const directoryName = (path: string) => path.replace(/[\\/]+$/, '').split(/[\\/]/).filter(Boolean).pop() || path
+
+const resetManualValidation = () => {
+  manualValid.value = false
+  manualMsg.value = ''
+}
 
 const isUnderRoot = (path: string) => {
   const root = candidates.value.root
@@ -359,7 +440,7 @@ const loadFilter = async () => {
 const reloadAll = async () => {
   // 候选发现仅管理员需要（普通用户无管理权限，不展示候选区）
   const tasks: Promise<unknown>[] = [loadRegistered(), loadFilter()]
-  if (isSuperuser.value) tasks.unshift(loadCandidates())
+  if (isSuperuser.value && !desktopMode) tasks.unshift(loadCandidates())
   await Promise.all(tasks)
 }
 
@@ -418,7 +499,9 @@ const validateManual = async () => {
     const data = await settingsApi.validateDirectory(manualPath.value.trim(), uid())
     manualValid.value = data.valid
     manualMsg.value = data.valid
-      ? (data.warnings?.includes('outside_root') ? '校验通过（该路径不在 /app/Photos 下，将作为自定义路径接入）' : '校验通过')
+      ? (desktopMode
+          ? '校验通过，可以添加此文件夹'
+          : (data.warnings?.includes('outside_root') ? '校验通过（该路径不在 /app/Photos 下，将作为自定义路径接入）' : '校验通过'))
       : (data.msg || '校验未通过')
   } catch (e: any) {
     manualValid.value = false
@@ -428,11 +511,11 @@ const validateManual = async () => {
   }
 }
 
-const useSelectedFolder = (path: string) => {
+const useSelectedFolder = async (path: string) => {
   manualPath.value = path
   manualValid.value = false
-  manualMsg.value = '已选择文件夹，请校验后添加'
-  focusManual()
+  manualMsg.value = '正在检查文件夹…'
+  await validateManual()
 }
 
 const chooseFolder = async () => {
@@ -443,7 +526,7 @@ const chooseFolder = async () => {
   try {
     const { open } = await import('@tauri-apps/plugin-dialog')
     const selected = await open({ directory: true, multiple: false, title: '选择照片文件夹' })
-    if (typeof selected === 'string') useSelectedFolder(selected)
+    if (typeof selected === 'string') await useSelectedFolder(selected)
   } catch {
     ElMessage.error('无法打开系统文件夹选择器')
   }

--- a/package/website/src/views/toolbox/SwipeFilter.vue
+++ b/package/website/src/views/toolbox/SwipeFilter.vue
@@ -5,7 +5,7 @@
       <button
         @click="handleBack"
         class="p-2 rounded-full bg-slate-200/50 dark:bg-slate-800/50 text-slate-700 dark:text-white hover:bg-slate-300/50 dark:hover:bg-slate-700 transition-colors backdrop-blur-md focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none"
-        title="返回并清理已丢弃的照片"
+        title="返回工具箱"
       >
         <ArrowLeft class="w-5 h-5" />
       </button>
@@ -13,6 +13,9 @@
         <h1 class="text-sm font-semibold tracking-wider text-slate-800 dark:text-slate-100">照片筛选</h1>
         <span class="text-xs text-slate-500 dark:text-slate-400">
           {{ processedCount }} / {{ totalCount }}
+        </span>
+        <span v-if="syncQueue.size > 0 || syncing" class="text-[10px] text-primary-600 dark:text-primary-500">
+          {{ syncError ? '等待网络同步' : '同步中' }}
         </span>
       </div>
       <button
@@ -32,15 +35,36 @@
         <span class="text-sm">加载中...</span>
       </div>
 
+      <div v-else-if="photos.length === 0 && syncError" class="flex flex-col items-center gap-4 text-slate-500 dark:text-slate-400 text-center">
+        <span class="icon-[tabler--cloud-off] w-16 h-16 opacity-70"></span>
+        <span class="text-lg font-medium text-slate-800 dark:text-slate-100">操作已保存在本地</span>
+        <p class="text-sm max-w-xs">恢复网络并同步完成后，会继续获取未处理照片。</p>
+        <button
+          @click="retrySync"
+          class="px-6 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+        >
+          重试同步
+        </button>
+      </div>
+
       <div v-else-if="photos.length === 0" class="flex flex-col items-center gap-4 text-slate-500 dark:text-slate-400">
         <CheckCircle class="w-16 h-16 text-emerald-500 opacity-80" />
-        <span class="text-lg font-medium text-slate-800 dark:text-slate-100">太棒了，全部处理完毕！</span>
-        <button 
-          @click="fetchPhotos" 
-          class="px-6 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none"
-        >
-          再来一批
-        </button>
+        <span class="text-lg font-medium text-slate-800 dark:text-slate-100">本轮照片已全部处理完成</span>
+        <span class="text-sm">保留 {{ keptTotal }} 张 · 丢弃 {{ deletedTotal }} 张</span>
+        <div class="flex items-center gap-3">
+          <button
+            @click="handleBack"
+            class="px-6 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            返回工具箱
+          </button>
+          <button
+            @click="resetProgress"
+            class="px-6 py-2 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 rounded-full transition-colors hover:bg-slate-100 dark:hover:bg-slate-700 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            重新开始筛选
+          </button>
+        </div>
       </div>
 
       <!-- 卡片堆叠 -->
@@ -49,6 +73,8 @@
         <div
           v-for="(photo, index) in stack"
           :key="photo.id"
+          data-testid="swipe-card"
+          :data-photo-id="photo.id"
           class="absolute inset-0 m-auto w-[85vw] max-w-[360px] h-[68vh] max-h-[600px] bg-white dark:bg-slate-800 rounded-2xl border border-slate-200 dark:border-slate-700 flex flex-col overflow-hidden transform-gpu will-change-transform touch-none"
           :class="index === 0
             ? 'cursor-grab active:cursor-grabbing'
@@ -279,8 +305,8 @@
                 <Undo class="w-5 h-5" />
               </div>
               <div class="flex-1 text-slate-700 dark:text-slate-200">
-                <p class="font-medium">撤销与清理</p>
-                <p class="text-xs text-slate-500 dark:text-slate-400">Ctrl+Z 撤销；返回时自动清理已丢弃照片</p>
+                <p class="font-medium">撤销与同步</p>
+                <p class="text-xs text-slate-500 dark:text-slate-400">Ctrl+Z 撤销；操作会自动同步，离线时安全保存</p>
               </div>
             </div>
           </div>
@@ -303,39 +329,55 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-import { useRouter, onBeforeRouteLeave } from 'vue-router'
+import { onBeforeRouteLeave } from 'vue-router'
 import { useAppBack } from '@/composables/useAppBack'
 import { ArrowLeft, Trash2, Heart, Undo, Maximize2, CheckCircle, MapPin, Sparkles, Hand, Play } from 'lucide-vue-next'
 import { photoApi } from '@/api/photo'
-import { albumService } from '@/api/album'
-import { ElMessage } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import type { Photo } from '@/types/album'
 import { format } from 'date-fns'
 import PhotoLightbox from '@/components/PhotoLightbox.vue'
 import { mapPhotoToImage } from '@/stores/photoStore'
 import { toServerUrl } from '@/config/server'
+import { useUserStore } from '@/stores/user'
+import type { SwipeFilterDecision } from '@/api/photo'
 
-const router = useRouter()
 const appBack = useAppBack('/toolbox')
+const userStore = useUserStore()
 
 // 状态
 const loading = ref(false)
 const photos = ref<Photo[]>([])
 const processedCount = ref(0)
 const totalCount = ref(0)
+const remainingCount = ref(0)
+const keptTotal = ref(0)
+const deletedTotal = ref(0)
 
 // 撤销历史与待删除队列
 const MAX_UNDO = 30
-const BATCH_SYNC_SIZE = 10
-const OFFLINE_STORAGE_KEY = 'trailsnap:swipe-filter:offline-deletes'
+const OFFLINE_STORAGE_KEY_PREFIX = 'trailsnap:swipe-filter:operations'
+const LEGACY_OFFLINE_STORAGE_KEY = 'trailsnap:swipe-filter:offline-deletes'
 
 interface ActionRecord {
   photo: Photo
   action: 'keep' | 'delete'
 }
 const actionHistory = ref<ActionRecord[]>([])
-const pendingDeleteIds = ref<Set<string>>(new Set()) // 还在撤销栈内的删除
-const syncQueue = ref<Set<string>>(new Set()) // 已超出撤销栈，等待后台提交的删除
+
+interface SyncOperation {
+  photo_id: string
+  type: 'decision' | 'undo'
+  decision?: SwipeFilterDecision
+  revision: number
+}
+
+const syncQueue = ref<Map<string, SyncOperation>>(new Map())
+const handledPhotoIds = ref<Set<string>>(new Set())
+const syncing = ref(false)
+const syncError = ref(false)
+let operationRevision = 0
+let activeSync: Promise<void> | null = null
 
 // 统计计数 (代替之前的 computed，保证超出撤销栈后数字不掉)
 const sessionDeletedCount = ref(0)
@@ -346,52 +388,111 @@ const currentPhoto = computed(() => photos.value[0] || null)
 const deletedCount = computed(() => sessionDeletedCount.value)
 const keptCount = computed(() => sessionKeptCount.value)
 
-// --- 本地离线缓存与静默提交 ---
+// --- 按用户隔离的离线操作队列与静默同步 ---
+const offlineStorageKey = () => `${OFFLINE_STORAGE_KEY_PREFIX}:${userStore.userInfo?.id || 'unknown'}`
+
 const persistToStorage = () => {
   try {
-    const allIds = [...syncQueue.value, ...pendingDeleteIds.value]
-    if (allIds.length > 0) {
-      localStorage.setItem(OFFLINE_STORAGE_KEY, JSON.stringify(allIds))
+    const operations = Array.from(syncQueue.value.values())
+    if (operations.length > 0) {
+      localStorage.setItem(offlineStorageKey(), JSON.stringify(operations))
     } else {
-      localStorage.removeItem(OFFLINE_STORAGE_KEY)
+      localStorage.removeItem(offlineStorageKey())
     }
   } catch (e) {}
 }
 
 const flushSyncQueue = async () => {
+  if (activeSync) return activeSync
   if (syncQueue.value.size === 0) return
-  const ids = Array.from(syncQueue.value)
+
+  activeSync = (async () => {
+    syncing.value = true
+    syncError.value = false
+    try {
+      while (syncQueue.value.size > 0) {
+        const snapshot = Array.from(syncQueue.value.values())
+        const decisions = snapshot.filter(op => op.type === 'decision')
+        const undos = snapshot.filter(op => op.type === 'undo')
+
+        if (decisions.length > 0) {
+          await photoApi.saveSwipeFilterDecisions(decisions.map(op => ({
+            photo_id: op.photo_id,
+            decision: op.decision!,
+          })))
+        }
+        for (const op of undos) {
+          await photoApi.undoSwipeFilterDecision(op.photo_id)
+        }
+
+        snapshot.forEach(op => {
+          if (syncQueue.value.get(op.photo_id)?.revision === op.revision) {
+            syncQueue.value.delete(op.photo_id)
+          }
+        })
+        persistToStorage()
+      }
+    } catch (error) {
+      syncError.value = true
+      persistToStorage()
+      console.warn('Swipe-filter sync failed, will retry later.', error)
+    } finally {
+      syncing.value = false
+    }
+  })()
+
   try {
-    await albumService.batchUpdatePhotos({
-      photo_ids: ids,
-      action: 'delete'
-    })
-    // 成功后从队列移除
-    ids.forEach(id => syncQueue.value.delete(id))
-    persistToStorage()
-  } catch (error) {
-    // 失败了（如断网）就留在队列里，等待下次触发或退出时再试
-    console.warn('Background sync failed, will retry later.', error)
+    await activeSync
+  } finally {
+    activeSync = null
   }
 }
 
-const recoverOfflineDeletes = async () => {
+const recoverOfflineOperations = async () => {
   try {
-    const saved = localStorage.getItem(OFFLINE_STORAGE_KEY)
+    const saved = localStorage.getItem(offlineStorageKey())
     if (saved) {
-      const ids = JSON.parse(saved) as string[]
-      if (ids.length > 0) {
-        await albumService.batchUpdatePhotos({
-          photo_ids: ids,
-          action: 'delete'
-        })
-        localStorage.removeItem(OFFLINE_STORAGE_KEY)
-        console.log(`Recovered and deleted ${ids.length} offline photos.`)
+      const operations = JSON.parse(saved) as SyncOperation[]
+      for (const op of operations) {
+        operationRevision = Math.max(operationRevision, op.revision || 0)
+        syncQueue.value.set(op.photo_id, op)
+        if (op.type === 'decision') handledPhotoIds.value.add(op.photo_id)
       }
     }
+
+    // Migrate the old delete-only queue once. It belonged to the currently
+    // authenticated user because logout clears all trailsnap:* keys.
+    const legacy = localStorage.getItem(LEGACY_OFFLINE_STORAGE_KEY)
+    if (legacy) {
+      const ids = JSON.parse(legacy) as string[]
+      ids.forEach(photoId => {
+        const op: SyncOperation = {
+          photo_id: photoId,
+          type: 'decision',
+          decision: 'delete',
+          revision: ++operationRevision,
+        }
+        syncQueue.value.set(photoId, op)
+        handledPhotoIds.value.add(photoId)
+      })
+      localStorage.removeItem(LEGACY_OFFLINE_STORAGE_KEY)
+      persistToStorage()
+    }
+    await flushSyncQueue()
   } catch (e) {
-    console.warn('Failed to recover offline deletes', e)
+    console.warn('Failed to recover swipe-filter operations', e)
   }
+}
+
+const enqueueOperation = (photoId: string, type: SyncOperation['type'], decision?: SwipeFilterDecision) => {
+  syncQueue.value.set(photoId, {
+    photo_id: photoId,
+    type,
+    decision,
+    revision: ++operationRevision,
+  })
+  persistToStorage()
+  void flushSyncQueue()
 }
 
 // --- 键化卡片栈 ---
@@ -681,12 +782,25 @@ const fetchPhotos = async () => {
   if (loading.value) return
   loading.value = true
   try {
-    const res = await photoApi.getRandomPhotos(20)
-    if (res && res.length > 0) {
-      photos.value.push(...res)
-      totalCount.value += res.length
+    await flushSyncQueue()
+    if (syncQueue.value.size > 0) return
+
+    const res = await photoApi.getSwipeFilterBatch(20)
+    syncError.value = false
+    const queuedIds = new Set(photos.value.map(photo => photo.id))
+    const uniquePhotos = res.photos.filter(photo => (
+      !queuedIds.has(photo.id) && !handledPhotoIds.value.has(photo.id)
+    ))
+    if (uniquePhotos.length > 0) {
+      photos.value.push(...uniquePhotos)
     }
+    processedCount.value = res.stats.processed
+    remainingCount.value = res.stats.remaining
+    totalCount.value = res.stats.total
+    keptTotal.value = res.stats.kept
+    deletedTotal.value = res.stats.deleted
   } catch (error) {
+    syncError.value = true
     ElMessage.error('获取照片失败')
   } finally {
     loading.value = false
@@ -712,28 +826,23 @@ const handleSwipe = (direction: 'left' | 'right', velocity = 0) => {
   // 记录操作
   const action = direction === 'left' ? 'delete' : 'keep'
   actionHistory.value.push({ photo, action })
+  handledPhotoIds.value.add(photo.id)
+  enqueueOperation(photo.id, 'decision', action)
   
   if (action === 'delete') {
     sessionDeletedCount.value++
-    pendingDeleteIds.value.add(photo.id)
+    deletedTotal.value++
   } else {
     sessionKeptCount.value++
+    keptTotal.value++
   }
+  processedCount.value++
+  remainingCount.value = Math.max(0, remainingCount.value - 1)
 
-  // 防止撤销栈无限膨胀：超出 MAX_UNDO 后，锁定最老的记录并移出撤销栈
+  // 防止撤销栈无限膨胀：超出 MAX_UNDO 后移除最老记录。
+  // 决策已经由幂等接口持久化，无需再维护第二套删除队列。
   if (actionHistory.value.length > MAX_UNDO) {
-    const oldest = actionHistory.value.shift()!
-    if (oldest.action === 'delete') {
-      pendingDeleteIds.value.delete(oldest.photo.id)
-      syncQueue.value.add(oldest.photo.id)
-    }
-  }
-
-  persistToStorage()
-
-  // 触发后台分批静默提交
-  if (syncQueue.value.size >= BATCH_SYNC_SIZE) {
-    flushSyncQueue()
+    actionHistory.value.shift()
   }
 
   // 保证 isAnimating=true 的 transition 先生效，下一帧再应用飞出 transform，避免偶发无动画闪切
@@ -746,7 +855,6 @@ const handleSwipe = (direction: 'left' | 'right', velocity = 0) => {
   // 动画结束后移除当前照片 (与飞出时长同步，避免提前/滞后裁切)
   setTimeout(() => {
     photos.value.shift()
-    processedCount.value++
 
     // 重置状态
     isAnimating.value = false
@@ -770,16 +878,18 @@ const undo = () => {
   
   if (lastAction.action === 'delete') {
     sessionDeletedCount.value--
-    pendingDeleteIds.value.delete(lastAction.photo.id)
+    deletedTotal.value = Math.max(0, deletedTotal.value - 1)
   } else {
     sessionKeptCount.value--
+    keptTotal.value = Math.max(0, keptTotal.value - 1)
   }
-  
-  persistToStorage()
+  handledPhotoIds.value.delete(lastAction.photo.id)
+  enqueueOperation(lastAction.photo.id, 'undo')
+  remainingCount.value++
   
   // 将照片插回队首
   photos.value.unshift(lastAction.photo)
-  processedCount.value--
+  processedCount.value = Math.max(0, processedCount.value - 1)
 }
 
 // 拖拽事件处理
@@ -890,25 +1000,44 @@ const handleWheel = (e: WheelEvent) => {
   }
 }
 
-// 退出前提交批量删除
-const submitDeletions = async () => {
-  const ids = Array.from(new Set([...syncQueue.value, ...pendingDeleteIds.value]))
-  if (ids.length > 0) {
-    try {
-      syncQueue.value.clear()
-      pendingDeleteIds.value.clear()
-      await albumService.batchUpdatePhotos({
-        photo_ids: ids,
-        action: 'delete'
-      })
-      persistToStorage() // 提交成功后清除本地缓存
-      ElMessage.success(`已将 ${ids.length} 张照片移至回收站`)
-    } catch (error) {
-      console.error(error)
-      // 失败后将 id 重新加回离线队列并缓存，下次进页面时自动重试
-      ids.forEach(id => syncQueue.value.add(id))
-      persistToStorage()
-      ElMessage.error('网络异常，删除操作已保存在本地，下次将自动重试')
+const retrySync = async () => {
+  syncError.value = false
+  await flushSyncQueue()
+  if (syncQueue.value.size === 0) await fetchPhotos()
+}
+
+const resetProgress = async () => {
+  try {
+    await ElMessageBox.confirm(
+      '将清除“已处理”记录，让仍在相册中的照片重新参与筛选。回收站照片不会自动恢复。',
+      '重新开始筛选？',
+      {
+        confirmButtonText: '重新开始',
+        cancelButtonText: '取消',
+        type: 'warning',
+      },
+    )
+    await flushSyncQueue()
+    if (syncQueue.value.size > 0) {
+      ElMessage.warning('请等待离线操作同步完成后再重置')
+      return
+    }
+    await photoApi.resetSwipeFilterDecisions()
+    photos.value = []
+    actionHistory.value = []
+    handledPhotoIds.value.clear()
+    processedCount.value = 0
+    totalCount.value = 0
+    remainingCount.value = 0
+    keptTotal.value = 0
+    deletedTotal.value = 0
+    sessionDeletedCount.value = 0
+    sessionKeptCount.value = 0
+    await fetchPhotos()
+    ElMessage.success('已重新开始筛选')
+  } catch (error: any) {
+    if (error !== 'cancel' && error !== 'close') {
+      ElMessage.error('重置处理记录失败')
     }
   }
 }
@@ -917,23 +1046,25 @@ const handleBack = () => {
   appBack()
 }
 
-onBeforeRouteLeave(async (to, from, next) => {
-  await submitDeletions()
+onBeforeRouteLeave((to, from, next) => {
+  // 操作入队时已写入 localStorage，离线时不阻塞离开页面。
+  persistToStorage()
+  void flushSyncQueue()
   next()
 })
 
 const handleBeforeUnload = () => {
-  if (pendingDeleteIds.value.size > 0) {
-    // 浏览器刷新/关闭标签页时，尽量尝试提交数据防丢失
-    submitDeletions()
-  }
+  persistToStorage()
 }
 
 // 生命周期
-onMounted(() => {
+onMounted(async () => {
   detectWeakNetwork()
-  recoverOfflineDeletes() // 页面加载时恢复并提交离线期间的删除操作
-  fetchPhotos()
+  if (!userStore.userInfo) {
+    try { await userStore.getUserInfo() } catch { /* 401 由请求拦截器处理 */ }
+  }
+  await recoverOfflineOperations()
+  await fetchPhotos()
   window.addEventListener('keydown', handleKeydown)
   window.addEventListener('beforeunload', handleBeforeUnload)
   // 首次打开时展示引导

--- a/package/website/tests/e2e/specs/settings/settings-tabs-extra.spec.ts
+++ b/package/website/tests/e2e/specs/settings/settings-tabs-extra.spec.ts
@@ -37,8 +37,7 @@ test.describe('Smoke - 设置中心剩余 Tab 切换 @smoke', () => {
     await page.goto('/settings');
 
     await clickSettingTab(page, 'external');
-    // ExternalGallery.vue 模板硬编码 <h2>外部图库管理</h2>
-    await expect(page.locator('h2', { hasText: '外部图库管理' }).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: '外部图库', exact: true })).toBeVisible({ timeout: 10_000 });
   });
 
   test('切换到「性能测试」- 渲染 PerformanceTest 子页 H2', async ({ page }) => {
@@ -133,13 +132,13 @@ test.describe('Smoke - 设置中心剩余 Tab 切换 @smoke', () => {
 
     // 切到外部图库 — 任务管理 H2 应消失，外部图库 H2 出现
     await clickSettingTab(page, 'external');
-    await expect(page.locator('h2', { hasText: '外部图库管理' }).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('heading', { name: '外部图库', exact: true })).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('h2', { hasText: '任务管理' })).toHaveCount(0);
 
     // 再切到性能测试 — 前两个 H2 都应消失
     await clickSettingTab(page, 'performance');
     await expect(page.locator('h2', { hasText: '性能测试' }).first()).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('h2', { hasText: '外部图库管理' })).toHaveCount(0);
+    await expect(page.getByRole('heading', { name: '外部图库', exact: true })).toHaveCount(0);
     await expect(page.locator('h2', { hasText: '任务管理' })).toHaveCount(0);
   });
   test('外部图库可切换到图片文件过滤并返回目录管理', async ({ page }) => {
@@ -150,8 +149,8 @@ test.describe('Smoke - 设置中心剩余 Tab 切换 @smoke', () => {
     await expect(page.getByText('启用过滤', { exact: true })).toBeVisible();
 
     await page.getByRole('tab', { name: '目录管理' }).click();
-    // 新版目录管理 tab：已接入图库列表始终渲染（管理员/普通用户均可见）
-    await expect(page.locator('h3', { hasText: '已接入图库' })).toBeVisible({ timeout: 10_000 });
+    // 新版目录管理 tab：文件夹列表始终渲染（管理员/普通用户均可见）
+    await expect(page.getByRole('heading', { name: '已添加的文件夹', exact: true })).toBeVisible({ timeout: 10_000 });
   });
 
   test('外部图库空路径时手动添加禁用且不发起添加请求', async ({ page }) => {
@@ -169,7 +168,7 @@ test.describe('Smoke - 设置中心剩余 Tab 切换 @smoke', () => {
 
     // 先等管理员区就绪（isSuperuser 依赖异步 getUserInfo），再展开手动添加折叠；
     // 用子串匹配折叠标题，兼容「手动输入容器内路径 / 手动输入路径」两种文案
-    await expect(page.locator('h3', { hasText: '照片目录接入' })).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole('heading', { name: '添加照片目录', exact: true })).toBeVisible({ timeout: 20_000 });
     await page.getByText('高级：手动输入').click();
     // 空路径时「添加并扫描」禁用；点「校验」提示请输入路径；且不发起 add 请求
     await expect(page.getByRole('button', { name: '添加并扫描' })).toBeVisible();


### PR DESCRIPTION
## 描述

优化照片“断舍离”功能，持久化用户对照片的保留/丢弃决定，避免小图库在补充随机照片时反复出现已经处理过的照片。

- 新增 `photo_declutter_records` 记录表及 PostgreSQL / SQLite 迁移
- 新增断舍离专用取图、决策、撤销和重置接口
- 左滑删除与处理记录同步落库，撤销或从回收站恢复时正确回退记录
- 前端使用真实处理进度，并增加会话内二次去重
- 支持按用户隔离的离线操作队列、失败重试和旧删除队列迁移
- 增加完成统计、重新开始筛选和离线同步状态提示

## 变更类型

- [ ] 🐛 修复错误 (Bug Fix)
- [x] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [x] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue

无。

## 如何测试

- `pwsh .\tests\scripts\run-tests.ps1 -Layer unit -Component server -Level smoke -Scope photo`：324 passed
- `pnpm build`：通过
- SQLite Alembic upgrade → downgrade → upgrade：通过
- Playwright 真实浏览器验证：处理后刷新不重复、删除撤销、完成统计和重置流程正常

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有已执行测试均已通过
- [x] 本次无需更新相关文档