### PR TITLE
feat(website): AI 助手输入框支持多行输入

### DIFF
--- a/package/website/src/views/agent/components/AgentInput.vue
+++ b/package/website/src/views/agent/components/AgentInput.vue
@@ -1,16 +1,18 @@
 <template>
   <div class="agent-chat-input-area">
     <div class="w-full max-w-4xl mx-auto">
-      <form @submit.prevent="emit('send')" class="relative">
-        <input
+      <form @submit.prevent="handleSubmit" class="relative">
+        <textarea
+          ref="textareaRef"
           :value="modelValue"
-          @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
-          type="text"
-          placeholder="问问我关于您的照片或行程..."
+          @input="handleInput"
+          @keydown.enter="handleEnter"
+          rows="1"
+          :placeholder="placeholder"
           class="agent-input"
-          :disabled="isGenerating || isSelectionMode"
-        />
-        <button 
+          :disabled="isSelectionMode"
+        ></textarea>
+        <button
           v-if="isGenerating"
           type="button"
           @click.prevent="emit('abort')"
@@ -19,9 +21,9 @@
         >
           <Square class="w-4 h-4 fill-current" />
         </button>
-        <button 
+        <button
           v-else
-          type="submit" 
+          type="submit"
           class="agent-send-btn"
           :disabled="!modelValue.trim() || isSelectionMode"
         >
@@ -33,9 +35,10 @@
 </template>
 
 <script setup lang="ts">
+import { ref, computed, watch, nextTick, onMounted } from 'vue';
 import { Send, Square } from 'lucide-vue-next';
 
