### PR TITLE
test(nightly): 2026-08-31 mobile-app assertion + ONNXCLIP wrappers

### DIFF
--- a/package/ai/tests/test_nightly_embedding_wrappers_gaps_20260831.py
+++ b/package/ai/tests/test_nightly_embedding_wrappers_gaps_20260831.py
@@ -1,0 +1,170 @@
+"""Coverage for the ONNXCLIPTextWrapper / ONNXCLIPImageWrapper classes in
+``app/services/embedding_service.py``.
+
+The 2026-08-31 nightly cov scan flagged these wrappers as the largest uncovered
+pocket (30 / 102 missed lines, ~70% coverage): the existing
+``test_embedding_service.py`` suite deliberately stubs the wrappers themselves
+to keep tests deterministic, so it never exercises the wrapper bodies:
+
+* ``ONNXCLIPTextWrapper.__init__`` - auto-tokenizer + onnx text session
+* ``ONNXCLIPTextWrapper.encode_text`` - tokenize -> onnx run -> L2-normalize
+* ``ONNXCLIPImageWrapper.__init__`` - auto-processor + onnx vision session
+* ``ONNXCLIPImageWrapper.encode_image`` - preprocess -> onnx run -> L2-normalize
+
+This file mocks the heavy collaborators (``modelscope`` and
+``create_inference_session``) at module level so the wrappers can run without
+touching disk and without loading real ONNX sessions. Real numpy is used so the
+``np.linalg.norm`` branch is exercised for real.
+
+Naming follows the nightly gap convention: ``test_nightly_<topic>_gaps_<date>.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from app.services.embedding_service import (
+    ONNXCLIPImageWrapper,
+    ONNXCLIPTextWrapper,
+)
+
+
+pytestmark = pytest.mark.smoke
+
+
+def _patch_modelscope(monkeypatch):
+    """Make ``from modelscope import AutoTokenizer`` / AutoImageProcessor return mocks."""
+
+    fake_modelscope = MagicMock(name="modelscope")
+
+    tokenize_result = {
+        "input_ids": np.zeros((1, 4), dtype=np.int64),
+        "attention_mask": np.ones((1, 4), dtype=np.int64),
+    }
+    fake_tokenizer = MagicMock(name="AutoTokenizer")
+    fake_tokenizer.return_value = tokenize_result
+    fake_modelscope.AutoTokenizer.from_pretrained = MagicMock(return_value=fake_tokenizer)
+
+    process_result = {"pixel_values": np.zeros((1, 3, 224, 224), dtype=np.float32)}
+    fake_processor = MagicMock(name="AutoImageProcessor")
+    fake_processor.return_value = process_result
+    fake_modelscope.AutoImageProcessor.from_pretrained = MagicMock(return_value=fake_processor)
+
+    monkeypatch.setitem(sys.modules, "modelscope", fake_modelscope)
+    return fake_tokenizer, fake_processor
+
+
+def _patch_inference_session(monkeypatch, embedding_dim=4):
+    """Stub ``create_inference_session`` to return a MagicMock that yields controlled outputs."""
+
+    sessions = {}
+
+    def fake_session(path):
+        s = MagicMock(name=f"ort_session[{path}]")
+
+        if path.endswith("textual.onnx"):
+            inputs = [
+                MagicMock(name="input_ids"),
+                MagicMock(name="attention_mask"),
+            ]
+            values = np.ones((1, embedding_dim), dtype=np.float32)
+        else:
+            inputs = [MagicMock(name="pixel_values")]
+            values = np.full((1, embedding_dim), 0.5, dtype=np.float32)
+
+        s.get_inputs = MagicMock(return_value=inputs)
+        s.run = MagicMock(return_value=[values])
+        sessions[path] = (s, values)
+        return s
+
+    monkeypatch.setattr(
+        "app.services.embedding_service.create_inference_session",
+        fake_session,
+    )
+    return sessions
+
+
+def test_text_wrapper_init_loads_tokenizer_and_creates_text_session(monkeypatch, tmp_path):
+    fake_tokenizer, _ = _patch_modelscope(monkeypatch)
+    sessions = _patch_inference_session(monkeypatch)
+
+    model_dir = tmp_path / "clip-text"
+    model_dir.mkdir()
+    wrapper = ONNXCLIPTextWrapper(str(model_dir))
+
+    # Tokenizer loaded from modelscope into the wrapper.
+    assert wrapper.tokenizer is fake_tokenizer
+    assert wrapper.model_dir == str(model_dir)
+    # ONNX session created for the textual.onnx path inside the dir.
+    text_session_path = str(model_dir / "textual.onnx")
+    assert text_session_path in sessions
+    assert wrapper.text_session is sessions[text_session_path][0]
+
+
+def test_text_wrapper_encode_text_returns_l2_normalized_embedding(monkeypatch, tmp_path):
+    _patch_modelscope(monkeypatch)
+    _patch_inference_session(monkeypatch, embedding_dim=8)
+
+    model_dir = tmp_path / "clip-text-2"
+    model_dir.mkdir()
+    wrapper = ONNXCLIPTextWrapper(str(model_dir))
+
+    result = wrapper.encode_text(["hello world"])
+
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (1, 8)
+    # L2 normalization: every row's L2 norm must be ~1 (allowing tiny epsilon drift).
+    norm = np.linalg.norm(result, axis=1)
+    assert np.allclose(norm, 1.0, atol=1e-5)
+    # Tokenizer was invoked with the right kwargs contract.
+    wrapper.tokenizer.assert_called_once()
+    call_kwargs = wrapper.tokenizer.call_args.kwargs
+    assert call_kwargs["text"] == ["hello world"]
+    assert call_kwargs["return_tensors"] == "np"
+    assert call_kwargs["padding"] is True
+    assert call_kwargs["truncation"] is True
+    assert call_kwargs["max_length"] == 128
+
+
+def test_image_wrapper_init_loads_processor_and_creates_vision_session(monkeypatch, tmp_path):
+    _, fake_processor = _patch_modelscope(monkeypatch)
+    sessions = _patch_inference_session(monkeypatch)
+
+    model_dir = tmp_path / "clip-image"
+    model_dir.mkdir()
+    wrapper = ONNXCLIPImageWrapper(str(model_dir))
+
+    assert wrapper.processor is fake_processor
+    assert wrapper.model_dir == str(model_dir)
+    vision_session_path = str(model_dir / "visual.onnx")
+    assert vision_session_path in sessions
+    assert wrapper.vision_session is sessions[vision_session_path][0]
+
+
+def test_image_wrapper_encode_image_returns_l2_normalized_embedding(monkeypatch, tmp_path):
+    _patch_modelscope(monkeypatch)
+    _patch_inference_session(monkeypatch, embedding_dim=12)
+
+    model_dir = tmp_path / "clip-image-2"
+    model_dir.mkdir()
+    wrapper = ONNXCLIPImageWrapper(str(model_dir))
+
+    # A 16x16 RGB PIL image - enough to exercise the wrapper path without disk I/O.
+    from PIL import Image
+
+    images = [Image.new("RGB", (16, 16), color=(10, 20, 30))]
+
+    result = wrapper.encode_image(images)
+
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (1, 12)
+    norm = np.linalg.norm(result, axis=1)
+    assert np.allclose(norm, 1.0, atol=1e-5)
+    wrapper.processor.assert_called_once()
+    call_kwargs = wrapper.processor.call_args.kwargs
+    assert call_kwargs["images"] is images
+    assert call_kwargs["return_tensors"] == "np"

--- a/package/website/tests/e2e/specs/settings/settings-tabs-extra.spec.ts
+++ b/package/website/tests/e2e/specs/settings/settings-tabs-extra.spec.ts
@@ -38,7 +38,10 @@ test.describe('Smoke - 设置中心剩余 Tab 切换 @smoke', () => {
 
     await expect(page.getByRole('heading', { name: '连接手机 App', exact: true })).toBeVisible();
     const addressInput = page.getByLabel('手机可访问的 TrailSnap 地址');
-    await expect(addressInput).toHaveValue(/127\.0\.0\.1/);
+    // dev / system 模式由 Vite config 决定 host；playwright config 会以 localhost 或 127.0.0.1 拉起。
+    // 两者都是 loopback, MobileAppConnection 的 isLoopbackAddress 会正确触发「手机无法访问」警告,
+    // 此处只校验 addressInput 已被自动填入当前 origin, 不锁具体 hostname.
+    await expect(addressInput).toHaveValue(/localhost|127\.0\.0\.1/);
     await expect(page.getByText(/手机无法访问/)).toBeVisible();
 
     await addressInput.fill('http://192.168.1.20:8082');


### PR DESCRIPTION
## 修复

- **settings-tabs-extra.spec.ts:36** 电脑网页的「连接手机 App」[A]
  把过于严格的 `/127.0.0.1/` 正则改成 `/localhost|127.0.0.1/`。
  `MobileAppConnection.vue` 的 address 默认值来自 `window.location.origin`:
  dev 模式 playwright baseURL 是 `http://localhost:5176`, system 模式是
  `http://localhost:8082`. 两条路径都不会得到 127.0.0.1, 但都会触发
  `isLoopbackAddress` 警告, 因此文案断言 `/手机无法访问/` 已足以守住真正的
  不变量. 修复后此条用例单独跑 3.7s 通过, 整文件 11/11, 整 settings 测试
  32/32 (1.2m) 通过.

## 新增测试

- **package/ai/tests/test_nightly_embedding_wrappers_gaps_20260831.py** (1 个模块 / 4 个用例)
  覆盖 `ONNXCLIPTextWrapper` 与 `ONNXCLIPImageWrapper` 类的四个未触达入口
  (`__init__` / `encode_text` / `__init__` / `encode_image`).
  通过 `monkeypatch.setitem(sys.modules, "modelscope", MagicMock())` 取代
  `modelscope.AutoTokenizer/AutoImageProcessor.from_pretrained`, 再通过
  `monkeypatch.setattr` 把 `create_inference_session` 替换为返回受控输出的
  stub, 让 wrapper 走完完整路径并对真实 numpy 跑 L2 归一化.

## 覆盖

| 模块                          | 之前      | 之后  |
|-------------------------------|-----------|-------|
| services/embedding_service.py | 75% (30)  | 100% (0) |
| AI 全量                       | 76%       | 77%   |

## 已知遗留

- §4 后端 pytest --cov 持续 hang 在 87% (已连续 7 轮), 本轮 5 分钟预算后停止.
  仍为 P1. 建议下轮直接动 `conftest.py` autouse fixture + gc.collect() + coverage.stop().
- `NIGHTLY-TEST-WATCH.md` §0 / §6.2 列举的影响范围未包含 `package/ai/tests/`,
  但前几轮 nightly commit (PR #152, PR #148, PR #154) 都把测试文件加在
  `package/ai/tests/`, 本次继续沿用惯例. §0 文档建议下轮显式补一行.

Nightly watch run 2026-08-31
