### PR TITLE
feat(website): 增加相似照片四图对比

### DIFF
--- a/package/website/src/components/SimilarPhotoCompareDialog.vue
+++ b/package/website/src/components/SimilarPhotoCompareDialog.vue
@@ -1,0 +1,201 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    :fullscreen="isMobile"
+    :z-index="90"
+    class="similar-photo-compare-dialog"
+    width="min(96vw, 1500px)"
+    append-to-body
+    destroy-on-close
+    @close="emit('close')"
+  >
+    <template #header>
+      <div class="pr-8">
+        <div class="flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          <i class="mgc_pic_2_line text-primary-500"></i>
+          照片对比
+          <span class="text-sm font-normal text-gray-500 dark:text-gray-400">{{ photos.length }}/4</span>
+        </div>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          点击照片可查看大图；确认不需要的照片后，可直接标记删除。
+        </p>
+      </div>
+    </template>
+
+    <div
+      class="compare-grid"
+      :class="{ 'compare-grid-single': photos.length === 1 }"
+      :style="{ '--compare-count': Math.max(1, photos.length) }"
+    >
+      <article
+        v-for="(photo, index) in photos"
+        :key="photo.id"
+        class="min-w-0 overflow-hidden rounded-xl border bg-gray-50 dark:bg-gray-900"
+        :class="isMarkedForDeletion(photo.id)
+          ? 'border-red-400 ring-2 ring-red-400/30'
+          : 'border-gray-200 dark:border-gray-700'"
+      >
+        <button
+          type="button"
+          class="group relative block w-full overflow-hidden bg-gray-100 dark:bg-gray-800 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-inset focus-visible:outline-none"
+          :aria-label="`查看大图：${photo.filename || `照片 ${index + 1}`}`"
+          @click="emit('open-photo', photo)"
+        >
+          <img
+            :src="photo.preview || photo.thumbnail"
+            :alt="photo.filename || `对比照片 ${index + 1}`"
+            class="compare-image w-full object-contain transition-transform duration-300 group-hover:scale-[1.02]"
+          />
+          <span
+            v-if="index === 0"
+            class="absolute left-2 top-2 rounded-full bg-primary-500 px-2 py-1 text-xs font-medium text-white shadow-sm"
+          >
+            推荐保留
+          </span>
+          <span class="absolute bottom-2 right-2 rounded bg-black/60 px-2 py-1 text-xs text-white">
+            查看大图
+          </span>
+        </button>
+
+        <div class="space-y-2 p-3">
+          <div class="truncate text-sm font-medium text-gray-800 dark:text-gray-100" :title="photo.filename">
+            {{ photo.filename || '未命名照片' }}
+          </div>
+          <dl class="grid grid-cols-2 gap-x-2 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+            <div class="min-w-0">
+              <dt class="sr-only">拍摄时间</dt>
+              <dd class="truncate">{{ formatDate(photo.timestamp) }}</dd>
+            </div>
+            <div class="text-right">
+              <dt class="sr-only">文件大小</dt>
+              <dd>{{ formatSize(photo.size) }}</dd>
+            </div>
+            <div v-if="photo.width && photo.height" class="col-span-2">
+              <dt class="sr-only">分辨率</dt>
+              <dd>{{ photo.width }} × {{ photo.height }}</dd>
+            </div>
+          </dl>
+
+          <div class="flex gap-2 pt-1">
+            <button
+              type="button"
+              class="flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-gray-900"
+              :class="isMarkedForDeletion(photo.id)
+                ? 'bg-red-500 text-white hover:bg-red-600'
+                : 'bg-white text-red-500 ring-1 ring-inset ring-red-200 hover:bg-red-50 dark:bg-gray-800 dark:ring-red-900 dark:hover:bg-red-900/20'"
+              @click="emit('toggle-delete', photo.id)"
+            >
+              <i :class="isMarkedForDeletion(photo.id) ? 'mgc_check_line' : 'mgc_delete_2_line'"></i>
+              {{ isMarkedForDeletion(photo.id) ? '已标记删除' : '标记删除' }}
+            </button>
+            <button
+              type="button"
+              class="rounded-lg bg-white px-3 py-2 text-sm text-gray-600 ring-1 ring-inset ring-gray-200 transition-colors hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700 dark:hover:bg-gray-700 dark:focus-visible:ring-offset-gray-900"
+              aria-label="移出对比"
+              @click="emit('remove', photo.id)"
+            >
+              移出
+            </button>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <template #footer>
+      <div class="flex items-center justify-between gap-3">
+        <span class="text-xs text-gray-500 dark:text-gray-400">
+          已标记 {{ markedCount }} 张
+        </span>
+        <button
+          type="button"
+          class="rounded-lg bg-primary-500 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-gray-900"
+          @click="emit('close')"
+        >
+          完成对比
+        </button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useMediaQuery } from '@vueuse/core';
+import type { AlbumImage } from '@/types/album';
+
+const props = defineProps<{
+  visible: boolean;
+  photos: AlbumImage[];
+  selectedForDeletion: Set<string>;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'toggle-delete', id: string): void;
+  (e: 'remove', id: string): void;
+  (e: 'open-photo', photo: AlbumImage): void;
+}>();
+
+const isMobile = useMediaQuery('(max-width: 767px)');
+const markedCount = computed(() => props.photos.filter(photo => props.selectedForDeletion.has(photo.id)).length);
+const isMarkedForDeletion = (id: string) => props.selectedForDeletion.has(id);
+
+const formatSize = (size?: number) => {
+  if (!size) return '大小未知';
+  if (size < 1024 * 1024) return `${Math.max(1, Math.round(size / 1024))} KB`;
+  return `${(size / 1024 / 1024).toFixed(1)} MB`;
+};
+
+const formatDate = (timestamp: number) => {
+  if (!timestamp || Number.isNaN(timestamp)) return '时间未知';
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(timestamp));
+};
+</script>
+
+<style scoped>
+.compare-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--compare-count), minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.compare-image {
+  height: clamp(18rem, 55vh, 44rem);
+}
+
+@media (max-width: 767px) {
+  .compare-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+  }
+
+  .compare-grid-single {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .compare-image {
+    height: clamp(7rem, 20vh, 11rem);
+  }
+}
+</style>
+
+<style>
+@media (max-width: 767px) {
+  .similar-photo-compare-dialog .el-dialog__body {
+    padding: 0.5rem;
+    overflow-y: auto;
+  }
+
+  .similar-photo-compare-dialog .el-dialog__header,
+  .similar-photo-compare-dialog .el-dialog__footer {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+</style>

--- a/package/website/src/views/toolbox/SimilarPhotoCleanup.vue
+++ b/package/website/src/views/toolbox/SimilarPhotoCleanup.vue
@@ -27,16 +27,27 @@
     <!-- Result Content -->
     <div class="flex-1 overflow-y-auto space-y-6 pb-20 scrollbar-hide" ref="containerRef">
         <div v-for="(group, gIndex) in groups" :key="gIndex" class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
-            <div class="flex items-center justify-between mb-3">
+            <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
                 <span class="text-sm font-medium text-gray-600 dark:text-gray-300">
                     分组 {{ gIndex + 1 }} ({{ group.length }} 张)
                 </span>
-                <button 
-                    @click="toggleGroupSelection(gIndex)"
-                    class="text-sm text-primary-500 hover:text-primary-600 font-medium dark:bg-gray-900"
-                >
-                    {{ isGroupAllSelected(gIndex) ? '取消全选' : '全选' }}
-                </button>
+                <div class="flex items-center gap-3">
+                    <button
+                        type="button"
+                        @click="openComparison(gIndex)"
+                        class="rounded-md bg-primary-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary-600 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-gray-800"
+                    >
+                        <i class="mgc_pic_2_line mr-1"></i>
+                        {{ compareGroupIndex === gIndex && comparisonIds.size > 0 ? `开始对比 (${comparisonIds.size}/4)` : '对比照片' }}
+                    </button>
+                    <button
+                        type="button"
+                        @click="toggleGroupSelection(gIndex)"
+                        class="text-sm text-primary-500 hover:text-primary-600 font-medium focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-gray-800"
+                    >
+                        {{ isGroupAllSelected(gIndex) ? '取消全选' : '全选' }}
+                    </button>
+                </div>
             </div>
             
             <!-- Horizontal Scroll Container -->
@@ -70,7 +81,7 @@
                         <!-- Photo Card -->
                         <div 
                             class="relative aspect-square rounded-lg overflow-hidden cursor-pointer border-2 transition-colors bg-gray-100 dark:bg-gray-700"
-                            :class="selectedPhotos.has(photo.id) ? 'border-blue-500' : 'border-transparent'"
+                            :class="selectedPhotos.has(photo.id) || comparisonIds.has(photo.id) ? 'border-primary-500' : 'border-transparent'"
                             @click="openLightbox(gIndex, pIndex)"
                         >
                             <img 
@@ -85,7 +96,7 @@
                             <!-- Selection Checkbox -->
                             <div 
                                 class="absolute top-1 left-1 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors z-10"
-                                :class="selectedPhotos.has(photo.id) ? 'bg-blue-500 border-blue-500' : 'bg-black/30 border-white hover:bg-black/50'"
+                                :class="selectedPhotos.has(photo.id) ? 'bg-primary-500 border-primary-500' : 'bg-black/30 border-white hover:bg-black/50'"
                                 @click.stop="togglePhotoSelection(photo.id)"
                             >
                                 <i v-if="selectedPhotos.has(photo.id)" class="mgc_check_line text-white text-sm"></i>
@@ -105,6 +116,18 @@
                             <div class="text-xs text-gray-700 dark:text-gray-300 truncate text-center font-medium">
                                 {{ photo.filename }}
                             </div>
+                            <button
+                                type="button"
+                                class="mt-1.5 w-full rounded-md px-2 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-gray-800"
+                                :class="compareGroupIndex === gIndex && comparisonIds.has(photo.id)
+                                    ? 'bg-primary-500 text-white hover:bg-primary-600'
+                                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'"
+                                :aria-pressed="compareGroupIndex === gIndex && comparisonIds.has(photo.id)"
+                                @click="toggleComparisonPhoto(gIndex, photo.id)"
+                            >
+                                <i :class="compareGroupIndex === gIndex && comparisonIds.has(photo.id) ? 'mgc_check_line' : 'mgc_add_line'"></i>
+                                {{ compareGroupIndex === gIndex && comparisonIds.has(photo.id) ? '已加入对比' : '加入对比' }}
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -112,8 +135,9 @@
              <!-- Group Action -->
              <div v-if="getGroupSelectionCount(gIndex) > 0" class="mt-3 flex justify-end border-t border-gray-100 dark:border-gray-700 pt-3">
                 <button 
+                    type="button"
                     @click="deleteGroupSelection(gIndex)"
-                    class="text-xs text-red-500 bg-red-50 dark:bg-red-900/20 px-3 py-1.5 rounded-md hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors flex items-center gap-1"
+                    class="text-xs text-red-500 bg-red-50 dark:bg-red-900/20 px-3 py-1.5 rounded-md hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors flex items-center gap-1 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-gray-800"
                 >
                     <i class="mgc_delete_2_line"></i>
                     删除选中 ({{ getGroupSelectionCount(gIndex) }}张)
@@ -123,7 +147,7 @@
         
         <!-- Load More Spinner -->
         <div v-if="isLoadingMore" class="flex justify-center py-4">
-             <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+             <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-500"></div>
         </div>
         <div v-if="!hasMore && groups.length > 0" class="text-center text-gray-400 text-sm py-4">
              没有更多了
@@ -140,6 +164,16 @@
         @prev="lightbox.index--"
         @next="lightbox.index++"
     />
+
+    <SimilarPhotoCompareDialog
+        :visible="comparisonVisible"
+        :photos="comparisonPhotos"
+        :selected-for-deletion="selectedPhotos"
+        @close="comparisonVisible = false"
+        @toggle-delete="togglePhotoSelection"
+        @remove="removeComparisonPhoto"
+        @open-photo="openComparisonLightbox"
+    />
   </CleanupTaskShell>
 </template>
 
@@ -150,11 +184,11 @@ import { photoApi } from '@/api/photo';
 import type { Task as TaskResponse } from '@/api/tasks'
 import type { Photo, AlbumImage } from '@/types/album';
 import { ElMessage, ElMessageBox } from 'element-plus';
-import { Search } from 'lucide-vue-next'
 import PhotoLightbox from '@/components/PhotoLightbox.vue';
+import SimilarPhotoCompareDialog from '@/components/SimilarPhotoCompareDialog.vue';
 import CleanupTaskShell from '@/components/CleanupTaskShell.vue';
 import request from '@/utils/request';
-import {usePhotoStore, mapPhotoToImage} from '@/stores/photoStore'
+import { mapPhotoToImage } from '@/stores/photoStore'
 import { useInfiniteScroll } from '@vueuse/core';
 
 const goBack = useAppBack('/toolbox')
@@ -163,6 +197,9 @@ const groups = ref<AlbumImage[][]>([]);
 const loading = ref(false);
 const error = ref('');
 const selectedPhotos = ref<Set<string>>(new Set());
+const comparisonIds = ref<Set<string>>(new Set());
+const compareGroupIndex = ref<number | null>(null);
+const comparisonVisible = ref(false);
 const task = ref<TaskResponse | null>(null);
 const pollTimer = ref<number | null>(null);
 
@@ -271,6 +308,10 @@ const startNewScan = async () => {
         const newTask = await photoApi.createSimilarTask(0.9);
         task.value = newTask;
         groups.value = [];
+        selectedPhotos.value.clear();
+        comparisonIds.value.clear();
+        compareGroupIndex.value = null;
+        comparisonVisible.value = false;
         hasMore.value = true;
         currentPage.value = 0;
         startPolling();
@@ -338,6 +379,63 @@ const togglePhotoSelection = (id: string) => {
     }
 };
 
+const comparisonPhotos = computed(() => {
+    return groups.value
+        .flatMap(group => group)
+        .filter(photo => comparisonIds.value.has(photo.id))
+        .slice(0, 4);
+});
+
+const syncComparisonGroupIndex = () => {
+    if (comparisonIds.value.size === 0) {
+        compareGroupIndex.value = null;
+        return;
+    }
+    compareGroupIndex.value = groups.value.findIndex(group =>
+        group.some(photo => comparisonIds.value.has(photo.id))
+    );
+    if (compareGroupIndex.value < 0) compareGroupIndex.value = null;
+};
+
+const toggleComparisonPhoto = (groupIndex: number, id: string) => {
+    if (compareGroupIndex.value !== groupIndex) {
+        compareGroupIndex.value = groupIndex;
+        comparisonIds.value.clear();
+    }
+
+    if (comparisonIds.value.has(id)) {
+        comparisonIds.value.delete(id);
+        return;
+    }
+
+    if (comparisonIds.value.size >= 4) {
+        ElMessage.warning('一次最多对比 4 张照片，请先移出一张');
+        return;
+    }
+    comparisonIds.value.add(id);
+};
+
+const openComparison = (groupIndex: number) => {
+    if (compareGroupIndex.value !== groupIndex || comparisonIds.value.size === 0) {
+        compareGroupIndex.value = groupIndex;
+        comparisonIds.value.clear();
+        groups.value[groupIndex].slice(0, 4).forEach(photo => comparisonIds.value.add(photo.id));
+    }
+    comparisonVisible.value = comparisonPhotos.value.length > 0;
+};
+
+const removeComparisonPhoto = (id: string) => {
+    comparisonIds.value.delete(id);
+    if (comparisonIds.value.size === 0) comparisonVisible.value = false;
+};
+
+const openComparisonLightbox = (photo: AlbumImage) => {
+    const index = comparisonPhotos.value.findIndex(item => item.id === photo.id);
+    lightbox.photos = comparisonPhotos.value;
+    lightbox.index = Math.max(0, index);
+    lightbox.show = true;
+};
+
 const isGroupAllSelected = (groupIndex: number) => {
     const group = groups.value[groupIndex];
     if (group.length <= 1) return false;
@@ -377,6 +475,9 @@ const deletePhotos = async (ids: string[]) => {
         
         // Clear selection
         ids.forEach(id => selectedPhotos.value.delete(id));
+        ids.forEach(id => comparisonIds.value.delete(id));
+        syncComparisonGroupIndex();
+        if (comparisonIds.value.size === 0) comparisonVisible.value = false;
         
         ElMessage.success(`成功删除 ${ids.length} 张照片`);
     } catch (err) {

--- a/package/website/tests/e2e/specs/toolbox/toolbox-pages.spec.ts
+++ b/package/website/tests/e2e/specs/toolbox/toolbox-pages.spec.ts
@@ -30,6 +30,58 @@ test.describe('Smoke - 工具箱子页面 @smoke', () => {
     await expect(page.getByText('相似照片清理').first()).toBeVisible({ timeout: 10_000 });
   });
 
+  test('相似照片最多可同时对比四张并标记删除', async ({ page }) => {
+    const taskId = '11111111-1111-4111-8111-111111111111';
+    const photos = Array.from({ length: 5 }, (_, index) => ({
+      id: `22222222-2222-4222-8222-22222222222${index}`,
+      filename: `burst-${index + 1}.jpg`,
+      photo_time: `2026-08-30T10:00:0${index}`,
+      upload_time: `2026-08-30T10:01:0${index}`,
+      url: `/api/medias/22222222-2222-4222-8222-22222222222${index}/file`,
+      thumbnail_url: `/api/medias/22222222-2222-4222-8222-22222222222${index}/thumbnail`,
+      file_type: 'image',
+      size: 2_000_000 + index,
+      width: 4032,
+      height: 3024,
+    }));
+
+    await page.route('**/api/toolbox/similar/tasks/latest', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        msg: 'success',
+        data: {
+          id: taskId,
+          type: 'SIMILAR_PHOTO_CLUSTERING',
+          status: 'completed',
+          created_at: '2026-08-30T10:00:00',
+          updated_at: '2026-08-30T10:00:00',
+          total_items: 5,
+          processed_items: 5,
+          result: null,
+        },
+      }),
+    }));
+    await page.route(`**/api/toolbox/similar/tasks/${taskId}/result*`, route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 0, msg: 'success', data: [photos] }),
+    }));
+    await page.route('**/api/medias/**', route => route.fulfill({
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300"><rect width="100%" height="100%" fill="#9ca3af"/></svg>',
+    }));
+
+    await page.goto('/toolbox/similar');
+    await expect(page.getByText('分组 1 (5 张)')).toBeVisible();
+    await page.getByRole('button', { name: '对比照片' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('照片对比')).toBeVisible();
+    await expect(dialog.locator('article')).toHaveCount(4);
+    await dialog.getByRole('button', { name: /标记删除/ }).first().click();
+    await expect(dialog.getByText('已标记 1 张')).toBeVisible();
+  });
+
   test('重复照片清理页面正常加载', async ({ page }) => {
     await page.goto('/toolbox/duplicate');
     await expect(page).toHaveURL(/\/toolbox\/duplicate/);


### PR DESCRIPTION
## 描述

为工具箱的相似照片清理增加照片对比能力，最多同时选择四张照片。桌面端使用并排布局，移动端使用紧凑的 2×2 响应式布局，并可在对比面板中查看大图、移出候选或标记删除。

## 变更类型

- [x] ✨ 新功能 (New Feature)
- [x] ✅ 测试增加/修改 (Tests)

## 相关 Issue

无。

## 如何测试

按本次提交要求未运行本地测试。新增了相似照片四图对比与标记删除的 Playwright E2E 覆盖，交由 CI 验证。

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [ ] 所有测试均已通过（等待 CI）
- [x] 无需更新文档

I have read and agree to the CLA