### PR TITLE
feat(server): 支持视频元数据解析

### DIFF
--- a/package/server/app/service/tasks/basic.py
+++ b/package/server/app/service/tasks/basic.py
@@ -54,6 +54,11 @@ def process_basic_cpu_job(file_path: str, file_id: UUID, storage_root: str, user
         # 2. Extract metadata (BASIC ONLY)
         file_name = os.path.basename(file_path)
         meta = exif.extract_metadata(file_path, file_name, image_obj=image_obj, extract_location_details=False)
+        # 视频的宽高/时长已由容器解析（moov/tkhd + mdhd）拿到，直接复用可省掉
+        # get_image_dimensions 里那次额外的 cv2.VideoCapture 打开。
+        meta_width = meta.get("width")
+        meta_height = meta.get("height")
+        meta_duration = meta.get("duration")
         if meta.get("exif_info"):
             # Serialize for storage
             # Convert non-serializable objects to string
@@ -64,7 +69,14 @@ def process_basic_cpu_job(file_path: str, file_id: UUID, storage_root: str, user
             meta['exif_info'] = json.dumps(meta["exif_info"], default=default_serializer, ensure_ascii=False)
         # 3. Get dimensions/size
         size = storage.get_file_size(file_path)
-        width, height, duration = storage.get_image_dimensions(file_path, image_obj=image_obj)
+        if meta_width and meta_height and meta_duration:
+            width, height, duration = meta_width, meta_height, meta_duration
+        else:
+            width, height, duration = storage.get_image_dimensions(file_path, image_obj=image_obj)
+            # cv2 读不到时（未装 opencv / 容器异常）用容器解析结果兜底
+            width = width or meta_width
+            height = height or meta_height
+            duration = duration or meta_duration
 
         # 4. Extract color/emotion info (while image_obj is still open)
         color_info = None

--- a/package/server/app/service/tasks/metadata.py
+++ b/package/server/app/service/tasks/metadata.py
@@ -9,15 +9,22 @@ import json
 from uuid import UUID
 from sqlalchemy.orm import Session
 from app.db.models.task import Task, TaskStatus, TaskType
-from app.db.models.photo import Photo, ImageType
+from app.db.models.photo import Photo, ImageType, FileType
 from app.db.models.photo_metadata import PhotoMetadata
 from app.db.models.scene import Scene
 from app.utils import exif
 
-def determine_image_type(filename: str, width: int, height: int, exif_data: dict) -> ImageType:
+def determine_image_type(filename: str, width: int, height: int, exif_data: dict,
+                         file_type: 'FileType | None' = None) -> ImageType:
     """
     Determine image type based on filename, dimensions, and EXIF data.
+
+    file_type 为视频时直接返回 OTHER：屏录视频的分辨率会命中下面的手机分辨率白名单
+    被误判成 SCREENSHOT，而视频元数据里的 Make/Model 也不代表"相机拍摄"这一图片语义。
     """
+    if file_type == FileType.video:
+        return ImageType.OTHER
+
     filename_lower = filename.lower()
 
     # 1. Check for Screenshot
@@ -222,6 +229,12 @@ def update_photo_metadata_from_extract(db: Session, photo: Photo, meta: dict):
             sp['focal_length'] = str(exif_dict.get('FocalLength'))
         if exif_dict.get('FocalLengthIn35mmFilm'):
             sp['focal_length_35mm'] = str(exif_dict.get('FocalLengthIn35mmFilm'))
+        # 视频专属参数。shooting_params 是 JSON 列，无需 migration。
+        for meta_key, sp_key in (('duration', 'duration'), ('fps', 'fps'),
+                                 ('codec', 'codec'), ('rotation', 'rotation')):
+            value = meta.get(meta_key)
+            if value is not None:
+                sp[sp_key] = value
         if sp:
             db_meta.shooting_params = sp
 
@@ -246,7 +259,20 @@ def update_photo_metadata_from_extract(db: Session, photo: Photo, meta: dict):
 
     if meta.get("photo_time"):
         photo.photo_time = meta["photo_time"]
-    photo.image_type = determine_image_type(photo.filename, photo.width, photo.height, meta.get("exif_info", {}))
+
+    # 视频的宽高交由容器解析补齐（含旋转矩阵校正），仅在原值为空时写入，
+    # 避免覆盖 PROCESS_BASIC 阶段 cv2 已经拿到的正确尺寸。
+    if getattr(photo, 'width', None) is None and meta.get("width"):
+        photo.width = meta["width"]
+    if getattr(photo, 'height', None) is None and meta.get("height"):
+        photo.height = meta["height"]
+    if not getattr(photo, 'duration', None) and meta.get("duration"):
+        photo.duration = meta["duration"]
+
+    photo.image_type = determine_image_type(
+        photo.filename, photo.width, photo.height, meta.get("exif_info", {}),
+        getattr(photo, 'file_type', None)
+    )
 
     # Mark as processed
     tasks_status = dict(photo.processed_tasks or {})

--- a/package/server/app/utils/exif.py
+++ b/package/server/app/utils/exif.py
@@ -25,7 +25,11 @@ import json
 import reverse_geocoder as rg
 
 from app.utils.filename import extract_datetime_from_filename
+from app.utils import video_meta
 from app.core.paths import RG_DATA_DIR as RG_DIR
+
+# 图片扩展名白名单（Pillow + pillow-heif 可解码的范围）
+IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.tiff', '.webp', '.png', '.heic', '.heif')
 
 def _convert_to_degrees(value):
     """
@@ -184,13 +188,34 @@ def reverse_geocode(lat: float, lng: float) -> dict:
     return {}
 
 
+def _attach_location_details(metadata: Dict[str, Any], gps: Optional[Dict[str, float]],
+                             extract_location_details: bool) -> None:
+    """把 GPS 写入 metadata，并按需补上逆地理编码结果。
+
+    图片与视频两条分支共用，保证视频的位置信息也能进入 city/province/scene 链路。
+    """
+    metadata["location"] = gps
+    if not (gps and extract_location_details):
+        return
+    loc = reverse_geocode(gps["latitude"], gps["longitude"])
+    if loc:
+        loc["latitude"] = gps["latitude"]
+        loc["longitude"] = gps["longitude"]
+        metadata["location_details"] = loc
+
+
 def extract_metadata(file_path: str, filename: str, image_obj: Optional[Image.Image] = None, extract_location_details: bool = True) -> Dict[str, Any]:
     """
     Extracts photo_time, exif_info, and location from the file.
+
+    图片走 EXIF，视频走 ISO BMFF (MP4/MOV) 的 moov/udta/meta 解析，两者写入同一份
+    metadata 结构，因此下游的时间回退、逆地理编码、入库映射全部共用。
+
     Priority:
-    1. EXIF DateTimeOriginal
+    1. EXIF DateTimeOriginal（图片） / CreateDate 或 mvhd creation_time（视频）
     2. Filename (YYYYMMDD_HHMMSS or YYYYMMDD)
-    3. Current Time
+    3. File mtime
+    4. Current Time
     """
     metadata = {
         "photo_time": None,
@@ -200,9 +225,10 @@ def extract_metadata(file_path: str, filename: str, image_obj: Optional[Image.Im
         "height": None
     }
 
-    # 1. Try EXIF
+    # 1. Try EXIF (image) / container metadata (video)
     try:
-        if file_path.lower().endswith(('.jpg', '.jpeg', '.tiff', '.webp', '.png', '.heic', '.heif')):
+        lower_path = file_path.lower()
+        if lower_path.endswith(IMAGE_EXTENSIONS):
             exif_dict = None
             img = None
             should_close = False
@@ -234,14 +260,26 @@ def extract_metadata(file_path: str, filename: str, image_obj: Optional[Image.Im
                         pass
 
                 # Extract GPS
-                gps = get_gps_info(exif_dict)
-                metadata["location"] = gps
-                if gps and extract_location_details:
-                    loc = reverse_geocode(gps["latitude"], gps["longitude"])
-                    if loc:
-                        loc["latitude"] = gps["latitude"]
-                        loc["longitude"] = gps["longitude"]
-                        metadata["location_details"] = loc
+                _attach_location_details(metadata, get_gps_info(exif_dict), extract_location_details)
+
+        elif video_meta.is_video_file(file_path):
+            # AVI/MKV/WEBM 不是 ISO BMFF，extract_video_metadata 会返回空结果，
+            # 此时自然落到下面的文件名 / mtime 回退。
+            v_meta = video_meta.extract_video_metadata(file_path)
+
+            if v_meta.get("video_info"):
+                metadata["exif_info"] = v_meta["video_info"]
+            if v_meta.get("video_time"):
+                metadata["photo_time"] = v_meta["video_time"]
+            if v_meta.get("width"):
+                metadata["width"] = v_meta["width"]
+            if v_meta.get("height"):
+                metadata["height"] = v_meta["height"]
+            for key in ("duration", "fps", "codec", "rotation"):
+                if v_meta.get(key) is not None:
+                    metadata[key] = v_meta[key]
+
+            _attach_location_details(metadata, v_meta.get("location"), extract_location_details)
 
     except Exception as e:
         print(traceback.format_exc())

--- a/package/server/app/utils/video_meta.py
+++ b/package/server/app/utils/video_meta.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""视频元数据解析（纯 Python，无外部二进制依赖）。
+
+设计约束
+--------
+服务端以 PyInstaller sidecar 形式随 Tauri 桌面端分发，引入 ffmpeg / exiftool
+这类外部可执行文件需要跨三平台打包，体积与构建复杂度都不可接受。因此这里沿用
+``app/utils/motion_photo.py`` 已有的做法：直接解析 ISO BMFF (MP4/MOV) 的 box
+(atom) 结构，只读文件头与 ``moov``，不解码任何音视频数据。
+
+覆盖范围
+--------
+* MP4 / MOV / M4V / 3GP —— 同一 ISO BMFF 容器，全覆盖。
+* AVI / MKV / WEBM —— 不同容器，本模块不解析；调用方会回退到文件名 / mtime。
+
+时间语义（关键）
+----------------
+``photos.photo_time`` 是 naive datetime，图片走 EXIF ``DateTimeOriginal``，存的是
+**拍摄地墙钟时间**。视频侧三个时间源语义并不一致，若不统一会让视频在时间线上
+整体偏移若干小时：
+
+1. ``moov/meta`` 的 ``com.apple.quicktime.creationdate`` —— 带时区偏移的字符串，
+   取其偏移下的墙钟时间并丢弃 tzinfo（与图片语义一致），优先级最高。
+2. ``moov/udta`` 的 ``©day`` —— 同上。
+3. ``moov/mvhd`` 的 ``creation_time`` —— 1904-01-01 UTC epoch，按规范转本机时区后
+   取墙钟时间，优先级最低。
+
+注意 ``mvhd`` 存在已知的厂商实现分歧：部分 Android 机型把本地时间当成 UTC 写入，
+此时转换会引入一次额外偏移。这里遵循规范实现，并把它放在最低优先级，让带显式
+时区的 1/2 优先生效。
+"""
+
+import logging
+import math
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterator, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# 所有被系统视作视频的扩展名（与 storage/basic/scan 中的判断保持一致）
+VIDEO_EXTENSIONS = {'.mp4', '.mov', '.m4v', '.avi', '.mkv', '.webm', '.3gp'}
+
+# 本模块能真正解析元数据的扩展名（ISO BMFF 家族）
+ISOBMFF_EXTENSIONS = {'.mp4', '.mov', '.m4v', '.3gp'}
+
+# QuickTime / ISO BMFF 时间基准：1904-01-01 00:00:00 UTC
+_QT_EPOCH = datetime(1904, 1, 1, tzinfo=timezone.utc)
+
+# 合理的拍摄年份区间，与 app/utils/filename.py 的校验口径一致
+_MIN_YEAR = 1990
+_MAX_YEAR = 2045
+
+# 单个 box payload 读入内存的上限，避免畸形文件把 size 写成天文数字
+_MAX_PAYLOAD_BYTES = 8 * 1024 * 1024
+
+# 原子键名 -> 归一化后的字段名。归一化成 EXIF 风格的键，
+# 使下游 update_photo_metadata_from_extract 的 Make/Model 映射可直接复用。
+_KEY_ALIASES = {
+    'com.apple.quicktime.creationdate': 'CreateDate',
+    'com.apple.quicktime.make': 'Make',
+    'com.apple.quicktime.model': 'Model',
+    'com.apple.quicktime.software': 'Software',
+    'com.apple.quicktime.location.iso6709': 'GPSCoordinates',
+    'com.apple.quicktime.location.accuracy.horizontal': 'GPSHorizontalAccuracy',
+    'com.apple.quicktime.camera.lens_model': 'LensModel',
+    'com.apple.quicktime.description': 'Description',
+    'com.apple.quicktime.title': 'Title',
+    'com.android.version': 'AndroidVersion',
+    'com.android.capture.fps': 'CaptureFrameRate',
+    '\xa9day': 'CreateDate',
+    '\xa9dat': 'CreateDate',
+    '\xa9mak': 'Make',
+    '\xa9mod': 'Model',
+    '\xa9swr': 'Software',
+    '\xa9xyz': 'GPSCoordinates',
+    '\xa9nam': 'Title',
+    '\xa9cmt': 'Comment',
+}
+
+_DATE_FORMATS = (
+    '%Y-%m-%dT%H:%M:%S%z',
+    '%Y-%m-%dT%H:%M:%S.%f%z',
+    '%Y-%m-%dT%H:%M:%S',
+    '%Y-%m-%dT%H:%M:%S.%f',
+    '%Y-%m-%d %H:%M:%S%z',
+    '%Y-%m-%d %H:%M:%S',
+    '%Y:%m:%d %H:%M:%S',
+    '%Y-%m-%d',
+)
+
+# ISO 6709: +34.0522-118.2437+000.000/  （高度段可选）
+_ISO6709_RE = re.compile(
+    r'^\s*([+-]\d{1,3}(?:\.\d+)?)([+-]\d{1,3}(?:\.\d+)?)'
+)
+
+
+def is_video_file(file_path: str) -> bool:
+    """扩展名是否属于视频。"""
+    return os.path.splitext(file_path)[1].lower() in VIDEO_EXTENSIONS
+
+
+def is_isobmff_file(file_path: str) -> bool:
+    """扩展名是否属于本模块可解析的 ISO BMFF 容器。"""
+    return os.path.splitext(file_path)[1].lower() in ISOBMFF_EXTENSIONS
+
+
+# --------------------------------------------------------------------------- #
+# box 遍历
+# --------------------------------------------------------------------------- #
+
+def _iter_boxes(f, start: int, end: int) -> Iterator[Tuple[bytes, int, int]]:
+    """顺序遍历 [start, end) 区间内的同级 box。
+
+    yield ``(box_type, payload_start, payload_end)``。只做 seek，不把 payload
+    读入内存，因此对含大 ``stbl`` 的 moov 也是常量内存开销。
+    """
+    offset = start
+    while offset + 8 <= end:
+        f.seek(offset)
+        header = f.read(8)
+        if len(header) < 8:
+            return
+        size = int.from_bytes(header[0:4], 'big')
+        box_type = header[4:8]
+        header_size = 8
+
+        if size == 1:
+            # 64 位 largesize
+            ext = f.read(8)
+            if len(ext) < 8:
+                return
+            size = int.from_bytes(ext, 'big')
+            header_size = 16
+        elif size == 0:
+            # size 为 0 表示该 box 延伸到容器末尾
+            size = end - offset
+
+        if size < header_size:
+            return
+
+        payload_start = offset + header_size
+        payload_end = min(offset + size, end)
+        if payload_start > payload_end:
+            return
+
+        yield box_type, payload_start, payload_end
+        offset += size
+
+
+def _find_box(f, start: int, end: int, path: Tuple[bytes, ...]) -> Optional[Tuple[int, int]]:
+    """按 path 逐层向下查找 box，返回最内层的 ``(payload_start, payload_end)``。"""
+    cur_start, cur_end = start, end
+    for want in path:
+        found = None
+        for box_type, p_start, p_end in _iter_boxes(f, cur_start, cur_end):
+            if box_type == want:
+                found = (p_start, p_end)
+                break
+        if found is None:
+            return None
+        cur_start, cur_end = found
+    return cur_start, cur_end
+
+
+def _read_payload(f, start: int, end: int) -> bytes:
+    """读取 box payload，带上限保护。"""
+    length = max(0, min(end - start, _MAX_PAYLOAD_BYTES))
+    if length == 0:
+        return b''
+    f.seek(start)
+    return f.read(length)
+
+
+# --------------------------------------------------------------------------- #
+# 标量解析
+# --------------------------------------------------------------------------- #
+
+def _fixed16_16(raw: bytes) -> float:
+    """16.16 定点数。"""
+    return int.from_bytes(raw, 'big', signed=True) / 65536.0
+
+
+def _fixed2_30(raw: bytes) -> float:
+    """2.30 定点数（变换矩阵的第三列）。"""
+    return int.from_bytes(raw, 'big', signed=True) / (1 << 30)
+
+
+def _qt_time_to_datetime(seconds: int) -> Optional[datetime]:
+    """1904 UTC epoch 秒 -> 本机时区墙钟时间（naive）。"""
+    if not seconds or seconds <= 0:
+        return None
+    try:
+        dt_utc = _QT_EPOCH + timedelta(seconds=int(seconds))
+    except (OverflowError, OSError, ValueError):
+        return None
+    try:
+        local = dt_utc.astimezone()
+    except (OverflowError, OSError, ValueError):
+        return None
+    if not (_MIN_YEAR <= local.year <= _MAX_YEAR):
+        return None
+    return local.replace(tzinfo=None)
+
+
+def parse_datetime_string(value: Any) -> Optional[datetime]:
+    """解析 atom 里的时间字符串，返回 naive 墙钟时间。
+
+    带时区偏移时保留该偏移下的墙钟读数并丢弃 tzinfo，从而与图片 EXIF
+    ``DateTimeOriginal`` 的语义对齐。
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip().replace('\x00', '')
+    if not text:
+        return None
+
+    # Z -> +0000；+08:00 -> +0800（%z 在 3.7+ 支持冒号，但统一处理更稳）
+    normalized = re.sub(r'[Zz]$', '+0000', text)
+    normalized = re.sub(r'([+-]\d{2}):(\d{2})$', r'\1\2', normalized)
+
+    for fmt in _DATE_FORMATS:
+        try:
+            dt = datetime.strptime(normalized, fmt)
+        except ValueError:
+            continue
+        if dt.tzinfo is not None:
+            dt = dt.replace(tzinfo=None)
+        if _MIN_YEAR <= dt.year <= _MAX_YEAR:
+            return dt
+        return None
+    return None
+
+
+def parse_iso6709(value: Any) -> Optional[Dict[str, float]]:
+    """解析 ISO 6709 坐标串（``©xyz`` / QuickTime location.ISO6709）。"""
+    if not isinstance(value, str):
+        return None
+    match = _ISO6709_RE.match(value.replace('\x00', ''))
+    if not match:
+        return None
+    try:
+        lat = float(match.group(1))
+        lng = float(match.group(2))
+    except ValueError:
+        return None
+    if not (-90.0 <= lat <= 90.0 and -180.0 <= lng <= 180.0):
+        return None
+    if lat == 0.0 and lng == 0.0:
+        return None
+    return {"latitude": lat, "longitude": lng}
+
+
+def _decode_text(raw: bytes) -> str:
+    for encoding in ('utf-8', 'utf-16-be', 'latin-1'):
+        try:
+            return raw.decode(encoding).strip().replace('\x00', '')
+        except UnicodeDecodeError:
+            continue
+    return ''
+
+
+def _atom_type_to_key(raw: bytes) -> str:
+    """4 字节 atom 类型转可读键名（``\\xa9day`` -> ``©day``）。"""
+    return raw.decode('latin-1')
+
+
+# --------------------------------------------------------------------------- #
+# udta / meta 标签解析
+# --------------------------------------------------------------------------- #
+
+def _parse_udta(payload: bytes) -> Dict[str, Any]:
+    """解析 ``udta`` 下的 QuickTime 文本型 user-data atom。
+
+    经典布局：``[size][type][text_size(2)][language(2)][text]``；部分写入器会
+    省略 text_size/language 直接跟裸文本，这里做兼容。
+    """
+    tags: Dict[str, Any] = {}
+    offset = 0
+    total = len(payload)
+    while offset + 8 <= total:
+        size = int.from_bytes(payload[offset:offset + 4], 'big')
+        atom_type = payload[offset + 4:offset + 8]
+        if size < 8 or offset + size > total:
+            break
+        body = payload[offset + 8:offset + size]
+        offset += size
+
+        if atom_type == b'meta':
+            tags.update(_parse_meta(body))
+            continue
+
+        if len(body) >= 4:
+            declared = int.from_bytes(body[0:2], 'big')
+            if declared == len(body) - 4:
+                body = body[4:]
+
+        text = _decode_text(body)
+        if text:
+            tags[_atom_type_to_key(atom_type)] = text
+    return tags
+
+
+def _parse_keys(payload: bytes) -> list:
+    """解析 ``meta/keys``，返回按序的 key 名称列表（1-based 由调用方处理）。"""
+    keys: list = []
+    if len(payload) < 8:
+        return keys
+    entry_count = int.from_bytes(payload[4:8], 'big')
+    offset = 8
+    total = len(payload)
+    while offset + 8 <= total and len(keys) < entry_count:
+        size = int.from_bytes(payload[offset:offset + 4], 'big')
+        if size < 8 or offset + size > total:
+            break
+        # payload[offset+4:offset+8] 是 namespace（通常为 'mdta'）
+        keys.append(_decode_text(payload[offset + 8:offset + size]))
+        offset += size
+    return keys
+
+
+def _parse_data_box(body: bytes) -> Any:
+    """解析 ilst 条目内的 ``data`` box，按 type indicator 还原值类型。"""
+    offset = 0
+    total = len(body)
+    while offset + 8 <= total:
+        size = int.from_bytes(body[offset:offset + 4], 'big')
+        box_type = body[offset + 4:offset + 8]
+        if size < 8 or offset + size > total:
+            break
+        inner = body[offset + 8:offset + size]
+        offset += size
+        if box_type != b'data' or len(inner) < 8:
+            continue
+
+        type_indicator = int.from_bytes(inner[0:4], 'big')
+        value_bytes = inner[8:]
+        if type_indicator == 1:  # UTF-8
+            return _decode_text(value_bytes)
+        if type_indicator == 2:  # UTF-16
+            try:
+                return value_bytes.decode('utf-16-be').strip().replace('\x00', '')
+            except UnicodeDecodeError:
+                return _decode_text(value_bytes)
+        if type_indicator in (21, 22) and value_bytes:  # 有/无符号整数
+            return int.from_bytes(value_bytes, 'big', signed=(type_indicator == 21))
+        if type_indicator == 23 and len(value_bytes) >= 4:  # float32
+            import struct
+            return struct.unpack('>f', value_bytes[:4])[0]
+        if type_indicator == 24 and len(value_bytes) >= 8:  # float64
+            import struct
+            return struct.unpack('>d', value_bytes[:8])[0]
+        text = _decode_text(value_bytes)
+        return text or None
+    return None
+
+
+def _parse_ilst(payload: bytes, keys: list) -> Dict[str, Any]:
+    """解析 ``meta/ilst``。
+
+    条目的 4 字节头既可能是指向 ``keys`` 表的 1-based 索引（QuickTime mdta 风格），
+    也可能直接是 iTunes 风格的 4 字符类型（如 ``©day``）。两种都处理。
+    """
+    tags: Dict[str, Any] = {}
+    offset = 0
+    total = len(payload)
+    while offset + 8 <= total:
+        size = int.from_bytes(payload[offset:offset + 4], 'big')
+        raw_key = payload[offset + 4:offset + 8]
+        if size < 8 or offset + size > total:
+            break
+        body = payload[offset + 8:offset + size]
+        offset += size
+
+        index = int.from_bytes(raw_key, 'big')
+        if keys and 1 <= index <= len(keys):
+            name = keys[index - 1]
+        else:
+            name = _atom_type_to_key(raw_key)
+        if not name:
+            continue
+
+        value = _parse_data_box(body)
+        if value is not None and value != '':
+            tags[name] = value
+    return tags
+
+
+def _parse_meta(payload: bytes) -> Dict[str, Any]:
+    """解析 ``meta``。
+
+    MP4 中 ``meta`` 是 FullBox（前置 4 字节 version/flags），而 QuickTime MOV 中
+    不是。通过探测前 4..8 字节是否为已知子 box 类型来区分。
+    """
+    if len(payload) < 8:
+        return {}
+
+    body = payload
+    if payload[4:8] not in (b'hdlr', b'keys', b'ilst', b'free', b'mdta'):
+        body = payload[4:]  # FullBox，跳过 version/flags
+
+    keys: list = []
+    ilst_payload = b''
+    nested: Dict[str, Any] = {}
+
+    offset = 0
+    total = len(body)
+    while offset + 8 <= total:
+        size = int.from_bytes(body[offset:offset + 4], 'big')
+        box_type = body[offset + 4:offset + 8]
+        if size < 8 or offset + size > total:
+            break
+        inner = body[offset + 8:offset + size]
+        offset += size
+
+        if box_type == b'keys':
+            keys = _parse_keys(inner)
+        elif box_type == b'ilst':
+            ilst_payload = inner
+        elif box_type == b'udta':
+            nested.update(_parse_udta(inner))
+
+    tags: Dict[str, Any] = {}
+    if ilst_payload:
+        tags.update(_parse_ilst(ilst_payload, keys))
+    tags.update(nested)
+    return tags
+
+
+# --------------------------------------------------------------------------- #
+# 轨道信息
+# --------------------------------------------------------------------------- #
+
+def _parse_mvhd(payload: bytes) -> Dict[str, Any]:
+    """解析 ``mvhd``：创建时间与总时长。"""
+    info: Dict[str, Any] = {}
+    if len(payload) < 4:
+        return info
+    version = payload[0]
+    if version == 1:
+        if len(payload) < 32:
+            return info
+        creation = int.from_bytes(payload[4:12], 'big')
+        timescale = int.from_bytes(payload[20:24], 'big')
+        duration = int.from_bytes(payload[24:32], 'big')
+    else:
+        if len(payload) < 20:
+            return info
+        creation = int.from_bytes(payload[4:8], 'big')
+        timescale = int.from_bytes(payload[12:16], 'big')
+        duration = int.from_bytes(payload[16:20], 'big')
+
+    info['creation_time'] = _qt_time_to_datetime(creation)
+    if timescale > 0 and duration > 0:
+        # 0xFFFFFFFF 是"时长未知"的惯用哨兵值
+        if not (version == 0 and duration == 0xFFFFFFFF):
+            info['duration'] = round(duration / timescale, 3)
+    return info
+
+
+def _parse_tkhd(payload: bytes) -> Dict[str, Any]:
+    """解析 ``tkhd``：显示宽高与变换矩阵推导出的旋转角。"""
+    info: Dict[str, Any] = {}
+    if len(payload) < 4:
+        return info
+    version = payload[0]
+    offset = 4 + (32 if version == 1 else 20)
+    offset += 8 + 2 + 2 + 2 + 2  # reserved(8) layer(2) alt_group(2) volume(2) reserved(2)
+
+    if len(payload) < offset + 36 + 8:
+        return info
+
+    matrix = [payload[offset + i * 4: offset + (i + 1) * 4] for i in range(9)]
+    offset += 36
+
+    width = _fixed16_16(payload[offset:offset + 4])
+    height = _fixed16_16(payload[offset + 4:offset + 8])
+
+    a = _fixed16_16(matrix[0])
+    b = _fixed16_16(matrix[1])
+    # matrix[2] / [5] / [8] 是 2.30 定点（u, v, w），此处仅用于健壮性校验
+    _fixed2_30(matrix[2])
+
+    rotation = 0
+    if a or b:
+        rotation = int(round(math.degrees(math.atan2(b, a)))) % 360
+        # 归一到 0/90/180/270
+        rotation = min((0, 90, 180, 270), key=lambda r: min(abs(rotation - r), 360 - abs(rotation - r)))
+
+    if width > 0 and height > 0:
+        w, h = int(round(width)), int(round(height))
+        if rotation in (90, 270):
+            w, h = h, w
+        info['width'] = w
+        info['height'] = h
+    info['rotation'] = rotation
+    return info
+
+
+def _parse_mdhd(payload: bytes) -> Dict[str, Any]:
+    """解析 ``mdhd``：媒体 timescale 与时长。"""
+    info: Dict[str, Any] = {}
+    if len(payload) < 4:
+        return info
+    version = payload[0]
+    if version == 1:
+        if len(payload) < 32:
+            return info
+        timescale = int.from_bytes(payload[20:24], 'big')
+        duration = int.from_bytes(payload[24:32], 'big')
+    else:
+        if len(payload) < 20:
+            return info
+        timescale = int.from_bytes(payload[12:16], 'big')
+        duration = int.from_bytes(payload[16:20], 'big')
+    if timescale > 0 and duration > 0:
+        info['duration'] = round(duration / timescale, 3)
+    return info
+
+
+def _parse_stsd_codec(payload: bytes) -> Optional[str]:
+    """从 ``stsd`` 第一条 sample entry 取 codec 四字符码。"""
+    if len(payload) < 16:
+        return None
+    codec = payload[12:16]
+    text = _decode_text(codec)
+    return text or None
+
+
+def _parse_stsz_sample_count(payload: bytes) -> Optional[int]:
+    """从 ``stsz`` 取样本数（用于估算帧率）。"""
+    if len(payload) < 12:
+        return None
+    count = int.from_bytes(payload[8:12], 'big')
+    return count or None
+
+
+def _parse_video_track(f, moov_start: int, moov_end: int) -> Dict[str, Any]:
+    """找到第一条 handler 为 ``vide`` 的轨道，抽取尺寸/时长/codec/帧率。"""
+    info: Dict[str, Any] = {}
+    for box_type, t_start, t_end in _iter_boxes(f, moov_start, moov_end):
+        if box_type != b'trak':
+            continue
+
+        hdlr = _find_box(f, t_start, t_end, (b'mdia', b'hdlr'))
+        if hdlr is None:
+            continue
+        hdlr_payload = _read_payload(f, *hdlr)
+        if len(hdlr_payload) < 12 or hdlr_payload[8:12] != b'vide':
+            continue
+
+        tkhd = _find_box(f, t_start, t_end, (b'tkhd',))
+        if tkhd is not None:
+            info.update(_parse_tkhd(_read_payload(f, *tkhd)))
+
+        mdhd = _find_box(f, t_start, t_end, (b'mdia', b'mdhd'))
+        track_duration = None
+        if mdhd is not None:
+            track_duration = _parse_mdhd(_read_payload(f, *mdhd)).get('duration')
+            if track_duration:
+                info['duration'] = track_duration
+
+        stsd = _find_box(f, t_start, t_end, (b'mdia', b'minf', b'stbl', b'stsd'))
+        if stsd is not None:
+            codec = _parse_stsd_codec(_read_payload(f, *stsd))
+            if codec:
+                info['codec'] = codec
+
+        stsz = _find_box(f, t_start, t_end, (b'mdia', b'minf', b'stbl', b'stsz'))
+        if stsz is not None and track_duration:
+            sample_count = _parse_stsz_sample_count(_read_payload(f, *stsz))
+            if sample_count and track_duration > 0:
+                info['fps'] = round(sample_count / track_duration, 3)
+
+        break
+    return info
+
+
+# --------------------------------------------------------------------------- #
+# 对外入口
+# --------------------------------------------------------------------------- #
+
+def _empty_result() -> Dict[str, Any]:
+    return {
+        "video_time": None,
+        "video_info": {},
+        "location": None,
+        "width": None,
+        "height": None,
+        "duration": None,
+        "rotation": None,
+        "fps": None,
+        "codec": None,
+    }
+
+
+def extract_video_metadata(file_path: str) -> Dict[str, Any]:
+    """解析视频文件元数据。
+
+    只读文件头与 ``moov``，不解码媒体数据。任何解析失败都被吞掉并返回已取到的
+    部分结果，绝不向上抛异常（调用链在批处理任务里，单文件不应拖垮整批）。
+    """
+    result = _empty_result()
+    if not is_isobmff_file(file_path):
+        return result
+
+    try:
+        file_size = os.path.getsize(file_path)
+        if file_size <= 8:
+            return result
+
+        with open(file_path, 'rb') as f:
+            moov = _find_box(f, 0, file_size, (b'moov',))
+            if moov is None:
+                return result
+            moov_start, moov_end = moov
+
+            tags: Dict[str, Any] = {}
+
+            # 1. moov/udta（含其下嵌套的 meta）
+            udta = _find_box(f, moov_start, moov_end, (b'udta',))
+            if udta is not None:
+                tags.update(_parse_udta(_read_payload(f, *udta)))
+
+            # 2. moov/meta（Apple mdta keys+ilst / Android com.android.*）
+            meta = _find_box(f, moov_start, moov_end, (b'meta',))
+            if meta is not None:
+                tags.update(_parse_meta(_read_payload(f, *meta)))
+
+            # 3. mvhd：总时长 + 最低优先级的创建时间
+            mvhd_time = None
+            mvhd = _find_box(f, moov_start, moov_end, (b'mvhd',))
+            if mvhd is not None:
+                mvhd_info = _parse_mvhd(_read_payload(f, *mvhd))
+                mvhd_time = mvhd_info.get('creation_time')
+                if mvhd_info.get('duration'):
+                    result['duration'] = mvhd_info['duration']
+
+            # 4. 视频轨道：尺寸 / 旋转 / codec / 帧率（轨道时长优先于 mvhd）
+            track_info = _parse_video_track(f, moov_start, moov_end)
+            for key in ('width', 'height', 'rotation', 'codec', 'fps'):
+                if track_info.get(key) is not None:
+                    result[key] = track_info[key]
+            if track_info.get('duration'):
+                result['duration'] = track_info['duration']
+
+        # 归一化标签键名
+        normalized: Dict[str, Any] = {}
+        for raw_key, value in tags.items():
+            alias = _KEY_ALIASES.get(raw_key.lower(), _KEY_ALIASES.get(raw_key))
+            normalized[alias or raw_key] = value
+
+        # 拍摄时间：CreateDate（带时区）> mvhd（1904 UTC epoch）
+        result['video_time'] = parse_datetime_string(normalized.get('CreateDate')) or mvhd_time
+
+        # GPS：优先 ISO 6709 字符串
+        result['location'] = parse_iso6709(normalized.get('GPSCoordinates'))
+
+        # 补齐视频专属字段，便于前端 EXIF 面板与导出模板直接使用
+        normalized['MediaType'] = 'video'
+        for key, label in (('duration', 'Duration'), ('fps', 'FrameRate'),
+                           ('codec', 'VideoCodec'), ('rotation', 'Rotation')):
+            if result.get(key) is not None:
+                normalized[label] = result[key]
+        if result.get('width') and result.get('height'):
+            normalized['ImageWidth'] = result['width']
+            normalized['ImageHeight'] = result['height']
+
+        result['video_info'] = normalized
+    except Exception as e:
+        logger.warning(f"extract_video_metadata failed for {file_path}: {e}")
+
+    return result

--- a/package/server/tests/unit/test_video_meta.py
+++ b/package/server/tests/unit/test_video_meta.py
@@ -1,0 +1,605 @@
+"""Unit coverage for app.utils.video_meta (视频容器元数据解析).
+
+所有用例都用代码构造 ISO BMFF (MP4/MOV) 的 box 字节流，不依赖任何样本文件，
+因此可在 CI / 无媒体资源环境下稳定运行。覆盖：
+
+* Happy path: moov/udta ©day 与 moov/meta(keys+ilst) 的时间、机型、GPS 提取。
+* 优先级: CreateDate（带时区）优先于 mvhd 的 1904 UTC epoch。
+* 轨道解析: tkhd 宽高、旋转矩阵 90° 时交换宽高、mdhd 时长、stsd codec、stsz 帧率。
+* Edge: 非 ISO BMFF 扩展名 / 无 moov / 空文件 / 畸形 size 都返回结构完整的空结果。
+* 集成: exif.extract_metadata 对视频走容器分支，并复用文件名 / mtime 回退链路。
+"""
+
+from __future__ import annotations
+
+import struct
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+# --------------------------------------------------------------------------- #
+# box 构造辅助
+# --------------------------------------------------------------------------- #
+
+def box(box_type: bytes, payload: bytes = b'') -> bytes:
+    """构造一个 32 位 size 的 box。"""
+    return struct.pack('>I', len(payload) + 8) + box_type + payload
+
+
+def large_box(box_type: bytes, payload: bytes) -> bytes:
+    """构造一个 64 位 largesize 的 box（size 字段写 1）。"""
+    return struct.pack('>I', 1) + box_type + struct.pack('>Q', len(payload) + 16) + payload
+
+
+def udta_text(box_type: bytes, text: str) -> bytes:
+    """QuickTime user-data 文本 atom: [text_size(2)][language(2)][text]."""
+    raw = text.encode('utf-8')
+    return box(box_type, struct.pack('>HH', len(raw), 0) + raw)
+
+
+def keys_box(names: list[str]) -> bytes:
+    """moov/meta/keys —— 按序声明 metadata key 名称。"""
+    entries = b''.join(box(b'mdta', name.encode('utf-8')) for name in names)
+    return box(b'keys', struct.pack('>II', 0, len(names)) + entries)
+
+
+def data_box(value, type_indicator: int = 1) -> bytes:
+    """ilst 条目内的 data box。"""
+    if type_indicator == 1:
+        raw = value.encode('utf-8')
+    elif type_indicator in (21, 22):
+        raw = struct.pack('>i', value)
+    elif type_indicator == 23:
+        raw = struct.pack('>f', value)
+    else:
+        raw = value
+    return box(b'data', struct.pack('>II', type_indicator, 0) + raw)
+
+
+def ilst_indexed(items: list[tuple[int, bytes]]) -> bytes:
+    """mdta 风格 ilst：条目头是指向 keys 表的 1-based 索引。"""
+    entries = b''.join(struct.pack('>I', len(body) + 8) + struct.pack('>I', idx) + body
+                       for idx, body in items)
+    return box(b'ilst', entries)
+
+
+def meta_box(names: list[str], values: list, full_box: bool = True) -> bytes:
+    """moov/meta = [version/flags?] hdlr + keys + ilst。"""
+    hdlr = box(b'hdlr', b'\x00' * 8 + b'mdta' + b'\x00' * 12)
+    items = [(i + 1, data_box(v)) for i, v in enumerate(values)]
+    payload = hdlr + keys_box(names) + ilst_indexed(items)
+    if full_box:
+        payload = b'\x00\x00\x00\x00' + payload
+    return box(b'meta', payload)
+
+
+def mvhd_box(creation_seconds: int, timescale: int = 1000, duration: int = 12345,
+             version: int = 0) -> bytes:
+    """moov/mvhd。creation_seconds 是 1904-01-01 UTC 起的秒数。"""
+    if version == 1:
+        payload = (bytes([1]) + b'\x00\x00\x00'
+                   + struct.pack('>Q', creation_seconds)
+                   + struct.pack('>Q', creation_seconds)
+                   + struct.pack('>I', timescale)
+                   + struct.pack('>Q', duration))
+    else:
+        payload = (b'\x00\x00\x00\x00'
+                   + struct.pack('>I', creation_seconds)
+                   + struct.pack('>I', creation_seconds)
+                   + struct.pack('>I', timescale)
+                   + struct.pack('>I', duration))
+    payload += b'\x00' * 80
+    return box(b'mvhd', payload)
+
+
+def _identity_matrix() -> bytes:
+    return (struct.pack('>i', 1 << 16) + struct.pack('>i', 0) + struct.pack('>i', 0)
+            + struct.pack('>i', 0) + struct.pack('>i', 1 << 16) + struct.pack('>i', 0)
+            + struct.pack('>i', 0) + struct.pack('>i', 0) + struct.pack('>i', 1 << 30))
+
+
+def _rotate90_matrix() -> bytes:
+    """顺时针 90°: a=0 b=1 c=-1 d=0。"""
+    return (struct.pack('>i', 0) + struct.pack('>i', 1 << 16) + struct.pack('>i', 0)
+            + struct.pack('>i', -(1 << 16)) + struct.pack('>i', 0) + struct.pack('>i', 0)
+            + struct.pack('>i', 0) + struct.pack('>i', 0) + struct.pack('>i', 1 << 30))
+
+
+def tkhd_box(width: int, height: int, matrix: bytes | None = None) -> bytes:
+    """moov/trak/tkhd（version 0）。"""
+    payload = b'\x00\x00\x00\x00'          # version + flags
+    payload += b'\x00' * 20                # creation/modification/track_id/reserved/duration
+    payload += b'\x00' * 8                 # reserved
+    payload += struct.pack('>hhhh', 0, 0, 0, 0)  # layer/alt_group/volume/reserved
+    payload += matrix if matrix is not None else _identity_matrix()
+    payload += struct.pack('>i', width << 16) + struct.pack('>i', height << 16)
+    return box(b'tkhd', payload)
+
+
+def mdhd_box(timescale: int, duration: int) -> bytes:
+    payload = (b'\x00\x00\x00\x00' + b'\x00' * 8
+               + struct.pack('>I', timescale) + struct.pack('>I', duration)
+               + b'\x00' * 4)
+    return box(b'mdhd', payload)
+
+
+def hdlr_box(handler: bytes) -> bytes:
+    return box(b'hdlr', b'\x00' * 8 + handler + b'\x00' * 12)
+
+
+def stsd_box(codec: bytes) -> bytes:
+    """stsd: [version/flags(4)][entry_count(4)][entry_size(4)][codec(4)]..."""
+    entry = struct.pack('>I', 16) + codec + b'\x00' * 8
+    return box(b'stsd', b'\x00\x00\x00\x00' + struct.pack('>I', 1) + entry)
+
+
+def stsz_box(sample_count: int) -> bytes:
+    return box(b'stsz', b'\x00\x00\x00\x00' + struct.pack('>I', 0)
+               + struct.pack('>I', sample_count))
+
+
+def video_trak(width: int = 1920, height: int = 1080, timescale: int = 600,
+               duration: int = 6000, codec: bytes = b'avc1', samples: int = 300,
+               matrix: bytes | None = None, handler: bytes = b'vide') -> bytes:
+    stbl = box(b'stbl', stsd_box(codec) + stsz_box(samples))
+    minf = box(b'minf', stbl)
+    mdia = box(b'mdia', mdhd_box(timescale, duration) + hdlr_box(handler) + minf)
+    return box(b'trak', tkhd_box(width, height, matrix) + mdia)
+
+
+def write_mp4(tmp_path, name: str, *moov_children: bytes) -> str:
+    """写出一个最小可解析的 MP4：ftyp + moov + mdat。"""
+    ftyp = box(b'ftyp', b'isom' + struct.pack('>I', 512) + b'isomiso2')
+    moov = box(b'moov', b''.join(moov_children))
+    mdat = box(b'mdat', b'\x00' * 64)
+    path = tmp_path / name
+    path.write_bytes(ftyp + moov + mdat)
+    return str(path)
+
+
+def qt_seconds(dt_utc: datetime) -> int:
+    """UTC datetime -> 1904 epoch 秒数。"""
+    epoch = datetime(1904, 1, 1, tzinfo=timezone.utc)
+    return int((dt_utc - epoch).total_seconds())
+
+
+# --------------------------------------------------------------------------- #
+# 标量解析
+# --------------------------------------------------------------------------- #
+
+def test_parse_datetime_string_keeps_wall_clock_and_drops_tzinfo():
+    from app.utils.video_meta import parse_datetime_string
+
+    # 带 +08:00 偏移时应保留该偏移下的墙钟读数（与图片 EXIF 语义一致），
+    # 不能再转成 UTC，否则视频在时间线上会整体前移 8 小时。
+    assert parse_datetime_string('2024-05-01T18:30:00+08:00') == datetime(2024, 5, 1, 18, 30, 0)
+    assert parse_datetime_string('2024-05-01T18:30:00Z') == datetime(2024, 5, 1, 18, 30, 0)
+    assert parse_datetime_string('2024-05-01T18:30:00') == datetime(2024, 5, 1, 18, 30, 0)
+    assert parse_datetime_string('2024-05-01 18:30:00') == datetime(2024, 5, 1, 18, 30, 0)
+    assert parse_datetime_string('2024:05:01 18:30:00') == datetime(2024, 5, 1, 18, 30, 0)
+
+
+def test_parse_datetime_string_rejects_garbage_and_out_of_range_years():
+    from app.utils.video_meta import parse_datetime_string
+
+    assert parse_datetime_string('not-a-date') is None
+    assert parse_datetime_string('') is None
+    assert parse_datetime_string(None) is None
+    assert parse_datetime_string(12345) is None
+    # 1904 是 QuickTime 的哨兵基准年，落在合理拍摄年份区间之外
+    assert parse_datetime_string('1904-01-01T00:00:00') is None
+    assert parse_datetime_string('2099-01-01T00:00:00') is None
+
+
+def test_parse_iso6709_handles_both_hemispheres():
+    from app.utils.video_meta import parse_iso6709
+
+    assert parse_iso6709('+34.0522-118.2437+000.000/') == {
+        "latitude": pytest.approx(34.0522), "longitude": pytest.approx(-118.2437)}
+    assert parse_iso6709('-33.8688+151.2093/') == {
+        "latitude": pytest.approx(-33.8688), "longitude": pytest.approx(151.2093)}
+    # 无高度段也应可解析
+    assert parse_iso6709('+30.5+114.3') == {
+        "latitude": pytest.approx(30.5), "longitude": pytest.approx(114.3)}
+
+
+def test_parse_iso6709_rejects_invalid_and_null_island():
+    from app.utils.video_meta import parse_iso6709
+
+    assert parse_iso6709('') is None
+    assert parse_iso6709(None) is None
+    assert parse_iso6709('34.05,-118.24') is None       # 缺符号前缀
+    assert parse_iso6709('+00.0000+000.0000/') is None   # (0,0) 视为无效占位
+    assert parse_iso6709('+99.0000+200.0000/') is None   # 超出经纬度范围
+
+
+def test_is_video_file_and_is_isobmff_file():
+    from app.utils.video_meta import is_isobmff_file, is_video_file
+
+    assert is_video_file('a.MP4') and is_video_file('a.mov') and is_video_file('a.mkv')
+    assert not is_video_file('a.jpg')
+    # MKV/WEBM 是视频但不是 ISO BMFF，本模块不解析
+    assert is_isobmff_file('a.mp4') and is_isobmff_file('a.MOV')
+    assert not is_isobmff_file('a.mkv') and not is_isobmff_file('a.webm')
+
+
+# --------------------------------------------------------------------------- #
+# udta 分支
+# --------------------------------------------------------------------------- #
+
+def test_extract_reads_creation_time_make_model_and_gps_from_udta(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    udta = box(b'udta',
+               udta_text(b'\xa9day', '2024-05-01T18:30:00+0800')
+               + udta_text(b'\xa9mak', 'Apple')
+               + udta_text(b'\xa9mod', 'iPhone 15 Pro')
+               + udta_text(b'\xa9xyz', '+34.0522-118.2437+000.000/'))
+    path = write_mp4(tmp_path, 'udta.mp4', mvhd_box(0), udta, video_trak())
+
+    result = extract_video_metadata(path)
+
+    assert result['video_time'] == datetime(2024, 5, 1, 18, 30, 0)
+    assert result['location'] == {
+        "latitude": pytest.approx(34.0522), "longitude": pytest.approx(-118.2437)}
+    # 键名归一成 EXIF 风格，下游 update_photo_metadata_from_extract 可直接复用
+    assert result['video_info']['Make'] == 'Apple'
+    assert result['video_info']['Model'] == 'iPhone 15 Pro'
+    assert result['video_info']['MediaType'] == 'video'
+
+
+def test_extract_tolerates_udta_atoms_without_language_prefix(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    # 部分写入器省略 text_size/language，直接跟裸文本
+    udta = box(b'udta', box(b'\xa9mak', b'Xiaomi'))
+    path = write_mp4(tmp_path, 'bare.mp4', mvhd_box(0), udta)
+
+    assert extract_video_metadata(path)['video_info']['Make'] == 'Xiaomi'
+
+
+# --------------------------------------------------------------------------- #
+# meta(keys + ilst) 分支
+# --------------------------------------------------------------------------- #
+
+def test_extract_reads_apple_quicktime_keys_from_meta(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    meta = meta_box(
+        ['com.apple.quicktime.creationdate',
+         'com.apple.quicktime.make',
+         'com.apple.quicktime.model',
+         'com.apple.quicktime.location.ISO6709'],
+        ['2025-03-08T09:15:20+0800', 'Apple', 'iPhone 14 Pro', '-33.8688+151.2093+021.000/'],
+    )
+    path = write_mp4(tmp_path, 'apple.mp4', mvhd_box(0), meta, video_trak())
+
+    result = extract_video_metadata(path)
+
+    assert result['video_time'] == datetime(2025, 3, 8, 9, 15, 20)
+    assert result['location']['latitude'] == pytest.approx(-33.8688)
+    assert result['location']['longitude'] == pytest.approx(151.2093)
+    assert result['video_info']['Model'] == 'iPhone 14 Pro'
+
+
+def test_extract_reads_android_version_key_from_meta(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    meta = meta_box(['com.android.version'], ['16'])
+    path = write_mp4(tmp_path, 'android.mp4', mvhd_box(0), meta)
+
+    assert extract_video_metadata(path)['video_info']['AndroidVersion'] == '16'
+
+
+def test_extract_handles_quicktime_meta_without_version_flags(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    # MOV 的 meta 不是 FullBox（没有前置 version/flags），需要能自动探测
+    meta = meta_box(['com.apple.quicktime.make'], ['Apple'], full_box=False)
+    path = write_mp4(tmp_path, 'mov_meta.mov', mvhd_box(0), meta)
+
+    assert extract_video_metadata(path)['video_info']['Make'] == 'Apple'
+
+
+def test_extract_reads_itunes_style_ilst_without_keys_table(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    # iTunes 风格：ilst 条目头直接是 4 字符类型而非 keys 索引
+    ilst = box(b'ilst', box(b'\xa9day', data_box('2023-11-02T07:00:00+0000')))
+    meta = box(b'meta', b'\x00\x00\x00\x00' + hdlr_box(b'mdir') + ilst)
+    path = write_mp4(tmp_path, 'itunes.mp4', mvhd_box(0), meta)
+
+    assert extract_video_metadata(path)['video_time'] == datetime(2023, 11, 2, 7, 0, 0)
+
+
+# --------------------------------------------------------------------------- #
+# 时间优先级
+# --------------------------------------------------------------------------- #
+
+def test_create_date_takes_priority_over_mvhd_creation_time(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    mvhd = mvhd_box(qt_seconds(datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)))
+    meta = meta_box(['com.apple.quicktime.creationdate'], ['2024-05-01T18:30:00+0800'])
+    path = write_mp4(tmp_path, 'priority.mp4', mvhd, meta)
+
+    # 带显式时区的 CreateDate 语义更明确，必须压过 mvhd 的 1904 epoch
+    assert extract_video_metadata(path)['video_time'] == datetime(2024, 5, 1, 18, 30, 0)
+
+
+def test_falls_back_to_mvhd_creation_time_converted_to_local_zone(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    moment = datetime(2024, 7, 15, 12, 0, 0, tzinfo=timezone.utc)
+    path = write_mp4(tmp_path, 'mvhd_only.mp4', mvhd_box(qt_seconds(moment)))
+
+    # mvhd 按规范是 1904 UTC epoch，需转成本机时区的墙钟时间
+    expected = moment.astimezone().replace(tzinfo=None)
+    assert extract_video_metadata(path)['video_time'] == expected
+
+
+def test_mvhd_version1_uses_64bit_fields(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    moment = datetime(2024, 2, 29, 6, 0, 0, tzinfo=timezone.utc)
+    mvhd = mvhd_box(qt_seconds(moment), timescale=1000, duration=90000, version=1)
+    path = write_mp4(tmp_path, 'v1.mp4', mvhd)
+
+    result = extract_video_metadata(path)
+    assert result['video_time'] == moment.astimezone().replace(tzinfo=None)
+    assert result['duration'] == pytest.approx(90.0)
+
+
+def test_zero_creation_time_does_not_produce_1904_timestamp(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    # 大量设备把 creation_time 写 0；不能因此把拍摄时间定成 1904 年
+    path = write_mp4(tmp_path, 'zero.mp4', mvhd_box(0))
+
+    assert extract_video_metadata(path)['video_time'] is None
+
+
+# --------------------------------------------------------------------------- #
+# 轨道解析
+# --------------------------------------------------------------------------- #
+
+def test_extract_reads_dimensions_duration_codec_and_fps_from_video_track(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    trak = video_trak(width=1920, height=1080, timescale=600, duration=6000,
+                      codec=b'avc1', samples=300)
+    path = write_mp4(tmp_path, 'track.mp4', mvhd_box(0), trak)
+
+    result = extract_video_metadata(path)
+
+    assert (result['width'], result['height']) == (1920, 1080)
+    assert result['duration'] == pytest.approx(10.0)   # 6000 / 600
+    assert result['codec'] == 'avc1'
+    assert result['fps'] == pytest.approx(30.0)        # 300 samples / 10s
+    assert result['rotation'] == 0
+
+
+def test_rotated_track_swaps_width_and_height(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    # 竖屏手机录像常见：tkhd 记录 1920x1080 + 90° 旋转矩阵，实际显示为 1080x1920
+    trak = video_trak(width=1920, height=1080, matrix=_rotate90_matrix())
+    path = write_mp4(tmp_path, 'rotated.mp4', mvhd_box(0), trak)
+
+    result = extract_video_metadata(path)
+
+    assert result['rotation'] == 90
+    assert (result['width'], result['height']) == (1080, 1920)
+
+
+def test_track_duration_overrides_mvhd_duration(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    mvhd = mvhd_box(0, timescale=1000, duration=5000)          # 5s
+    trak = video_trak(timescale=600, duration=6000)            # 10s
+    path = write_mp4(tmp_path, 'dur.mp4', mvhd, trak)
+
+    assert extract_video_metadata(path)['duration'] == pytest.approx(10.0)
+
+
+def test_audio_only_track_is_ignored_for_dimensions(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    audio = video_trak(width=0, height=0, handler=b'soun')
+    path = write_mp4(tmp_path, 'audio.mp4', mvhd_box(0), audio)
+
+    result = extract_video_metadata(path)
+    assert result['width'] is None
+    assert result['height'] is None
+
+
+def test_unknown_duration_sentinel_is_not_reported(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    # 0xFFFFFFFF 是"时长未知"的惯用哨兵，不能算成 4294967 秒
+    path = write_mp4(tmp_path, 'sentinel.mp4',
+                     mvhd_box(0, timescale=1000, duration=0xFFFFFFFF))
+
+    assert extract_video_metadata(path)['duration'] is None
+
+
+def test_extract_handles_64bit_largesize_moov(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    ftyp = box(b'ftyp', b'isom' + b'\x00' * 8)
+    moov = large_box(b'moov', mvhd_box(0) + box(
+        b'udta', udta_text(b'\xa9mak', 'Sony')))
+    path = tmp_path / 'large.mp4'
+    path.write_bytes(ftyp + moov + box(b'mdat', b'\x00' * 16))
+
+    assert extract_video_metadata(str(path))['video_info']['Make'] == 'Sony'
+
+
+# --------------------------------------------------------------------------- #
+# 边界与容错
+# --------------------------------------------------------------------------- #
+
+def test_non_isobmff_extension_returns_empty_structure(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    path = tmp_path / 'clip.mkv'
+    path.write_bytes(b'\x1a\x45\xdf\xa3' + b'\x00' * 64)
+
+    result = extract_video_metadata(str(path))
+    # 结构完整但全空，调用方据此回退到文件名 / mtime
+    assert result['video_time'] is None
+    assert result['video_info'] == {}
+    assert result['width'] is None and result['duration'] is None
+
+
+def test_missing_moov_returns_empty_structure(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    path = tmp_path / 'nomoov.mp4'
+    path.write_bytes(box(b'ftyp', b'isom' + b'\x00' * 8) + box(b'mdat', b'\x00' * 32))
+
+    assert extract_video_metadata(str(path))['video_info'] == {}
+
+
+def test_empty_and_missing_file_do_not_raise(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    empty = tmp_path / 'empty.mp4'
+    empty.write_bytes(b'')
+    assert extract_video_metadata(str(empty))['video_time'] is None
+    # 不存在的文件也必须静默返回，批处理任务不应被单个文件拖垮
+    assert extract_video_metadata(str(tmp_path / 'ghost.mp4'))['video_time'] is None
+
+
+def test_malformed_box_size_terminates_parsing_without_raising(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    # moov 内塞一个 size=3（< header 8 字节）的畸形 box
+    bad = struct.pack('>I', 3) + b'junk'
+    path = write_mp4(tmp_path, 'bad.mp4', mvhd_box(0), bad,
+                     box(b'udta', udta_text(b'\xa9mak', 'ShouldNotReach')))
+
+    result = extract_video_metadata(path)
+    # 遇到畸形 size 即停止遍历，已解析到的 mvhd 时长仍保留
+    assert result['duration'] == pytest.approx(12.345)
+    assert 'Make' not in result['video_info']
+
+
+def test_truncated_moov_payload_is_tolerated(tmp_path):
+    from app.utils.video_meta import extract_video_metadata
+
+    # 声明 size 超出实际文件长度
+    ftyp = box(b'ftyp', b'isom' + b'\x00' * 8)
+    truncated = struct.pack('>I', 4096) + b'moov' + mvhd_box(0)[:12]
+    path = tmp_path / 'trunc.mp4'
+    path.write_bytes(ftyp + truncated)
+
+    assert extract_video_metadata(str(path))['video_time'] is None
+
+
+# --------------------------------------------------------------------------- #
+# 与 exif.extract_metadata 的集成
+# --------------------------------------------------------------------------- #
+
+def test_extract_metadata_routes_video_to_container_parser(tmp_path):
+    from app.utils.exif import extract_metadata
+
+    meta = meta_box(
+        ['com.apple.quicktime.creationdate', 'com.apple.quicktime.model'],
+        ['2024-05-01T18:30:00+0800', 'iPhone 15'],
+    )
+    path = write_mp4(tmp_path, 'IMG_9999.mov', mvhd_box(0), meta,
+                     video_trak(width=1920, height=1080, timescale=600, duration=6000))
+
+    result = extract_metadata(path, 'IMG_9999.mov', extract_location_details=False)
+
+    assert result['photo_time'] == datetime(2024, 5, 1, 18, 30, 0)
+    assert result['width'] == 1920 and result['height'] == 1080
+    assert result['duration'] == pytest.approx(10.0)
+    assert result['exif_info']['Model'] == 'iPhone 15'
+    assert result['exif_info']['MediaType'] == 'video'
+
+
+def test_extract_metadata_video_falls_back_to_filename_when_no_container_time(tmp_path):
+    from app.utils.exif import extract_metadata
+
+    # 无 CreateDate、mvhd creation_time 为 0 —— 应复用图片分支已有的文件名回退
+    path = write_mp4(tmp_path, 'VID_20240601_120000.mp4', mvhd_box(0), video_trak())
+
+    result = extract_metadata(path, 'VID_20240601_120000.mp4', extract_location_details=False)
+
+    assert result['photo_time'] == datetime(2024, 6, 1, 12, 0, 0)
+
+
+def test_extract_metadata_video_falls_back_to_mtime_when_filename_unparsable(tmp_path):
+    from app.utils.exif import extract_metadata
+
+    path = write_mp4(tmp_path, 'clip.mp4', mvhd_box(0), video_trak())
+    expected = datetime(2022, 9, 9, 9, 9, 9)
+    with patch('app.utils.exif.get_file_time_form_system', return_value=expected):
+        result = extract_metadata(path, 'clip.mp4', extract_location_details=False)
+
+    assert result['photo_time'] == expected
+
+
+def test_extract_metadata_video_runs_reverse_geocode_on_container_gps(tmp_path):
+    from app.utils.exif import extract_metadata
+
+    udta = box(b'udta', udta_text(b'\xa9xyz', '+30.5928+114.3055/'))
+    path = write_mp4(tmp_path, 'geo.mp4', mvhd_box(0), udta)
+
+    fake_loc = {"city": "武汉市", "province": "湖北省", "country": "CN",
+                "district": "", "address": "湖北省武汉市"}
+    with patch('app.utils.exif.reverse_geocode', return_value=dict(fake_loc)) as mocked:
+        result = extract_metadata(path, 'geo.mp4', extract_location_details=True)
+
+    mocked.assert_called_once()
+    # 视频必须和图片一样进入 city/province/scene 链路
+    assert result['location_details']['city'] == '武汉市'
+    assert result['location_details']['latitude'] == pytest.approx(30.5928)
+
+
+def test_extract_metadata_video_swallows_reverse_geocode_failure(tmp_path):
+    from app.utils.exif import extract_metadata
+
+    udta = box(b'udta', udta_text(b'\xa9xyz', '+30.5928+114.3055/'))
+    path = write_mp4(tmp_path, 'geofail.mp4', mvhd_box(0), udta)
+
+    with patch('app.utils.exif.reverse_geocode', side_effect=RuntimeError('rg down')):
+        result = extract_metadata(path, 'geofail.mp4', extract_location_details=True)
+
+    assert result['location']['latitude'] == pytest.approx(30.5928)
+    assert 'location_details' not in result
+
+
+def test_extract_metadata_non_isobmff_video_still_returns_photo_time(tmp_path):
+    from app.utils.exif import extract_metadata
+
+    path = tmp_path / 'VID_20230715_083000.mkv'
+    path.write_bytes(b'\x1a\x45\xdf\xa3' + b'\x00' * 32)
+
+    result = extract_metadata(str(path), 'VID_20230715_083000.mkv',
+                              extract_location_details=False)
+
+    assert result['photo_time'] == datetime(2023, 7, 15, 8, 30, 0)
+    assert result['exif_info'] is None
+
+
+def test_determine_image_type_returns_other_for_video_regardless_of_metadata():
+    from app.db.models.photo import FileType, ImageType
+    from app.service.tasks.metadata import determine_image_type
+
+    # 屏录视频的分辨率会命中手机分辨率白名单，不加 file_type 守卫会被误判为截图
+    assert determine_image_type('screen_rec.mp4', 1170, 2532, {},
+                                FileType.video) is ImageType.OTHER
+    assert determine_image_type('Screenshot_rec.mp4', 800, 600, {},
+                                FileType.video) is ImageType.OTHER
+    assert determine_image_type('clip.mp4', 4000, 3000, {"Make": "Apple"},
+                                FileType.video) is ImageType.OTHER
+    # 不传 file_type 时行为与改动前完全一致（存量调用方向后兼容）
+    assert determine_image_type('photo.jpg', 1170, 2532, {}) is ImageType.SCREENSHOT


### PR DESCRIPTION
此前 extract_metadata 只处理图片 EXIF，视频的拍摄时间、GPS、机型全部缺失， 只能退回文件名或系统 mtime，导致视频在时间线与地图上无法正确归位。

新增 app/utils/video_meta.py，纯 Python 解析 ISO BMFF (MP4/MOV/M4V/3GP) box：
- moov/meta (keys+ilst): com.apple.quicktime.creationdate/.make/.model/ .location.ISO6709、com.android.version，同时兼容 iTunes 风格 ilst
- moov/udta: ©day/©mak/©mod/©xyz，兼容省略 text_size/language 的写入器
- moov/mvhd: 总时长与 1904 epoch 创建时间（version 0/1 均支持）
- moov/trak/tkhd: 宽高与变换矩阵推导的旋转角，90°/270° 自动交换宽高
- mdia/mdhd + stsd + stsz: 轨道时长、codec、帧率

选型说明：服务端以 PyInstaller sidecar 随 Tauri 桌面端分发，引入 ffmpeg / exiftool 需跨三平台打包外部二进制，体积与构建成本不可接受，故沿用
motion_photo.py 已有的手写 atom 解析方式，不新增任何依赖。

时间语义统一（关键）：photo_time 是 naive 墙钟时间。CreateDate 带时区偏移时 保留该偏移下的墙钟读数并丢弃 tzinfo，与图片 EXIF DateTimeOriginal 对齐； mvhd 按规范视为 1904 UTC epoch 转本机时区，因存在厂商把本地时间当 UTC 写入 的实现分歧而置于最低优先级。creation_time 为 0 时返回 None，避免大批设备的
视频被定位到 1904 年。

其余改动：
- exif.py: extract_metadata 增加视频分支，抽出 _attach_location_details 供 图片/视频共用，视频 GPS 因此自动进入 reverse_geocode 与 scene 识别链路； 文件名与 mtime 回退全部复用
- metadata.py: determine_image_type 增加可选 file_type 参数，视频短路返回 OTHER（屏录分辨率会误命中手机分辨率白名单）；不传时行为不变，存量调用方 向后兼容。shooting_params 扩展 duration/fps/codec/rotation
- basic.py: 容器已解析出宽高与时长时跳过 get_image_dimensions，省去一次 cv2.VideoCapture 打开；cv2 失败时反向兜底

exif_info 为 Text 存 JSON、shooting_params 为 JSON 列，无需数据库迁移； 存量视频通过 REBUILD_METADATA 携带 force=True 回填。AVI/MKV/WEBM 属不同容器， 暂走文件名与 mtime 回退。

新增 tests/unit/test_video_meta.py，33 个用例全部以 struct.pack 构造 atom 字节流，不依赖样本文件。

## 描述
<!-- 请简要描述您的更改。如果是修复 Bug，请链接相关 Issue。 -->

## 变更类型
<!-- 请删除不相关的选项 -->
- [ ] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [ ] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue
<!-- 例如：Fixes #123 -->

## 如何测试
<!-- 请描述您是如何测试这些更改的 -->

## 检查清单
- [ ] 我已阅读并遵循项目的贡献指南
- [ ] 我的代码遵循项目的代码风格
- [ ] 我已添加/更新了必要的测试
- [ ] 所有测试均已通过
- [ ] 我已更新了相关文档