-defineProps<{
+const props = defineProps<{
   modelValue: string;
   isGenerating: boolean;
   isSelectionMode: boolean;
@@ -46,6 +49,64 @@ const emit = defineEmits<{
   (e: 'send'): void;
   (e: 'abort'): void;
 }>();
+
+const textareaRef = ref<HTMLTextAreaElement | null>(null);
+
+// 输入框最大高度（约 6 行），超出后内部滚动，避免撑高整个对话弹窗
+const MAX_HEIGHT = 120;
+
+/**
+ * 触摸设备（手机 / 平板）上软键盘没有 Shift 键，若 Enter 直接发送，用户将永远无法输入多行。
+ * 因此与 ChatGPT / Claude 移动端一致：触摸设备 Enter 换行，发送只走右侧按钮。
+ * 用 hover/pointer 媒体查询判断，比 UA 嗅探可靠。
+ */
+const isTouchDevice =
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+
+const placeholder = computed(() =>
+  isTouchDevice
+    ? '问问我关于您的照片或行程...'
+    : '问问我关于您的照片或行程...（Shift + Enter 换行）'
+);
+
+/** 根据内容自适应高度：先归零再按 scrollHeight 回写，并限制上限 */
+const resize = () => {
+  const el = textareaRef.value;
+  if (!el) return;
+  el.style.height = 'auto';
+  el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT)}px`;
+};
+
+const handleInput = (e: Event) => {
+  const el = e.target as HTMLTextAreaElement;
+  emit('update:modelValue', el.value);
+  resize();
+};
+
+const handleSubmit = () => {
+  if (!props.modelValue.trim() || props.isGenerating || props.isSelectionMode) return;
+  emit('send');
+};
+
+const handleEnter = (e: KeyboardEvent) => {
+  // 中文等输入法组合输入期间（选词时）按 Enter 属于确认候选词，不能当作发送
+  if (e.isComposing) return;
+  // 显式换行：Shift/Ctrl/Meta/Alt + Enter，以及触摸设备的裸 Enter
+  if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey || isTouchDevice) return;
+  e.preventDefault();
+  handleSubmit();
+};
+
+// 外部清空（发送成功后 AgentChat 会重置 inputMessage）或程序化填充（重新生成 / 编辑消息）
+// 时同步高度，避免发送后输入框仍停留在多行高度。
+watch(
+  () => props.modelValue,
+  () => nextTick(resize)
+);
+
+onMounted(resize);
 </script>
 
 <style scoped>
@@ -55,13 +116,17 @@ const emit = defineEmits<{
 
 .agent-input {
   @apply w-full pl-4 pr-12 py-3 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl text-sm text-slate-800 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed;
+  /* 自适应高度由 JS 控制，这里禁用手动拖拽并隐藏初始滚动条 */
+  @apply resize-none overflow-y-auto leading-6;
+  max-height: 120px;
 }
 
+/* 输入框可变高，按钮改为贴底对齐（原先垂直居中会在多行时飘到中间） */
 .agent-send-btn {
-  @apply absolute right-2 top-1/2 -translate-y-1/2 p-2 bg-indigo-600 dark:bg-indigo-500 text-white rounded-lg hover:bg-indigo-700 dark:hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors;
+  @apply absolute right-2 bottom-2 p-2 bg-indigo-600 dark:bg-indigo-500 text-white rounded-lg hover:bg-indigo-700 dark:hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors;
 }
 
 .agent-stop-btn {
-  @apply absolute right-2 top-1/2 -translate-y-1/2 p-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 rounded-lg hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors;
+  @apply absolute right-2 bottom-2 p-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 rounded-lg hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors;
 }
 </style>

--- a/package/website/tests/e2e/specs/views-coverage/views-deeper.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/views-deeper.spec.ts
@@ -410,13 +410,31 @@ test.describe('P1 - AgentInput 输入区交互 @views-coverage', () => {
     await agentEntry.click()
     await expect(page.locator('.agent-chat-overlay')).toBeVisible({ timeout: 10_000 })
 
-    const input = page.locator('.agent-chat-overlay input.agent-input')
+    // 选择器不带标签限定（.agent-input 现为 textarea），避免与实现细节耦合
+    const input = page.locator('.agent-chat-overlay .agent-input')
     await expect(input).toBeVisible()
     await input.fill('帮我找一下今天拍的照片')
     await expect(input).toHaveValue('帮我找一下今天拍的照片')
 
-    await page.locator('.agent-chat-overlay input.agent-input').press('Enter')
+    await input.press('Enter')
     await expect(page.locator('.agent-chat-overlay')).toBeVisible({ timeout: 3_000 })
+  })
+
+  test('Shift+Enter 换行而不发送 -> 输入框保留换行内容', async ({ page }) => {
+    await page.goto('/')
+    const agentEntry = page.getByRole('button', { name: 'AI 助手', exact: true })
+    await expect(agentEntry).toBeVisible({ timeout: 10_000 })
+    await agentEntry.click()
+    await expect(page.locator('.agent-chat-overlay')).toBeVisible({ timeout: 10_000 })
+
+    const input = page.locator('.agent-chat-overlay .agent-input')
+    await expect(input).toBeVisible()
+    await input.fill('第一行')
+    await input.press('Shift+Enter')
+    await input.pressSequentially('第二行')
+
+    // Shift+Enter 不应触发发送，内容仍留在输入框内且包含换行
+    await expect(input).toHaveValue('第一行\n第二行')
   })
 
   test('生成态 isGenerating=true -> 按钮切到 agent-stop-btn', async ({ page }) => {
@@ -426,8 +444,9 @@ test.describe('P1 - AgentInput 输入区交互 @views-coverage', () => {
     await agentEntry.click()
     await expect(page.locator('.agent-chat-overlay')).toBeVisible({ timeout: 10_000 })
 
-    await page.locator('.agent-chat-overlay input.agent-input').fill('查询照片')
-    await page.locator('.agent-chat-overlay input.agent-input').press('Enter')
+    const input = page.locator('.agent-chat-overlay .agent-input')
+    await input.fill('查询照片')
+    await input.press('Enter')
 
     await expect.poll(
       async () =>


### PR DESCRIPTION
将 AgentInput 的单行 input 改造为自适应高度的 textarea，
解决无法换行、无法粘贴多行、长文本看不全的问题。

- Enter 发送，Shift/Ctrl/Meta/Alt + Enter 换行
- 通过 isComposing 拦截输入法组合态，中文选词按 Enter 不再误发送
- 触摸设备裸 Enter 换行（软键盘无 Shift 键），发送只走按钮
- 高度按内容自适应，上限 120px（约 6 行）后内部滚动
- 外部清空/程序化填值时同步高度，发送后自动缩回单行
- 发送按钮改为贴底对齐，避免多行时垂直居中飘到中间
- 生成中仅禁用发送、保留可输入，便于等待回复时起草下一个问题

测试：e2e 选择器去掉标签限定（input.agent-input -> .agent-input）， 并补充 Shift+Enter 换行不发送的用例。

## 描述
<!-- 请简要描述您的更改。如果是修复 Bug，请链接相关 Issue。 -->

## 变更类型
<!-- 请删除不相关的选项 -->
- [ ] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [ ] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue
<!-- 例如：Fixes #123 -->

## 如何测试
<!-- 请描述您是如何测试这些更改的 -->

## 检查清单
- [ ] 我已阅读并遵循项目的贡献指南
- [ ] 我的代码遵循项目的代码风格
- [ ] 我已添加/更新了必要的测试
- [ ] 所有测试均已通过
- [ ] 我已更新了相关文档
