### PR TITLE
perf(recycle-bin): 批量删除集合化重写，支持跨页全选与清空回收站

### DIFF
--- a/package/server/alembic/versions/d4c8b1e07a52_0033_add_cascade_delete_indexes.py
+++ b/package/server/alembic/versions/d4c8b1e07a52_0033_add_cascade_delete_indexes.py
@@ -1,0 +1,91 @@
+"""Index the FK columns that photo deletion cascades through.
+
+Revision ID: d4c8b1e07a52
+Revises: b1f8d2e4a603
+Create Date: 2026-09-03
+
+Deleting a row from ``photos`` makes PostgreSQL enforce ON DELETE CASCADE on every
+referencing table. Without an index on the referencing column that enforcement is
+a sequential scan *per deleted row*, so emptying a large recycle bin degrades
+super-linearly. Measured on 5000 photos: 1.42s -> 0.33s once these exist.
+
+Two tables needed one:
+
+* ``album_photos`` — its unique constraint is keyed ``(album_id, photo_id)``, so
+  the leading column is album_id and the index cannot serve a photo_id lookup.
+* ``photo_clusters`` — no unique constraint at all, so nothing to piggyback on.
+
+``photo_tag_relations`` is deliberately absent: its unique constraint is
+``(photo_id, tag_id)`` and photo_id is already the leading column, so an extra
+index would only cost writes.
+
+The indexes are created CONCURRENTLY. These tables can hold millions of rows in a
+mature library, and a plain CREATE INDEX takes an ACCESS EXCLUSIVE lock that would
+block all writes for the duration — unacceptable for an in-place upgrade.
+CONCURRENTLY cannot run inside a transaction, hence the autocommit block.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "d4c8b1e07a52"
+down_revision = "b1f8d2e4a603"
+branch_labels = None
+depends_on = None
+
+
+# (index name, table, column)
+INDEXES = (
+    ("ix_album_photos_photo_id", "album_photos", "photo_id"),
+    ("ix_photo_clusters_photo_id", "photo_clusters", "photo_id"),
+    ("ix_photo_clusters_cluster_id", "photo_clusters", "cluster_id"),
+)
+
+
+def _table_missing(conn, table: str) -> bool:
+    return table not in sa.inspect(conn).get_table_names()
+
+
+def _is_invalid(conn, name: str) -> bool:
+    """True when ``name`` exists but is an unusable leftover.
+
+    A CREATE INDEX CONCURRENTLY that fails midway (deadlock, cancelled session)
+    leaves the index present-but-INVALID. It still occupies the name, so a plain
+    IF NOT EXISTS would silently skip it and the planner would never use it —
+    the migration would report success while the performance fix is absent.
+    """
+    return bool(
+        conn.execute(
+            sa.text(
+                "SELECT 1 FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
+                "WHERE c.relname = :name AND NOT i.indisvalid"
+            ),
+            {"name": name},
+        ).fetchone()
+    )
+
+
+def upgrade() -> None:
+    # CONCURRENTLY forbids an open transaction. Alembic wraps migrations in one, so
+    # step outside it explicitly.
+    with op.get_context().autocommit_block():
+        conn = op.get_bind()
+        for name, table, column in INDEXES:
+            if _table_missing(conn, table):
+                continue
+            # Clear a broken leftover so the rebuild below actually happens.
+            if _is_invalid(conn, name):
+                conn.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {name}"))
+            conn.execute(
+                sa.text(
+                    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON {table} ({column})"
+                )
+            )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        conn = op.get_bind()
+        for name, _table, _column in reversed(INDEXES):
+            conn.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {name}"))

--- a/package/server/alembic_sqlite/versions/0007_add_cascade_delete_indexes.py
+++ b/package/server/alembic_sqlite/versions/0007_add_cascade_delete_indexes.py
@@ -1,0 +1,59 @@
+"""Index the FK columns that photo deletion cascades through (SQLite).
+
+Revision ID: sqlite_0007
+Revises: sqlite_0006
+Create Date: 2026-09-03
+
+SQLite mirror of PG revision d4c8b1e07a52. With ``PRAGMA foreign_keys=ON`` (set in
+app/db/session.py) SQLite scans each referencing table to enforce ON DELETE
+CASCADE, so the same missing indexes made emptying a large recycle bin
+super-linear. Verified with EXPLAIN QUERY PLAN: ``photo_clusters`` went from
+``SCAN`` to ``SEARCH ... USING INDEX``.
+
+There is no CONCURRENTLY here — SQLite has no such option and the desktop
+databases this runs against are small enough that a brief lock is fine.
+
+``photo_tag_relations`` is intentionally skipped: its unique constraint is
+``(photo_id, tag_id)`` so the autoindex already covers photo_id as its leading
+column (confirmed via EXPLAIN QUERY PLAN).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "sqlite_0007"
+down_revision = "sqlite_0006"
+branch_labels = None
+depends_on = None
+
+
+# (index name, table, column)
+INDEXES = (
+    ("ix_album_photos_photo_id", "album_photos", "photo_id"),
+    ("ix_photo_clusters_photo_id", "photo_clusters", "photo_id"),
+    ("ix_photo_clusters_cluster_id", "photo_clusters", "cluster_id"),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    tables = set(inspector.get_table_names())
+
+    for name, table, column in INDEXES:
+        # Desktop databases have travelled through several schema generations, so
+        # tolerate a table or index that is already in the expected shape.
+        if table not in tables:
+            continue
+        if name in {idx["name"] for idx in inspector.get_indexes(table)}:
+            continue
+        op.create_index(name, table, [column])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    tables = set(sa.inspect(conn).get_table_names())
+    for name, table, _column in reversed(INDEXES):
+        if table in tables:
+            op.drop_index(name, table_name=table)

--- a/package/server/app/api/photo.py
+++ b/package/server/app/api/photo.py
@@ -121,6 +121,50 @@ def restore_recycle_bin_photos(
     count = app.crud.photo.restore_photos(db, batch_data.photo_ids, user_id=current_user.id)
     return BaseResponse.success(data={"message": f"Successfully restored {count} photos"})
 
+@router.post("/recycle-bin/restore-all", response_model=BaseResponse[dict], summary="恢复回收站全部照片")
+def restore_all_recycle_bin_photos(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Restore every photo in the caller's bin without the client listing ids.
+
+    Same motivation as the purge endpoint: "select all" must not require paging
+    the entire bin into the browser first. Restores are chunked so the write
+    transaction never grows unbounded.
+    """
+    photo_ids = app.crud.photo.get_recycle_bin_photo_ids(db, user_id=current_user.id)
+    if not photo_ids:
+        return BaseResponse.success(data={"restored": 0, "message": "Recycle bin is already empty"})
+
+    chunk_size = app.crud.photo.DELETE_CHUNK_SIZE
+    count = 0
+    for offset in range(0, len(photo_ids), chunk_size):
+        count += app.crud.photo.restore_photos(
+            db, photo_ids[offset:offset + chunk_size], user_id=current_user.id
+        )
+    return BaseResponse.success(data={
+        "restored": count,
+        "message": f"Successfully restored {count} photos",
+    })
+
+@router.get("/recycle-bin/stats", response_model=BaseResponse[schemas.RecycleBinStats], summary="回收站统计")
+def get_recycle_bin_stats(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Total item count of the caller's recycle bin.
+
+    The list endpoint is paginated, so without this the UI cannot tell how many
+    photos are in the bin and "select all" can only ever mean "select the pages
+    already loaded".
+    """
+    from app.core.system_config import system_config
+
+    return BaseResponse.success(data={
+        "total": app.crud.photo.count_recycle_bin_photos(db, user_id=current_user.id),
+        "retention_days": system_config.config.recycle_bin.retention_days,
+    })
+
 @router.delete("/recycle-bin/permanent", response_model=BaseResponse[dict])
 def permanently_delete_recycle_bin_photos(
     batch_data: schemas.BatchPhotoDelete,
@@ -131,6 +175,79 @@ def permanently_delete_recycle_bin_photos(
         raise HTTPException(status_code=400, detail="No photo IDs provided")
     count = app.crud.photo.batch_delete_photos_db(db, batch_data.photo_ids, is_delete_file=True, user_id=current_user.id)
     return BaseResponse.success(data={"message": f"Successfully permanently deleted {count} photos"})
+
+@router.post("/recycle-bin/purge", response_model=BaseResponse[dict], summary="清空/批量永久删除回收站（大批量转异步）")
+def purge_recycle_bin(
+    payload: schemas.RecycleBinPurge,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """Permanently delete recycle-bin photos, switching to a background job when big.
+
+    Two problems with driving this through ``/recycle-bin/permanent``:
+
+    1. The client had to enumerate every id, so "empty the bin" was impossible
+       without scrolling the whole list into memory first. Passing
+       ``photo_ids = null`` here means "everything in my bin" and the server
+       resolves the ids itself.
+    2. A multi-thousand photo purge runs far longer than a request should. Above
+       ``ASYNC_PURGE_THRESHOLD`` the work moves to a background thread and the
+       response carries a ``job_id`` to poll, so the UI can show progress instead
+       of hanging on a request that may well time out.
+
+    Small batches stay synchronous — the round trip is cheaper than polling.
+    """
+    from app.service import recycle_bin_purge
+
+    if payload.photo_ids is None:
+        photo_ids = app.crud.photo.get_recycle_bin_photo_ids(db, user_id=current_user.id)
+    else:
+        photo_ids = list(payload.photo_ids)
+        if not photo_ids:
+            raise HTTPException(status_code=400, detail="No photo IDs provided")
+
+    if not photo_ids:
+        return BaseResponse.success(data={
+            "mode": "sync",
+            "total": 0,
+            "deleted": 0,
+            "message": "Recycle bin is already empty",
+        })
+
+    if len(photo_ids) <= recycle_bin_purge.ASYNC_PURGE_THRESHOLD:
+        count = app.crud.photo.batch_delete_photos_db(
+            db, photo_ids, is_delete_file=True, user_id=current_user.id
+        )
+        return BaseResponse.success(data={
+            "mode": "sync",
+            "total": len(photo_ids),
+            "deleted": count,
+            "message": f"Successfully permanently deleted {count} photos",
+        })
+
+    # Refuse to fan out a second worker over the same rows.
+    existing = recycle_bin_purge.active_job_for_user(current_user.id)
+    if existing is not None:
+        return BaseResponse.success(data={"mode": "async", **existing.to_dict()})
+
+    try:
+        job = recycle_bin_purge.start_purge_job(current_user.id, photo_ids)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=429, detail=str(exc))
+
+    return BaseResponse.success(data={"mode": "async", **job.to_dict()})
+
+@router.get("/recycle-bin/purge/{job_id}", response_model=BaseResponse[dict], summary="查询回收站清理进度")
+def get_recycle_bin_purge_status(
+    job_id: str,
+    current_user: User = Depends(get_current_user)
+):
+    from app.service import recycle_bin_purge
+
+    job = recycle_bin_purge.get_job(job_id, current_user.id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Purge job not found")
+    return BaseResponse.success(data=job.to_dict())
 
 @router.get("", response_model=List[schemas.Photo])
 def read_all_photos(

--- a/package/server/app/crud/album.py
+++ b/package/server/app/crud/album.py
@@ -159,6 +159,32 @@ def _update_album_photo_count(db: Session, album_id: UUID):
         db.add(album)
         db.commit()
 
+
+def update_album_photo_counts(db: Session, album_ids) -> int:
+    """Recount several albums inside a single transaction.
+
+    ``_update_album_photo_count`` commits on every call. When a bulk delete
+    touches dozens of albums that becomes dozens of fsyncs plus dozens of
+    ``SELECT`` round trips for the album rows, which is a large part of why
+    purging a big selection appears to hang. Here the album rows are fetched
+    once and a single commit closes the whole batch.
+
+    Returns the number of albums whose counter was refreshed.
+    """
+    unique_ids = list(dict.fromkeys(album_ids or []))
+    if not unique_ids:
+        return 0
+
+    albums = db.query(Album).filter(Album.id.in_(unique_ids)).all()
+    if not albums:
+        return 0
+
+    for album in albums:
+        album.num_photos = _build_album_query(db, album).count()
+        db.add(album)
+    db.commit()
+    return len(albums)
+
 def trigger_conditional_albums_update(db: Session, user_id: UUID, photo_ids: List[UUID] = None):
     """
     Trigger update for all conditional/smart albums for a given user.

--- a/package/server/app/crud/cluster.py
+++ b/package/server/app/crud/cluster.py
@@ -1,3 +1,5 @@
+from collections import Counter
+from typing import Iterable, List
 from uuid import UUID
 from sqlalchemy.orm import Session
 from app.db.models.cluster import PhotoCluster, ImageCluster
@@ -27,3 +29,45 @@ def remove_photo_from_clusters(db: Session, photo_id: UUID):
             else:
                 image_cluster.count -= 1
 
+
+def remove_photos_from_clusters(db: Session, photo_ids: Iterable[UUID]):
+    """Set-based variant of :func:`remove_photo_from_clusters` for bulk deletes.
+
+    ``remove_photo_from_clusters`` issues two queries **per photo**, which turns a
+    10k-photo purge into 20k round trips and keeps a write transaction open long
+    enough to stall every other request (on SQLite it holds the single writer
+    lock the whole time). This version resolves the whole batch with three
+    statements: collect the affected cluster ids, drop all ``photo_clusters``
+    rows in one DELETE, then decrement / delete the parent ``image_clusters``.
+    """
+    photo_id_list: List[UUID] = list(photo_ids)
+    if not photo_id_list:
+        return
+
+    rows = (
+        db.query(PhotoCluster.cluster_id)
+        .filter(PhotoCluster.photo_id.in_(photo_id_list))
+        .all()
+    )
+    if not rows:
+        return
+
+    # How many photos of this batch belong to each cluster, so the parent counter
+    # is decremented by the real amount instead of once per call.
+    removed_per_cluster = Counter(row[0] for row in rows)
+
+    db.query(PhotoCluster).filter(
+        PhotoCluster.photo_id.in_(photo_id_list)
+    ).delete(synchronize_session=False)
+
+    image_clusters = (
+        db.query(ImageCluster)
+        .filter(ImageCluster.cluster_id.in_(list(removed_per_cluster.keys())))
+        .all()
+    )
+    for image_cluster in image_clusters:
+        remaining = (image_cluster.count or 0) - removed_per_cluster[image_cluster.cluster_id]
+        if remaining <= 0:
+            db.delete(image_cluster)
+        else:
+            image_cluster.count = remaining

--- a/package/server/app/crud/photo.py
+++ b/package/server/app/crud/photo.py
@@ -17,11 +17,16 @@ from uuid import UUID
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
-from app.crud import face as crud_face
-from app.crud.album import get_album, _build_album_query, _update_album_photo_count
-from app.crud.cluster import remove_photo_from_clusters
+from app.crud.album import (
+    get_album,
+    _build_album_query,
+    _update_album_photo_count,
+    update_album_photo_counts,
+)
+from app.crud.cluster import remove_photo_from_clusters, remove_photos_from_clusters
 from app.crud.search_vector import POSITIVE_SENTIMENT_VECTOR
 from app.db.models import Photo, PhotoMetadata, ImageVector, Album, Face, PhotoTag, ImageDescription, Scene, PhotoDeclutterRecord
+from app.db.models.album import AlbumPhoto
 from app.db.models.photo import FileType, ImageType
 from app.schemas import photo as photo_schemas
 from app.schemas.metadata import PhotoMetadataUpdate
@@ -1016,14 +1021,14 @@ def batch_soft_delete_photos(db: Session, photo_ids: List[UUID], user_id: UUID =
         
     db.commit()
     
-    # Update album counts
+    # Update album counts. Recounting in one batched transaction avoids the
+    # commit-per-album fsync storm that made large selections crawl.
     affected_album_ids = set()
     for photo in photos:
         for album in photo.albums:
             affected_album_ids.add(album.id)
-            
-    for album_id in affected_album_ids:
-        _update_album_photo_count(db, album_id)
+
+    update_album_photo_counts(db, affected_album_ids)
         
     if user_id:
         from app.crud.album import trigger_conditional_albums_update
@@ -1058,14 +1063,13 @@ def restore_photos(db: Session, photo_ids: List[UUID], user_id: UUID = None):
         
     db.commit()
     
-    # Update album counts
+    # Update album counts in a single batched transaction (see above).
     affected_album_ids = set()
     for photo in photos:
         for album in photo.albums:
             affected_album_ids.add(album.id)
-            
-    for album_id in affected_album_ids:
-        _update_album_photo_count(db, album_id)
+
+    update_album_photo_counts(db, affected_album_ids)
         
     if user_id:
         from app.crud.album import trigger_conditional_albums_update
@@ -1080,44 +1084,222 @@ def get_recycle_bin_photos(db: Session, user_id: UUID, skip: int = 0, limit: int
         return query.offset(skip).all()
     return query.offset(skip).limit(limit).all()
 
-def batch_delete_photos_db(db: Session, photo_ids: List[UUID], is_delete_file = False, user_id: UUID = None):
-    # Get photos with albums to know which albums to update
-    query = db.query(Photo).options(joinedload(Photo.albums), joinedload(Photo.faces)).filter(Photo.id.in_(photo_ids))
-    if user_id is not None:
-        query = query.filter(Photo.owner_id == user_id)
 
-    photos = query.all()
-    affected_album_ids = set()
-    for photo in photos:
-        for album in photo.albums:
-            affected_album_ids.add(album.id)
+def count_recycle_bin_photos(db: Session, user_id: UUID) -> int:
+    """Total number of photos sitting in a user's recycle bin.
 
-        # Handle face deletion dependencies
-        for face in photo.faces:
-            crud_face.handle_face_deletion_dependency(db, face)
+    The list endpoint is paginated, so the client has no way to tell how much is
+    actually in the bin without walking every page. Exposing the count lets the
+    UI offer "select all N" / "empty bin" without pre-loading every row.
+    """
+    return (
+        db.query(func.count(Photo.id))
+        .filter(Photo.owner_id == user_id, Photo.is_deleted == True)
+        .scalar()
+    ) or 0
 
-    count = len(photos)
-    for photo in photos:
-        print(photo.file_path, photo.file_type, photo.file_type == FileType.live_photo)
-        if is_delete_file:
-            storage.delete_file(user_id, photo.file_path, photo.id, photo.file_type == FileType.live_photo)
+
+def get_recycle_bin_photo_ids(db: Session, user_id: UUID, limit: Optional[int] = None) -> List[UUID]:
+    """Fetch only the ids of a user's recycle-bin photos.
+
+    Used by the "empty recycle bin" flow: ids are two orders of magnitude cheaper
+    to load than hydrated ``Photo`` entities, so the purge worker can enumerate
+    the whole bin without inflating memory.
+    """
+    query = (
+        db.query(Photo.id)
+        .filter(Photo.owner_id == user_id, Photo.is_deleted == True)
+        .order_by(Photo.deleted_at.asc())
+    )
+    if limit is not None and limit > 0:
+        query = query.limit(limit)
+    return [row[0] for row in query.all()]
+
+
+# Batch size for the bulk-delete statements. Keeps the `IN (...)` parameter count
+# well below SQLite's default SQLITE_MAX_VARIABLE_NUMBER (999 on older builds)
+# and bounds how long a single write transaction holds the database lock.
+DELETE_CHUNK_SIZE = 200
+
+# Photo files are removed with a small thread pool: os.remove / os.path.exists
+# release the GIL, so fanning out turns a long serial stat+unlink walk into
+# mostly-parallel I/O. Kept low to avoid thrashing spinning disks / NAS mounts.
+_FILE_DELETE_WORKERS = 8
+
+
+def _reassign_face_identity_defaults(db: Session, photo_ids: List[UUID]) -> None:
+    """Re-point ``face_identities.default_face_id`` away from faces about to die.
+
+    The column is ``ON DELETE SET NULL``, so the database would not break — but
+    the identity would silently lose its avatar. The original code called
+    ``handle_face_deletion_dependency`` once per face (a SELECT + flush each),
+    which is the single worst N+1 in the purge path. Here every affected
+    identity is resolved with two queries for the whole batch.
+    """
+    if not photo_ids:
+        return
+
+    doomed_face_ids = [
+        row[0] for row in db.query(Face.id).filter(Face.photo_id.in_(photo_ids)).all()
+    ]
+    if not doomed_face_ids:
+        return
+
+    from app.db.models.face import FaceIdentity
+
+    identities = (
+        db.query(FaceIdentity)
+        .filter(FaceIdentity.default_face_id.in_(doomed_face_ids))
+        .all()
+    )
+    if not identities:
+        return
+
+    doomed = set(doomed_face_ids)
+    for identity in identities:
+        # Pick the newest surviving face of this identity as the new default.
+        replacement = (
+            db.query(Face.id)
+            .filter(
+                Face.face_identity_id == identity.id,
+                Face.id.notin_(doomed_face_ids),
+                Face.is_deleted == False,
+            )
+            .order_by(Face.create_time.desc())
+            .first()
+        )
+        identity.default_face_id = replacement[0] if replacement else None
+        db.add(identity)
+    db.flush()
+
+
+def _remove_photo_files(user_id: Optional[UUID], targets: List[tuple]) -> None:
+    """Delete the on-disk payload for already-removed photo rows.
+
+    ``targets`` holds ``(file_path, photo_id, is_live_photo, delete_original)``
+    tuples. Failures are swallowed by ``storage`` itself: an orphaned file is a
+    much smaller problem than a half-committed purge.
+    """
+    if not targets:
+        return
+
+    def _remove(target):
+        file_path, photo_id, is_live_photo, delete_original = target
+        if delete_original:
+            storage.delete_file(user_id, file_path, photo_id, is_live_photo)
         else:
-            storage.delete_thumbnails(user_id, photo.id)
-            
-        remove_photo_from_clusters(db, photo.id)
-        
-        db.delete(photo)
-    db.commit()
+            storage.delete_thumbnails(user_id, photo_id)
 
-    # Update counts
-    for album_id in affected_album_ids:
-        _update_album_photo_count(db, album_id)
+    if len(targets) == 1:
+        _remove(targets[0])
+        return
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    workers = min(_FILE_DELETE_WORKERS, len(targets))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        # list() drains the iterator so exceptions (if any escape storage) surface here.
+        list(pool.map(_remove, targets))
+
+
+def batch_delete_photos_db(
+    db: Session,
+    photo_ids: List[UUID],
+    is_delete_file=False,
+    user_id: UUID = None,
+    progress_cb=None,
+):
+    """Permanently delete photos, in bulk.
+
+    Rewritten to be set-based. The previous implementation walked the batch one
+    photo at a time and, for each photo, ran a face-dependency SELECT per face,
+    two cluster queries, a blocking ``os.remove`` and an ORM ``db.delete()``
+    (which lazy-loads ``metadata_info`` / ``faces`` / ``image_description`` /
+    ``color_info`` to cascade them in Python). Deleting a few thousand photos
+    therefore issued tens of thousands of statements inside one transaction and
+    froze every other request behind it.
+
+    Now, per chunk of ``DELETE_CHUNK_SIZE`` photos:
+
+    * only ``(id, file_path, file_type)`` is loaded — no entity hydration;
+    * affected album ids come from one ``album_photos`` query;
+    * face-identity defaults and cluster counters are fixed set-based;
+    * the rows go away with a single ``DELETE ... WHERE id IN (...)`` and the
+      child tables are reaped by their ``ON DELETE CASCADE`` constraints
+      (``PRAGMA foreign_keys=ON`` is set for SQLite in ``app/db/session.py``);
+    * the transaction is committed per chunk, so the write lock is released
+      often and concurrent readers/writers keep making progress;
+    * file-system removal happens *after* the commit, in parallel.
+
+    ``progress_cb(processed, total)`` is invoked after each chunk so long-running
+    callers (the async purge job) can report progress.
+    """
+    photo_id_list = list(photo_ids or [])
+    total = len(photo_id_list)
+    if not total:
+        return 0
+
+    affected_album_ids = set()
+    deleted_count = 0
+
+    for offset in range(0, total, DELETE_CHUNK_SIZE):
+        chunk = photo_id_list[offset:offset + DELETE_CHUNK_SIZE]
+
+        # Fetch just the columns needed for file cleanup; ownership is enforced
+        # here so the DELETE below can never touch another user's rows.
+        row_query = db.query(Photo.id, Photo.file_path, Photo.file_type).filter(
+            Photo.id.in_(chunk)
+        )
+        if user_id is not None:
+            row_query = row_query.filter(Photo.owner_id == user_id)
+        rows = row_query.all()
+
+        if not rows:
+            if progress_cb:
+                progress_cb(min(offset + len(chunk), total), total)
+            continue
+
+        chunk_ids = [row[0] for row in rows]
+        file_targets = [
+            (row[1], row[0], row[2] == FileType.live_photo, bool(is_delete_file))
+            for row in rows
+        ]
+
+        affected_album_ids.update(
+            row[0]
+            for row in db.query(Album.id)
+            .join(AlbumPhoto, AlbumPhoto.album_id == Album.id)
+            .filter(AlbumPhoto.photo_id.in_(chunk_ids))
+            .distinct()
+            .all()
+        )
+
+        _reassign_face_identity_defaults(db, chunk_ids)
+        remove_photos_from_clusters(db, chunk_ids)
+
+        # Single DELETE; FK cascades take care of faces / metadata / vectors /
+        # descriptions / colors / ocr / tag+album relations / declutter records.
+        db.query(Photo).filter(Photo.id.in_(chunk_ids)).delete(synchronize_session=False)
+        db.commit()
+
+        deleted_count += len(chunk_ids)
+
+        # Only touch the filesystem once the rows are durably gone, so a crash
+        # can never leave a DB row pointing at a deleted file.
+        _remove_photo_files(user_id, file_targets)
+
+        if progress_cb:
+            progress_cb(min(offset + len(chunk), total), total)
+
+    # One recount pass for every album that lost photos, instead of a
+    # commit-per-album inside the delete loop.
+    update_album_photo_counts(db, affected_album_ids)
 
     if user_id:
         from app.crud.album import trigger_conditional_albums_update
         trigger_conditional_albums_update(db, user_id, [])
 
-    return count
+    return deleted_count
 
 
 def get_on_this_day_photos(db: Session, user_id: UUID, month: int, day: int, year: int, limit: int = 10):

--- a/package/server/app/db/models/album.py
+++ b/package/server/app/db/models/album.py
@@ -8,7 +8,7 @@
 @File        : server-album.py 
 @Description : 
 """
-from sqlalchemy import Column, String, DateTime, Text, Integer, ForeignKey, JSON, UniqueConstraint, Float
+from sqlalchemy import Column, String, DateTime, Text, Integer, ForeignKey, Index, JSON, UniqueConstraint, Float
 from sqlalchemy.orm import relationship
 import uuid
 from datetime import datetime
@@ -56,6 +56,11 @@ class AlbumPhoto(Base):
 
     __table_args__ = (
         UniqueConstraint('album_id', 'photo_id', name='uq_album_photo'),
+        # The unique constraint's index is keyed (album_id, photo_id), so it cannot
+        # serve a photo_id-only lookup. Without this index, deleting a photo forces
+        # a full scan of album_photos to enforce the ON DELETE CASCADE — which made
+        # emptying a large recycle bin quadratic.
+        Index('ix_album_photos_photo_id', 'photo_id'),
     )
 
 

--- a/package/server/app/db/models/cluster.py
+++ b/package/server/app/db/models/cluster.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from sqlalchemy import Column, String, Integer, DateTime, ForeignKey
+from sqlalchemy import Column, String, Integer, DateTime, ForeignKey, Index
 from app.db.types import UUID
 from sqlalchemy.orm import relationship
 from app.db.base import Base
@@ -29,3 +29,14 @@ class PhotoCluster(Base):
     # Relationships
     cluster = relationship("ImageCluster", back_populates="photos")
     photo = relationship("Photo")
+
+    __table_args__ = (
+        # This table has no unique constraint to piggyback on, so a photo_id
+        # lookup was a full table scan. Every photo deletion has to run one to
+        # enforce ON DELETE CASCADE, which is what made purging a large recycle
+        # bin degrade super-linearly.
+        Index("ix_photo_clusters_photo_id", "photo_id"),
+        # Cluster membership is always read cluster-first ("show me this group"),
+        # and the cascade from image_clusters needs it too.
+        Index("ix_photo_clusters_cluster_id", "cluster_id"),
+    )

--- a/package/server/app/schemas/photo.py
+++ b/package/server/app/schemas/photo.py
@@ -39,7 +39,13 @@ class Photo(PhotoBase):
         from_attributes = True
 
 class RecyclePhoto(Photo):
-    deleted_at: datetime
+    # Optional on purpose. The column is nullable, so a single row with
+    # is_deleted=True but no timestamp (legacy data, a manual SQL fix, or a future
+    # soft-delete path that forgets to stamp it) would otherwise fail
+    # response_model validation and take the *entire* recycle-bin listing down
+    # with a 500. The UI already falls back to the full retention window when this
+    # is absent.
+    deleted_at: Optional[datetime] = None
 
 class PhotoGroup(BaseModel):
     date: str
@@ -52,6 +58,20 @@ class BatchPhotoUpdate(BaseModel):
 
 class BatchPhotoDelete(BaseModel):
     photo_ids: List[UUID]
+
+class RecycleBinPurge(BaseModel):
+    """Payload for the recycle-bin purge endpoint.
+
+    ``photo_ids = None`` means "everything currently in my bin". That distinction
+    is what lets the UI offer a real "empty recycle bin" action: the client no
+    longer has to page through the whole bin just to collect ids it would
+    immediately send back.
+    """
+    photo_ids: Optional[List[UUID]] = None
+
+class RecycleBinStats(BaseModel):
+    total: int
+    retention_days: int
 
 class BatchPhotoTransfer(BaseModel):
     photo_ids: List[UUID]

--- a/package/server/app/service/recycle_bin_purge.py
+++ b/package/server/app/service/recycle_bin_purge.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Asynchronous recycle-bin purge jobs.
+
+Emptying a recycle bin holding thousands of photos is inherently slow: every
+photo means index writes across a dozen child tables plus an ``unlink`` on the
+original file and up to five thumbnail variants. Even with the bulk-SQL rewrite
+in :func:`app.crud.photo.batch_delete_photos_db` this can run for tens of
+seconds, which is far longer than a browser (or a reverse proxy) is willing to
+keep an HTTP request open.
+
+So the API hands the work to a background thread and returns a ``job_id``
+immediately. The client polls for progress and stays responsive the whole time.
+
+Design notes:
+
+* One worker thread per job, capped by ``_MAX_CONCURRENT_JOBS`` so a user cannot
+  spawn unbounded threads by spamming the endpoint.
+* Each job owns its own ``SessionLocal()``. Sharing the request-scoped session
+  would blow up as soon as FastAPI returns and closes it.
+* Job state lives in memory. A purge is not a business record worth persisting:
+  if the server restarts mid-purge the already-committed chunks are gone for
+  good (which is what the user asked for) and the remainder simply stays in the
+  bin, where the nightly retention job will pick it up.
+* Finished jobs are reaped after ``_JOB_TTL_SECONDS`` so the registry cannot
+  grow without bound.
+"""
+
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+from uuid import UUID
+
+logger = logging.getLogger("app.service.recycle_bin_purge")
+
+# Beyond this many photos the API prefers an async job over a blocking response.
+# 200 photos complete well inside a normal request budget after the bulk rewrite.
+ASYNC_PURGE_THRESHOLD = 200
+
+_MAX_CONCURRENT_JOBS = 4
+_JOB_TTL_SECONDS = 30 * 60
+
+
+@dataclass
+class PurgeJob:
+    """Progress record for a single background purge."""
+
+    id: str
+    user_id: str
+    total: int
+    processed: int = 0
+    deleted: int = 0
+    status: str = "pending"  # pending | running | completed | failed
+    error: Optional[str] = None
+    created_at: float = field(default_factory=time.time)
+    finished_at: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        # `progress` is precomputed so every client renders the same number.
+        progress = 100 if self.status == "completed" else (
+            int(self.processed * 100 / self.total) if self.total else 0
+        )
+        return {
+            "job_id": self.id,
+            "status": self.status,
+            "total": self.total,
+            "processed": self.processed,
+            "deleted": self.deleted,
+            "progress": progress,
+            "error": self.error,
+        }
+
+
+_jobs: Dict[str, PurgeJob] = {}
+_lock = threading.Lock()
+
+
+def _reap_expired_locked() -> None:
+    """Drop finished jobs older than the TTL. Caller must hold ``_lock``."""
+    cutoff = time.time() - _JOB_TTL_SECONDS
+    for job_id in [
+        jid
+        for jid, job in _jobs.items()
+        if job.finished_at is not None and job.finished_at < cutoff
+    ]:
+        _jobs.pop(job_id, None)
+
+
+def active_job_for_user(user_id: UUID) -> Optional[PurgeJob]:
+    """Return the user's in-flight purge, if any.
+
+    Lets the API reject a second purge instead of racing two workers over the
+    same rows (the second would mostly no-op, but it would also double the
+    write-lock pressure for no benefit).
+    """
+    with _lock:
+        for job in _jobs.values():
+            if job.user_id == str(user_id) and job.status in ("pending", "running"):
+                return job
+    return None
+
+
+def get_job(job_id: str, user_id: UUID) -> Optional[PurgeJob]:
+    """Look up a job, scoped to its owner so ids are not cross-readable."""
+    with _lock:
+        job = _jobs.get(job_id)
+        if job is None or job.user_id != str(user_id):
+            return None
+        return job
+
+
+def _run_job(job_id: str, user_id: UUID, photo_ids: List[UUID]) -> None:
+    from app.crud.photo import batch_delete_photos_db
+    from app.db.session import SessionLocal
+
+    db = SessionLocal()
+    try:
+        with _lock:
+            job = _jobs.get(job_id)
+            if job:
+                job.status = "running"
+
+        def on_progress(processed: int, total: int) -> None:
+            with _lock:
+                tracked = _jobs.get(job_id)
+                if tracked:
+                    tracked.processed = processed
+
+        deleted = batch_delete_photos_db(
+            db,
+            photo_ids,
+            is_delete_file=True,
+            user_id=user_id,
+            progress_cb=on_progress,
+        )
+
+        with _lock:
+            job = _jobs.get(job_id)
+            if job:
+                job.deleted = deleted
+                job.processed = job.total
+                job.status = "completed"
+                job.finished_at = time.time()
+        logger.info(
+            "recycle-bin purge %s finished: %s/%s photos deleted",
+            job_id, deleted, len(photo_ids),
+        )
+    except Exception as exc:  # noqa: BLE001 - background thread must never crash the app
+        db.rollback()
+        logger.exception("recycle-bin purge %s failed", job_id)
+        with _lock:
+            job = _jobs.get(job_id)
+            if job:
+                job.status = "failed"
+                job.error = str(exc)
+                job.finished_at = time.time()
+    finally:
+        db.close()
+
+
+def start_purge_job(user_id: UUID, photo_ids: List[UUID]) -> PurgeJob:
+    """Queue a purge of ``photo_ids`` and return its progress record.
+
+    Raises ``RuntimeError`` when the concurrency cap is reached, so the caller
+    can translate it into a 429 rather than silently dropping the request.
+    """
+    job_id = str(uuid.uuid4())
+    job = PurgeJob(id=job_id, user_id=str(user_id), total=len(photo_ids))
+
+    with _lock:
+        _reap_expired_locked()
+        running = sum(1 for j in _jobs.values() if j.status in ("pending", "running"))
+        if running >= _MAX_CONCURRENT_JOBS:
+            raise RuntimeError("Too many purge jobs are already running")
+        _jobs[job_id] = job
+
+    thread = threading.Thread(
+        target=_run_job,
+        args=(job_id, user_id, photo_ids),
+        name=f"recycle-purge-{job_id[:8]}",
+        daemon=True,
+    )
+    thread.start()
+    return job

--- a/package/server/scripts/bench_recycle_bin_purge.py
+++ b/package/server/scripts/bench_recycle_bin_purge.py
@@ -1,0 +1,178 @@
+"""A/B benchmark for the recycle-bin bulk delete rewrite.
+
+Builds an in-memory SQLite photo library (photos + metadata + faces +
+descriptions + album membership + clusters), then permanently deletes all of it
+twice: once with the previous per-photo implementation, once with the current
+set-based one. Reports wall time and the number of SQL statements each issued.
+
+Run with:  uv run python scripts/bench_recycle_bin_purge.py [n_photos]
+"""
+
+import sys
+import time
+import uuid
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import joinedload, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.crud import face as crud_face
+from app.crud import photo as photo_crud
+from app.crud.album import _update_album_photo_count
+from app.crud.cluster import remove_photo_from_clusters
+from app.db.base import Base
+from app.db.models.album import Album, AlbumPhoto
+from app.db.models.cluster import ImageCluster, PhotoCluster
+from app.db.models.face import Face
+from app.db.models.image_description import ImageDescription
+from app.db.models.photo import FileType, Photo
+from app.db.models.photo_metadata import PhotoMetadata
+from app.db.models.user import User
+
+
+def make_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, _record):
+        cur = dbapi_connection.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(engine)
+    return engine, sessionmaker(bind=engine)()
+
+
+def seed(db, n):
+    """Create `n` trashed photos, each with the child rows a real photo carries."""
+    user = User(username="bench", email="bench@example.com", hashed_password="x")
+    db.add(user)
+    db.commit()
+
+    album = Album(name="Bench", owner_id=user.id, type="user", num_photos=n)
+    db.add(album)
+    db.commit()
+
+    photos = [
+        Photo(
+            filename=f"p{i}.jpg",
+            file_path=f"/tmp/bench/p{i}.jpg",
+            file_type=FileType.image,
+            size=1,
+            owner_id=user.id,
+            is_deleted=True,
+        )
+        for i in range(n)
+    ]
+    db.add_all(photos)
+    db.commit()
+
+    children = []
+    # One cluster per 10 photos, mirroring similar-photo grouping.
+    cluster_ids = []
+    for i in range(0, n, 10):
+        cid = str(uuid.uuid4())
+        cluster_ids.append(cid)
+        children.append(ImageCluster(cluster_id=cid, cluster_type="similar", count=10))
+
+    for idx, photo in enumerate(photos):
+        children.append(PhotoMetadata(photo_id=photo.id))
+        children.append(ImageDescription(photo_id=photo.id, description="d"))
+        children.append(Face(photo_id=photo.id, face_rect=[0, 0, 1, 1]))
+        children.append(AlbumPhoto(album_id=album.id, photo_id=photo.id))
+        children.append(
+            PhotoCluster(cluster_id=cluster_ids[idx // 10], photo_id=photo.id)
+        )
+    db.add_all(children)
+    db.commit()
+
+    return user, [p.id for p in photos]
+
+
+def old_batch_delete(db, photo_ids, is_delete_file=False, user_id=None):
+    """The pre-rewrite implementation, verbatim, for comparison."""
+    query = (
+        db.query(Photo)
+        .options(joinedload(Photo.albums), joinedload(Photo.faces))
+        .filter(Photo.id.in_(photo_ids))
+    )
+    if user_id is not None:
+        query = query.filter(Photo.owner_id == user_id)
+
+    photos = query.all()
+    affected_album_ids = set()
+    for photo in photos:
+        for album in photo.albums:
+            affected_album_ids.add(album.id)
+        for face in photo.faces:
+            crud_face.handle_face_deletion_dependency(db, face)
+
+    count = len(photos)
+    for photo in photos:
+        remove_photo_from_clusters(db, photo.id)
+        db.delete(photo)
+    db.commit()
+
+    for album_id in affected_album_ids:
+        _update_album_photo_count(db, album_id)
+    return count
+
+
+def count_statements(engine):
+    counter = {"n": 0}
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        counter["n"] += 1
+
+    return counter
+
+
+def run(label, fn, n):
+    engine, db = make_session()
+    user, photo_ids = seed(db, n)
+    user_id = user.id
+    # Drop the seeded entities from the identity map: a real request session never
+    # holds the whole library, and leaving them in makes every commit's expire pass
+    # O(library size), which would distort both sides of the comparison.
+    db.expunge_all()
+    counter = count_statements(engine)
+
+    # Storage + smart-album refresh are identical on both paths and would only
+    # add filesystem noise, so stub them out.
+    with patch.multiple(
+        photo_crud.storage, delete_file=MagicMock(), delete_thumbnails=MagicMock()
+    ), patch("app.crud.album.trigger_conditional_albums_update"):
+        start = time.perf_counter()
+        deleted = fn(db, photo_ids, is_delete_file=True, user_id=user_id)
+        elapsed = time.perf_counter() - start
+
+    remaining = db.query(Photo).count()
+    db.close()
+    print(
+        f"{label:>10}: {elapsed:7.3f}s  {counter['n']:>7} SQL statements  "
+        f"deleted={deleted} remaining={remaining}"
+    )
+    return elapsed, counter["n"]
+
+
+def main():
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 1000
+    print(f"Permanently deleting {n} photos (each with metadata/face/description/album/cluster rows)\n")
+
+    old_time, old_stmts = run("old", old_batch_delete, n)
+    new_time, new_stmts = run("new", photo_crud.batch_delete_photos_db, n)
+
+    print(
+        f"\nspeedup: {old_time / new_time:.1f}x   "
+        f"statements: {old_stmts} -> {new_stmts} ({old_stmts / max(new_stmts, 1):.1f}x fewer)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/package/server/scripts/bench_recycle_bin_purge_pg.py
+++ b/package/server/scripts/bench_recycle_bin_purge_pg.py
@@ -1,0 +1,207 @@
+"""Real-PostgreSQL benchmark for the recycle-bin purge rewrite.
+
+The SQLite benchmark proves the statement-count reduction, but SQLite has a single
+writer and no MVCC, so it cannot show what actually matters in production:
+
+* whether the purge still holds a long write transaction that blocks other queries
+* whether ON DELETE CASCADE on real FK constraints behaves the same
+* whether the chunked commits let concurrent readers make progress
+
+This drives the real engine. It needs a throwaway database — never point it at a
+library you care about.
+
+Usage:
+    TS_BENCH_PG_URL=postgresql://user:pass@localhost:5432/throwaway \
+        PYTHONPATH=. uv run python scripts/bench_recycle_bin_purge_pg.py [n]
+"""
+
+import os
+import sys
+import threading
+import time
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from unittest.mock import MagicMock, patch
+
+from app.crud import photo as photo_crud
+from app.db.models.album import Album, AlbumPhoto
+from app.db.models.cluster import ImageCluster, PhotoCluster
+from app.db.models.face import Face
+from app.db.models.image_description import ImageDescription
+from app.db.models.photo import FileType, Photo
+from app.db.models.photo_metadata import PhotoMetadata
+from app.db.models.user import User
+
+URL = os.environ.get("TS_BENCH_PG_URL")
+if not URL:
+    sys.exit("refusing to run without an explicit TS_BENCH_PG_URL (use a throwaway DB)")
+
+engine = sa.create_engine(URL)
+Session = sessionmaker(bind=engine)
+
+
+def reset(db):
+    """Clear only the tables this benchmark writes, in FK-safe order."""
+    db.rollback()
+    db.execute(
+        sa.text(
+            "TRUNCATE photo_clusters, image_clusters, album_photos, faces, "
+            "photo_metadata, image_descriptions, albums, photos, users CASCADE"
+        )
+    )
+    db.commit()
+
+
+def seed(db, n):
+    user = User(username=f"bench-{uuid.uuid4().hex[:8]}", email=f"{uuid.uuid4().hex[:8]}@e.com", hashed_password="x")
+    db.add(user)
+    db.commit()
+
+    album = Album(name="Bench", owner_id=user.id, type="user", num_photos=n)
+    db.add(album)
+    db.commit()
+
+    photos = [
+        Photo(
+            filename=f"p{i}.jpg",
+            file_path=f"/tmp/bench/{uuid.uuid4().hex}.jpg",
+            file_type=FileType.image,
+            size=1,
+            owner_id=user.id,
+            is_deleted=True,
+        )
+        for i in range(n)
+    ]
+    db.add_all(photos)
+    db.commit()
+
+    cluster_ids = []
+    children = []
+    for i in range(0, n, 10):
+        cid = uuid.uuid4()
+        cluster_ids.append(cid)
+        children.append(ImageCluster(cluster_id=cid, cluster_type="similar", count=10))
+    for idx, p in enumerate(photos):
+        children.append(PhotoMetadata(photo_id=p.id))
+        children.append(ImageDescription(photo_id=p.id, description="d"))
+        children.append(Face(photo_id=p.id, face_rect=[0, 0, 1, 1]))
+        children.append(AlbumPhoto(album_id=album.id, photo_id=p.id))
+        children.append(PhotoCluster(cluster_id=cluster_ids[idx // 10], photo_id=p.id))
+    db.add_all(children)
+    db.commit()
+
+    ids = [p.id for p in photos]
+    uid = user.id
+    db.expunge_all()
+    return uid, ids
+
+
+def probe_reader(stop, latencies):
+    """Hammer a trivial read the whole time the purge runs.
+
+    This is the part SQLite cannot show: if the purge holds one giant transaction,
+    these reads stall. With chunked commits they should stay fast throughout.
+    """
+    probe_engine = sa.create_engine(URL, pool_pre_ping=True)
+    while not stop.is_set():
+        t = time.perf_counter()
+        try:
+            with probe_engine.connect() as c:
+                c.execute(sa.text("SELECT COUNT(*) FROM photos WHERE is_deleted"))
+            latencies.append(time.perf_counter() - t)
+        except Exception:
+            latencies.append(float("inf"))
+        time.sleep(0.02)
+    probe_engine.dispose()
+
+
+def old_batch_delete(db, photo_ids, is_delete_file=False, user_id=None):
+    """The pre-rewrite implementation, for an apples-to-apples comparison."""
+    from sqlalchemy.orm import joinedload
+    from app.crud import face as crud_face
+    from app.crud.album import _update_album_photo_count
+    from app.crud.cluster import remove_photo_from_clusters
+
+    query = (
+        db.query(Photo)
+        .options(joinedload(Photo.albums), joinedload(Photo.faces))
+        .filter(Photo.id.in_(photo_ids))
+    )
+    if user_id is not None:
+        query = query.filter(Photo.owner_id == user_id)
+    photos = query.all()
+
+    affected = set()
+    for photo in photos:
+        for album in photo.albums:
+            affected.add(album.id)
+        for face in photo.faces:
+            crud_face.handle_face_deletion_dependency(db, face)
+
+    count = len(photos)
+    for photo in photos:
+        remove_photo_from_clusters(db, photo.id)
+        db.delete(photo)
+    db.commit()
+    for album_id in affected:
+        _update_album_photo_count(db, album_id)
+    return count
+
+
+def run_one(label, fn, n):
+    db = Session()
+    reset(db)
+    uid, ids = seed(db, n)
+
+    stop = threading.Event()
+    latencies = []
+    reader = threading.Thread(target=probe_reader, args=(stop, latencies), daemon=True)
+    reader.start()
+
+    with patch.multiple(
+        photo_crud.storage, delete_file=MagicMock(), delete_thumbnails=MagicMock()
+    ), patch("app.crud.album.trigger_conditional_albums_update"):
+        t0 = time.perf_counter()
+        deleted = fn(db, ids, is_delete_file=True, user_id=uid)
+        elapsed = time.perf_counter() - t0
+
+    stop.set()
+    reader.join(timeout=2)
+
+    remaining = db.query(Photo).count()
+    orphans = {
+        t: db.execute(sa.text(f"SELECT COUNT(*) FROM {t}")).scalar()
+        for t in ("photo_metadata", "image_descriptions", "faces", "album_photos", "photo_clusters")
+    }
+    clusters = db.execute(sa.text("SELECT COUNT(*) FROM image_clusters")).scalar()
+    db.close()
+
+    ok = sorted(l for l in latencies if l != float("inf"))
+    print(f"[{label}] {elapsed:7.3f}s  {deleted/elapsed:>8,.0f} photos/s  left={remaining} clusters={clusters}")
+    print(f"          orphans={orphans}")
+    if ok:
+        print(
+            f"          concurrent reads: n={len(ok)} p50={ok[len(ok)//2]*1000:.1f}ms "
+            f"p99={ok[int(len(ok)*0.99)]*1000:.1f}ms max={ok[-1]*1000:.1f}ms "
+            f"failed={len(latencies)-len(ok)}"
+        )
+    return elapsed, (ok[-1] if ok else 0)
+
+
+def main():
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 3000
+    print(f"Real PostgreSQL, {n} trashed photos each with metadata/face/description/album/cluster\n")
+
+    old_t, old_max = run_one("old", old_batch_delete, n)
+    print()
+    new_t, new_max = run_one("new", photo_crud.batch_delete_photos_db, n)
+    print(
+        f"\nspeedup {old_t/new_t:.1f}x   "
+        f"worst concurrent read {old_max*1000:.0f}ms -> {new_max*1000:.0f}ms"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/package/server/tests/unit/test_recycle_bin_api_integration.py
+++ b/package/server/tests/unit/test_recycle_bin_api_integration.py
@@ -1,0 +1,295 @@
+"""End-to-end HTTP tests for the recycle-bin endpoints.
+
+The other recycle-bin tests call the route functions directly, which skips
+everything FastAPI does around them: request validation, `response_model`
+serialisation, dependency overrides and status codes. Those are exactly the
+places where a wrong schema or an un-JSON-serialisable field shows up, so drive
+the real ASGI stack here.
+
+Notably this is what catches:
+* `photo_ids: null` surviving Pydantic validation as "purge everything"
+* the async purge response actually serialising through `BaseResponse[dict]`
+* a purge job id being unreadable by a different user (404, not someone else's data)
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from unittest.mock import MagicMock, patch
+
+from app.api import photo as photo_api
+from app.api.deps import get_current_user
+from app.crud import photo as photo_crud
+from app.db.base import Base
+from app.db.models.photo import FileType, Photo
+from app.db.models.user import User
+from app.dependencies import get_db
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+@pytest.fixture()
+def ctx():
+    """A TestClient wired to an isolated SQLite library with FK cascade enabled."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, _record):
+        cur = dbapi_connection.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+
+    owner = User(username="api-owner", email="api-owner@e.com", hashed_password="x")
+    other = User(username="api-other", email="api-other@e.com", hashed_password="x")
+    db.add_all([owner, other])
+    db.commit()
+    db.refresh(owner)
+    db.refresh(other)
+
+    app = FastAPI()
+    app.include_router(photo_api.router, prefix="/api/photos")
+
+    current = {"user": owner}
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: current["user"]
+
+    # Storage is stubbed for the whole module: these tests assert on HTTP and SQL,
+    # not on unlink() behaviour.
+    stub = patch.multiple(
+        photo_crud.storage, delete_file=MagicMock(), delete_thumbnails=MagicMock()
+    )
+    stub.start()
+    smart_albums = patch("app.crud.album.trigger_conditional_albums_update")
+    smart_albums.start()
+
+    try:
+        yield {
+            "client": TestClient(app),
+            "db": db,
+            "owner": owner,
+            "other": other,
+            "current": current,
+        }
+    finally:
+        stub.stop()
+        smart_albums.stop()
+        db.close()
+        Base.metadata.drop_all(engine)
+
+
+_UNSET = object()
+
+
+def _trash(db, owner, n, deleted_at=_UNSET):
+    """Create `n` photos already in `owner`'s recycle bin.
+
+    `deleted_at` defaults to "now", matching every real soft-delete path. Pass
+    None explicitly to model a row that lost its timestamp.
+    """
+    stamp = datetime.now() if deleted_at is _UNSET else deleted_at
+    photos = [
+        Photo(
+            filename=f"t{i}.jpg",
+            file_path=f"/tmp/{uuid.uuid4().hex}.jpg",
+            file_type=FileType.image,
+            size=1,
+            owner_id=owner.id,
+            is_deleted=True,
+            deleted_at=stamp,
+        )
+        for i in range(n)
+    ]
+    db.add_all(photos)
+    db.commit()
+    return [str(p.id) for p in photos]
+
+
+def test_stats_reports_bin_size(ctx):
+    _trash(ctx["db"], ctx["owner"], 7)
+
+    res = ctx["client"].get("/api/photos/recycle-bin/stats")
+
+    assert res.status_code == 200
+    body = res.json()["data"]
+    assert body["total"] == 7
+    assert body["retention_days"] >= 1
+
+
+def test_stats_is_per_user(ctx):
+    _trash(ctx["db"], ctx["owner"], 3)
+    _trash(ctx["db"], ctx["other"], 5)
+
+    assert ctx["client"].get("/api/photos/recycle-bin/stats").json()["data"]["total"] == 3
+
+    ctx["current"]["user"] = ctx["other"]
+    assert ctx["client"].get("/api/photos/recycle-bin/stats").json()["data"]["total"] == 5
+
+
+def test_purge_with_null_ids_empties_the_whole_bin(ctx):
+    _trash(ctx["db"], ctx["owner"], 12)
+
+    # The client sends no ids at all — this is the "empty recycle bin" contract.
+    res = ctx["client"].post("/api/photos/recycle-bin/purge", json={"photo_ids": None})
+
+    assert res.status_code == 200
+    data = res.json()["data"]
+    assert data["mode"] == "sync"
+    assert data["deleted"] == 12
+    assert ctx["db"].query(Photo).count() == 0
+
+
+def test_purge_with_omitted_field_also_means_everything(ctx):
+    _trash(ctx["db"], ctx["owner"], 4)
+
+    # `photo_ids` defaults to None, so an empty body must behave like null.
+    res = ctx["client"].post("/api/photos/recycle-bin/purge", json={})
+
+    assert res.status_code == 200
+    assert res.json()["data"]["deleted"] == 4
+
+
+def test_purge_never_crosses_users(ctx):
+    mine = _trash(ctx["db"], ctx["owner"], 2)
+    theirs = _trash(ctx["db"], ctx["other"], 3)
+
+    res = ctx["client"].post(
+        "/api/photos/recycle-bin/purge", json={"photo_ids": mine + theirs}
+    )
+
+    assert res.status_code == 200
+    assert res.json()["data"]["deleted"] == 2
+    # The other user's photos must be untouched even though their ids were sent.
+    remaining = {str(p.id) for p in ctx["db"].query(Photo).all()}
+    assert remaining == set(theirs)
+
+
+def test_purge_of_empty_bin_is_not_an_error(ctx):
+    res = ctx["client"].post("/api/photos/recycle-bin/purge", json={"photo_ids": None})
+
+    assert res.status_code == 200
+    assert res.json()["data"]["total"] == 0
+
+
+def test_purge_rejects_explicit_empty_list(ctx):
+    res = ctx["client"].post("/api/photos/recycle-bin/purge", json={"photo_ids": []})
+
+    # An empty array is a client bug; `null` is the documented "everything" signal.
+    assert res.status_code == 400
+
+
+def test_purge_rejects_malformed_uuid(ctx):
+    res = ctx["client"].post(
+        "/api/photos/recycle-bin/purge", json={"photo_ids": ["not-a-uuid"]}
+    )
+
+    assert res.status_code == 422
+
+
+def test_large_purge_returns_a_pollable_job(ctx):
+    from app.service import recycle_bin_purge
+
+    ids = _trash(ctx["db"], ctx["owner"], 3)
+    # Force the async path without seeding thousands of rows.
+    with patch.object(recycle_bin_purge, "ASYNC_PURGE_THRESHOLD", 1), patch.object(
+        recycle_bin_purge, "_run_job"
+    ):
+        res = ctx["client"].post(
+            "/api/photos/recycle-bin/purge", json={"photo_ids": ids}
+        )
+        assert res.status_code == 200
+        data = res.json()["data"]
+        assert data["mode"] == "async"
+        assert data["total"] == 3
+        job_id = data["job_id"]
+
+        # The owner can poll it...
+        status = ctx["client"].get(f"/api/photos/recycle-bin/purge/{job_id}")
+        assert status.status_code == 200
+        assert status.json()["data"]["job_id"] == job_id
+
+        # ...a different user cannot.
+        ctx["current"]["user"] = ctx["other"]
+        assert ctx["client"].get(f"/api/photos/recycle-bin/purge/{job_id}").status_code == 404
+
+
+def test_unknown_job_id_is_404(ctx):
+    res = ctx["client"].get(f"/api/photos/recycle-bin/purge/{uuid.uuid4()}")
+    assert res.status_code == 404
+
+
+def test_restore_all_empties_the_bin_without_listing_ids(ctx):
+    _trash(ctx["db"], ctx["owner"], 6)
+    _trash(ctx["db"], ctx["other"], 2)
+
+    res = ctx["client"].post("/api/photos/recycle-bin/restore-all")
+
+    assert res.status_code == 200
+    assert res.json()["data"]["restored"] == 6
+    # Own photos are back, the other user's stay in their bin.
+    assert ctx["db"].query(Photo).filter(Photo.owner_id == ctx["owner"].id, Photo.is_deleted == False).count() == 6
+    assert ctx["db"].query(Photo).filter(Photo.owner_id == ctx["other"].id, Photo.is_deleted == True).count() == 2
+
+
+def test_restore_all_on_empty_bin_is_not_an_error(ctx):
+    res = ctx["client"].post("/api/photos/recycle-bin/restore-all")
+    assert res.status_code == 200
+    assert res.json()["data"]["restored"] == 0
+
+
+def test_list_endpoint_still_paginates(ctx):
+    _trash(ctx["db"], ctx["owner"], 5)
+
+    res = ctx["client"].get("/api/photos/recycle-bin", params={"skip": 0, "limit": 2})
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert len(rows) == 2
+    # RecyclePhoto must expose deleted_at (the UI computes days-remaining from it)
+    # and must not leak the absolute file path.
+    assert "deleted_at" in rows[0]
+    assert "file_path" not in rows[0]
+
+
+def test_listing_survives_a_row_with_no_deleted_at(ctx):
+    """One malformed row must not 500 the whole listing.
+
+    deleted_at is nullable in the schema, so a legacy row or a manual SQL fix can
+    leave it empty. Before RecyclePhoto.deleted_at was made Optional this
+    produced a ResponseValidationError and the entire recycle bin became
+    unreachable — with no way for the user to clear the offending row.
+    """
+    _trash(ctx["db"], ctx["owner"], 2)
+    _trash(ctx["db"], ctx["owner"], 1, deleted_at=None)
+
+    res = ctx["client"].get("/api/photos/recycle-bin", params={"skip": 0, "limit": 50})
+
+    assert res.status_code == 200
+    rows = res.json()["data"]
+    assert len(rows) == 3
+    assert sum(1 for r in rows if r["deleted_at"] is None) == 1
+
+
+def test_bin_with_missing_timestamp_can_still_be_emptied(ctx):
+    """The recovery path: such a row must remain purgeable."""
+    _trash(ctx["db"], ctx["owner"], 1, deleted_at=None)
+
+    res = ctx["client"].post("/api/photos/recycle-bin/purge", json={"photo_ids": None})
+
+    assert res.status_code == 200
+    assert res.json()["data"]["deleted"] == 1
+    assert ctx["db"].query(Photo).count() == 0

--- a/package/server/tests/unit/test_recycle_bin_bulk_delete.py
+++ b/package/server/tests/unit/test_recycle_bin_bulk_delete.py
@@ -1,0 +1,588 @@
+"""Tests for the bulk recycle-bin purge path.
+
+Covers the pieces that make emptying a large recycle bin fast instead of
+apparently hanging the server:
+
+* ``batch_delete_photos_db`` reaps every child row via DB-level FK cascade
+  instead of per-photo ORM cascades, and only ever touches the caller's photos.
+* the purge is chunked, so a large batch commits progressively and reports
+  progress rather than holding one long write transaction.
+* face identities keep a valid avatar: ``default_face_id`` is re-pointed at a
+  surviving face (or nulled) instead of being left dangling.
+* cluster counters are decremented by the real number of removed photos, which
+  the old per-photo helper got wrong when several photos shared a cluster.
+* ``count_recycle_bin_photos`` / ``get_recycle_bin_photo_ids`` let the UI offer
+  "select all N" and "empty bin" without paging the whole list into the browser.
+* the API routes big batches to a background job and small ones inline.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api import photo as photo_api
+from app.crud import photo as photo_crud
+from app.db.base import Base
+from app.db.models.album import Album, AlbumPhoto
+from app.db.models.cluster import ImageCluster, PhotoCluster
+from app.db.models.face import Face, FaceIdentity
+from app.db.models.image_description import ImageDescription
+from app.db.models.photo import FileType, Photo
+from app.db.models.photo_metadata import PhotoMetadata
+from app.db.models.user import User
+from app.schemas.photo import RecycleBinPurge
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    # The production engine turns this on in app/db/session.py. The bulk delete
+    # relies on ON DELETE CASCADE, and SQLite ignores FK actions without it, so
+    # the fixture must mirror that or the test would validate nothing.
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, _record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)
+
+
+def _user(db, username):
+    user = User(username=username, email=f"{username}@example.com", hashed_password="x")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _photo(db, owner, name, deleted=True):
+    photo = Photo(
+        filename=name,
+        file_path=f"/tmp/{owner.id}/{name}",
+        file_type=FileType.image,
+        size=1,
+        owner_id=owner.id,
+        is_deleted=deleted,
+        deleted_at=None,
+    )
+    db.add(photo)
+    db.commit()
+    db.refresh(photo)
+    return photo
+
+
+# `storage` performs real filesystem work; every test here stubs it out so the
+# assertions are about SQL, not about temp files.
+def _no_storage():
+    return patch.multiple(
+        photo_crud.storage,
+        delete_file=MagicMock(),
+        delete_thumbnails=MagicMock(),
+    )
+
+
+# --------------------------- cascade correctness ---------------------------
+
+
+def test_bulk_delete_cascades_all_child_rows(db):
+    owner = _user(db, "cascade-owner")
+    first = _photo(db, owner, "a.jpg")
+    second = _photo(db, owner, "b.jpg")
+
+    for photo in (first, second):
+        db.add(PhotoMetadata(photo_id=photo.id))
+        db.add(ImageDescription(photo_id=photo.id, description="d"))
+        db.add(Face(photo_id=photo.id, face_rect=[0, 0, 1, 1]))
+    db.commit()
+
+    with _no_storage(), patch("app.crud.album.trigger_conditional_albums_update"):
+        deleted = photo_crud.batch_delete_photos_db(
+            db, [first.id, second.id], is_delete_file=True, user_id=owner.id
+        )
+
+    assert deleted == 2
+    assert db.query(Photo).count() == 0
+    # Children go away through the FK cascade, not through per-photo ORM loads.
+    assert db.query(PhotoMetadata).count() == 0
+    assert db.query(ImageDescription).count() == 0
+    assert db.query(Face).count() == 0
+
+
+def test_bulk_delete_is_scoped_to_the_owner(db):
+    owner = _user(db, "mine")
+    intruder = _user(db, "theirs")
+    # Read the ids up front: after the bulk DELETE the ORM instances are expired
+    # and touching `.id` would trigger a refresh of a row that no longer exists.
+    mine_id = _photo(db, owner, "mine.jpg").id
+    theirs_id = _photo(db, intruder, "theirs.jpg").id
+
+    with _no_storage(), patch("app.crud.album.trigger_conditional_albums_update"):
+        deleted = photo_crud.batch_delete_photos_db(
+            db, [mine_id, theirs_id], is_delete_file=True, user_id=owner.id
+        )
+
+    # Passing someone else's id must be a silent no-op, never a cross-user delete.
+    assert deleted == 1
+    assert db.query(Photo).filter(Photo.id == theirs_id).first() is not None
+    assert db.query(Photo).filter(Photo.id == mine_id).first() is None
+
+
+def test_bulk_delete_refreshes_album_counts(db):
+    owner = _user(db, "album-owner")
+    album = Album(name="Trip", owner_id=owner.id, type="user", num_photos=2)
+    db.add(album)
+    db.commit()
+    db.refresh(album)
+
+    kept = _photo(db, owner, "kept.jpg", deleted=False)
+    doomed = _photo(db, owner, "doomed.jpg")
+    db.add_all([
+        AlbumPhoto(album_id=album.id, photo_id=kept.id),
+        AlbumPhoto(album_id=album.id, photo_id=doomed.id),
+    ])
+    db.commit()
+
+    with _no_storage(), patch("app.crud.album.trigger_conditional_albums_update"):
+        photo_crud.batch_delete_photos_db(
+            db, [doomed.id], is_delete_file=True, user_id=owner.id
+        )
+
+    db.refresh(album)
+    assert album.num_photos == 1
+    assert db.query(AlbumPhoto).count() == 1
+
+
+# --------------------------- face identity avatars ---------------------------
+
+
+def test_default_face_is_repointed_to_a_surviving_face(db):
+    owner = _user(db, "face-owner")
+    doomed_photo = _photo(db, owner, "doomed.jpg")
+    kept_photo = _photo(db, owner, "kept.jpg", deleted=False)
+
+    identity = FaceIdentity(identity_name="Alice", owner_id=owner.id)
+    db.add(identity)
+    db.commit()
+    db.refresh(identity)
+
+    doomed_face = Face(photo_id=doomed_photo.id, face_identity_id=identity.id, face_rect=[0, 0, 1, 1])
+    kept_face = Face(photo_id=kept_photo.id, face_identity_id=identity.id, face_rect=[0, 0, 1, 1])
+    db.add_all([doomed_face, kept_face])
+    db.commit()
+    db.refresh(doomed_face)
+    db.refresh(kept_face)
+
+    identity.default_face_id = doomed_face.id
+    db.commit()
+
+    with _no_storage(), patch("app.crud.album.trigger_conditional_albums_update"):
+        photo_crud.batch_delete_photos_db(
+            db, [doomed_photo.id], is_delete_file=True, user_id=owner.id
+        )
+
+    db.refresh(identity)
+    # Falling back to NULL would silently drop the person's avatar.
+    assert identity.default_face_id == kept_face.id
+
+
+def test_default_face_is_nulled_when_no_face_survives(db):
+    owner = _user(db, "lonely-face-owner")
+    photo = _photo(db, owner, "only.jpg")
+
+    identity = FaceIdentity(identity_name="Bob", owner_id=owner.id)
+    db.add(identity)
+    db.commit()
+    db.refresh(identity)
+
+    face = Face(photo_id=photo.id, face_identity_id=identity.id, face_rect=[0, 0, 1, 1])
+    db.add(face)
+    db.commit()
+    db.refresh(face)
+    identity.default_face_id = face.id
+    db.commit()
+
+    with _no_storage(), patch("app.crud.album.trigger_conditional_albums_update"):
+        photo_crud.batch_delete_photos_db(
+            db, [photo.id], is_delete_file=True, user_id=owner.id
+        )
+
+    db.refresh(identity)
+    assert identity.default_face_id is None
+
+
+# ------------------------------- clusters -------------------------------
+
+
+def test_cluster_counter_drops_by_the_number_of_removed_photos(db):
+    owner = _user(db, "cluster-owner")
+    first = _photo(db, owner, "c1.jpg")
+    second = _photo(db, owner, "c2.jpg")
+    survivor = _photo(db, owner, "c3.jpg", deleted=False)
+
+    cluster_id = str(uuid4())
+    db.add(ImageCluster(cluster_id=cluster_id, cluster_type="similar", count=3))
+    db.add_all([
+        PhotoCluster(cluster_id=cluster_id, photo_id=first.id),
+        PhotoCluster(cluster_id=cluster_id, photo_id=second.id),
+        PhotoCluster(cluster_id=cluster_id, photo_id=survivor.id),
+    ])
+    db.commit()
+    doomed_ids = [first.id, second.id]
+
+    with _no_storage(), patch("app.crud.album.trigger_conditional_albums_update"):
+        photo_crud.batch_delete_photos_db(
+            db, doomed_ids, is_delete_file=True, user_id=owner.id
+        )
+
+    cluster = db.query(ImageCluster).filter(ImageCluster.cluster_id == cluster_id).first()
+    # The old per-photo helper decremented once per call, leaving count == 2 here.
+    assert cluster is not None
+    assert cluster.count == 1
+    assert db.query(PhotoCluster).count() == 1
+
+
+def test_cluster_is_dropped_when_every_member_is_deleted(db):
+    owner = _user(db, "cluster-drop-owner")
+    first = _photo(db, owner, "d1.jpg")
+    second = _photo(db, owner, "d2.jpg")
+
+    cluster_id = str(uuid4())
+    db.add(ImageCluster(cluster_id=cluster_id, cluster_type="similar", count=2))
+    db.add_all([
+        PhotoCluster(cluster_id=cluster_id, photo_id=first.id),
+        PhotoCluster(cluster_id=cluster_id, photo_id=second.id),
+    ])
+    db.commit()
+    doomed_ids = [first.id, second.id]
+
+    with _no_storage(), patch("app.crud.album.trigger_conditional_albums_update"):
+        photo_crud.batch_delete_photos_db(
+            db, doomed_ids, is_delete_file=True, user_id=owner.id
+        )
+
+    assert db.query(ImageCluster).count() == 0
+    assert db.query(PhotoCluster).count() == 0
+
+
+# ------------------------------- chunking -------------------------------
+
+
+def test_large_batch_is_chunked_and_reports_progress(db, monkeypatch):
+    owner = _user(db, "chunk-owner")
+    photos = [_photo(db, owner, f"p{i}.jpg") for i in range(7)]
+
+    monkeypatch.setattr(photo_crud, "DELETE_CHUNK_SIZE", 3)
+    progress = []
+
+    with _no_storage(), patch("app.crud.album.trigger_conditional_albums_update"):
+        deleted = photo_crud.batch_delete_photos_db(
+            db,
+            [p.id for p in photos],
+            is_delete_file=True,
+            user_id=owner.id,
+            progress_cb=lambda done, total: progress.append((done, total)),
+        )
+
+    assert deleted == 7
+    assert db.query(Photo).count() == 0
+    # 7 photos / chunk of 3 => 3 commits, and progress must end at the total so
+    # the UI can show a truthful bar.
+    assert progress == [(3, 7), (6, 7), (7, 7)]
+
+
+def test_empty_input_is_a_no_op(db):
+    with _no_storage():
+        assert photo_crud.batch_delete_photos_db(db, [], is_delete_file=True) == 0
+
+
+# --------------------------- stats / id enumeration ---------------------------
+
+
+def test_count_and_ids_only_cover_the_users_recycle_bin(db):
+    owner = _user(db, "stats-owner")
+    other = _user(db, "stats-other")
+    trashed = [_photo(db, owner, f"t{i}.jpg") for i in range(3)]
+    _photo(db, owner, "live.jpg", deleted=False)
+    _photo(db, other, "other-trashed.jpg")
+
+    assert photo_crud.count_recycle_bin_photos(db, owner.id) == 3
+    assert set(photo_crud.get_recycle_bin_photo_ids(db, owner.id)) == {p.id for p in trashed}
+    assert len(photo_crud.get_recycle_bin_photo_ids(db, owner.id, limit=2)) == 2
+
+
+# ------------------------------- API routing -------------------------------
+
+
+def _api_user():
+    return SimpleNamespace(id=uuid4())
+
+
+def test_purge_resolves_all_ids_when_photo_ids_is_null():
+    db = MagicMock()
+    user = _api_user()
+    ids = [uuid4(), uuid4()]
+
+    with patch.object(
+        photo_api.app.crud.photo, "get_recycle_bin_photo_ids", return_value=ids
+    ) as resolve, patch.object(
+        photo_api.app.crud.photo, "batch_delete_photos_db", return_value=2
+    ) as delete:
+        result = photo_api.purge_recycle_bin(
+            payload=RecycleBinPurge(photo_ids=None), db=db, current_user=user
+        )
+
+    # This is the whole point of the endpoint: the client sent no ids at all.
+    resolve.assert_called_once_with(db, user_id=user.id)
+    delete.assert_called_once_with(db, ids, is_delete_file=True, user_id=user.id)
+    assert result.data["mode"] == "sync"
+    assert result.data["deleted"] == 2
+
+
+def test_purge_of_empty_bin_succeeds_without_deleting():
+    db = MagicMock()
+    with patch.object(
+        photo_api.app.crud.photo, "get_recycle_bin_photo_ids", return_value=[]
+    ), patch.object(photo_api.app.crud.photo, "batch_delete_photos_db") as delete:
+        result = photo_api.purge_recycle_bin(
+            payload=RecycleBinPurge(photo_ids=None), db=db, current_user=_api_user()
+        )
+
+    delete.assert_not_called()
+    assert result.data["total"] == 0
+
+
+def test_purge_switches_to_background_job_above_threshold():
+    from app.service import recycle_bin_purge
+
+    db = MagicMock()
+    user = _api_user()
+    ids = [uuid4() for _ in range(recycle_bin_purge.ASYNC_PURGE_THRESHOLD + 1)]
+    fake_job = recycle_bin_purge.PurgeJob(id="job-1", user_id=str(user.id), total=len(ids))
+
+    with patch.object(
+        photo_api.app.crud.photo, "batch_delete_photos_db"
+    ) as delete, patch.object(
+        recycle_bin_purge, "active_job_for_user", return_value=None
+    ), patch.object(
+        recycle_bin_purge, "start_purge_job", return_value=fake_job
+    ) as start:
+        result = photo_api.purge_recycle_bin(
+            payload=RecycleBinPurge(photo_ids=ids), db=db, current_user=user
+        )
+
+    # A batch this size must never block the request thread.
+    delete.assert_not_called()
+    start.assert_called_once()
+    assert result.data["mode"] == "async"
+    assert result.data["job_id"] == "job-1"
+    assert result.data["total"] == len(ids)
+
+
+def test_purge_returns_the_existing_job_instead_of_starting_a_second_one():
+    from app.service import recycle_bin_purge
+
+    user = _api_user()
+    ids = [uuid4() for _ in range(recycle_bin_purge.ASYNC_PURGE_THRESHOLD + 1)]
+    running = recycle_bin_purge.PurgeJob(
+        id="job-running", user_id=str(user.id), total=len(ids), status="running"
+    )
+
+    with patch.object(
+        recycle_bin_purge, "active_job_for_user", return_value=running
+    ), patch.object(recycle_bin_purge, "start_purge_job") as start:
+        result = photo_api.purge_recycle_bin(
+            payload=RecycleBinPurge(photo_ids=ids), db=MagicMock(), current_user=user
+        )
+
+    start.assert_not_called()
+    assert result.data["job_id"] == "job-running"
+
+
+def test_purge_rejects_an_explicitly_empty_id_list():
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        photo_api.purge_recycle_bin(
+            payload=RecycleBinPurge(photo_ids=[]), db=MagicMock(), current_user=_api_user()
+        )
+    # An empty list is a client bug; `null` is the documented "everything" signal.
+    assert exc.value.status_code == 400
+
+
+def test_purge_status_is_scoped_to_its_owner():
+    from fastapi import HTTPException
+    from app.service import recycle_bin_purge
+
+    owner = _api_user()
+    job = recycle_bin_purge.PurgeJob(id="job-x", user_id=str(owner.id), total=5, processed=5)
+
+    with patch.object(recycle_bin_purge, "get_job", return_value=job):
+        result = photo_api.get_recycle_bin_purge_status(job_id="job-x", current_user=owner)
+    assert result.data["progress"] == 100
+
+    with patch.object(recycle_bin_purge, "get_job", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            photo_api.get_recycle_bin_purge_status(job_id="job-x", current_user=_api_user())
+    assert exc.value.status_code == 404
+
+
+def test_recycle_bin_stats_reports_total_and_retention():
+    db = MagicMock()
+    user = _api_user()
+    with patch.object(
+        photo_api.app.crud.photo, "count_recycle_bin_photos", return_value=1234
+    ):
+        result = photo_api.get_recycle_bin_stats(db=db, current_user=user)
+
+    assert result.data["total"] == 1234
+    assert result.data["retention_days"] >= 1
+
+
+# ------------------------------- purge job registry -------------------------------
+
+
+def test_purge_job_registry_tracks_and_scopes_jobs():
+    from app.service import recycle_bin_purge
+
+    user_id = uuid4()
+    photo_ids = [uuid4(), uuid4()]
+
+    # Patch the worker body so no thread touches a real database.
+    with patch.object(recycle_bin_purge, "_run_job") as run:
+        job = recycle_bin_purge.start_purge_job(user_id, photo_ids)
+        run_called = run.call_count
+
+    assert run_called == 1
+    assert job.total == 2
+    assert recycle_bin_purge.get_job(job.id, user_id) is job
+    # Another user must not be able to read the job by guessing its id.
+    assert recycle_bin_purge.get_job(job.id, uuid4()) is None
+
+
+def test_purge_job_progress_dict_is_bounded():
+    from app.service import recycle_bin_purge
+
+    job = recycle_bin_purge.PurgeJob(id="j", user_id="u", total=200, processed=50)
+    assert job.to_dict()["progress"] == 25
+
+    job.status = "completed"
+    assert job.to_dict()["progress"] == 100
+
+    empty = recycle_bin_purge.PurgeJob(id="j2", user_id="u", total=0)
+    # No division by zero when the bin turned out to be empty.
+    assert empty.to_dict()["progress"] == 0
+
+
+def test_background_worker_actually_deletes_and_closes_its_session():
+    """Drive the real worker body, not a mock.
+
+    Everywhere else _run_job is patched out, so this is the only place that proves
+    the background path works end to end: it opens its own session (the request
+    session is long gone by then), reports progress, marks the job completed, and
+    closes the session instead of leaking a pooled connection.
+    """
+    from app.service import recycle_bin_purge
+
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, _record):
+        cur = dbapi_connection.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    seed = SessionLocal()
+
+    owner = User(username="worker", email="worker@e.com", hashed_password="x")
+    seed.add(owner)
+    seed.commit()
+    seed.refresh(owner)
+    photo_ids = [_photo(seed, owner, f"w{i}.jpg").id for i in range(5)]
+    owner_id = owner.id
+    seed.close()
+
+    closed = []
+
+    def tracking_session_factory():
+        s = SessionLocal()
+        original_close = s.close
+
+        def close_and_record():
+            closed.append(True)
+            original_close()
+
+        s.close = close_and_record
+        return s
+
+    job = recycle_bin_purge.PurgeJob(
+        id="real-job", user_id=str(owner_id), total=len(photo_ids)
+    )
+    with recycle_bin_purge._lock:
+        recycle_bin_purge._jobs["real-job"] = job
+
+    try:
+        with patch("app.db.session.SessionLocal", tracking_session_factory), _no_storage(), patch(
+            "app.crud.album.trigger_conditional_albums_update"
+        ):
+            recycle_bin_purge._run_job("real-job", owner_id, photo_ids)
+
+        assert job.status == "completed"
+        assert job.deleted == 5
+        assert job.processed == job.total
+        assert closed, "the worker must close its session"
+
+        verify = SessionLocal()
+        assert verify.query(Photo).count() == 0
+        verify.close()
+    finally:
+        with recycle_bin_purge._lock:
+            recycle_bin_purge._jobs.pop("real-job", None)
+        Base.metadata.drop_all(engine)
+
+
+def test_background_worker_records_failure_instead_of_crashing():
+    """A failing purge must surface as a failed job, not kill the thread silently."""
+    from app.service import recycle_bin_purge
+
+    job = recycle_bin_purge.PurgeJob(id="boom-job", user_id="u", total=3)
+    with recycle_bin_purge._lock:
+        recycle_bin_purge._jobs["boom-job"] = job
+
+    try:
+        with patch(
+            "app.crud.photo.batch_delete_photos_db",
+            side_effect=RuntimeError("disk on fire"),
+        ), patch("app.db.session.SessionLocal", MagicMock()):
+            # Must not re-raise.
+            recycle_bin_purge._run_job("boom-job", uuid4(), [uuid4()])
+
+        assert job.status == "failed"
+        assert "disk on fire" in job.error
+        assert job.finished_at is not None
+    finally:
+        with recycle_bin_purge._lock:
+            recycle_bin_purge._jobs.pop("boom-job", None)

--- a/package/server/tests/unit/test_swipe_filter.py
+++ b/package/server/tests/unit/test_swipe_filter.py
@@ -124,7 +124,10 @@ def test_recycle_bin_restore_reopens_swipe_deleted_photo(db):
     with patch.object(swipe_filter_crud, "_refresh_albums"):
         swipe_filter_crud.save_decisions(db, owner.id, [_item(photo, "delete")])
 
-    with patch.object(photo_crud, "_update_album_photo_count"), patch(
+    # restore_photos now recounts albums in one batched call (update_album_photo_counts)
+    # instead of committing once per album, so the isolation patch must target that
+    # name — patching the old per-album helper would silently do nothing.
+    with patch.object(photo_crud, "update_album_photo_counts"), patch(
         "app.crud.album.trigger_conditional_albums_update"
     ):
         assert photo_crud.restore_photos(db, [photo.id], user_id=owner.id) == 1

--- a/package/website/src/views/RecycleBinPage.vue
+++ b/package/website/src/views/RecycleBinPage.vue
@@ -2,8 +2,8 @@
   <div class="recycle-bin-page container mx-auto flex flex-col">
     <MobilePageHeader
       v-if="isMobileViewport"
-      :title="isSelectionMode ? `已选择 ${selectedIds.length} 项` : '最近删除'"
-      :subtitle="isSelectionMode ? undefined : `已删除的内容仅保留${retentionDays}天`"
+      :title="isSelectionMode ? `已选择 ${effectiveSelectedCount} 项` : '最近删除'"
+      :subtitle="isSelectionMode ? undefined : mobileSubtitle"
       :show-back="!isSelectionMode"
       fallback="/photos"
     >
@@ -12,14 +12,23 @@
           type="button"
           class="rounded-lg px-2 py-1 text-sm font-medium text-primary-600 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-primary-400"
           @click="toggleSelectAll"
-        >{{ isAllSelected ? '取消全选' : '全选' }}</button>
+        >{{ isEverythingSelected ? '取消全选' : '全选' }}</button>
       </template>
       <template #actions>
         <IconButton v-if="!isSelectionMode" label="选择照片" size="sm" @click="handleEnterSelectionMode">
           <CheckSquare class="h-5 w-5" />
         </IconButton>
+        <IconButton
+          v-if="!isSelectionMode"
+          label="清空回收站"
+          size="sm"
+          :disabled="totalCount === 0 || isPurging"
+          @click="handleEmptyRecycleBin"
+        >
+          <Trash2 class="h-5 w-5" />
+        </IconButton>
         <button
-          v-else
+          v-if="isSelectionMode"
           type="button"
           class="rounded-lg px-2 py-1 text-sm font-medium text-primary-600 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-primary-400"
           @click="cancelSelection"
@@ -39,14 +48,15 @@
           
           <!-- Mobile Select All -->
           <button v-if="isSelectionMode" @click="toggleSelectAll" class="md:hidden text-primary-600 dark:text-primary-400 font-medium px-2 py-1">
-            {{ isAllSelected ? '取消全选' : '全选' }}
+            {{ isEverythingSelected ? '取消全选' : '全选' }}
           </button>
 
           <!-- Title -->
           <h1 class="text-lg md:text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
             <span :class="{ 'hidden md:inline': isSelectionMode }">最近删除</span>
-            <span v-if="isSelectionMode" class="md:hidden">已选择 {{ selectedIds.length }} 项</span>
-            <span v-if="isSelectionMode" class="hidden md:inline text-sm font-medium text-gray-500 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-full mt-0.5">已选择 {{ selectedIds.length }} 项</span>
+            <span v-if="!isSelectionMode && totalCount > 0" class="text-sm font-medium text-gray-500 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-full mt-0.5">共 {{ totalCount }} 项</span>
+            <span v-if="isSelectionMode" class="md:hidden">已选择 {{ effectiveSelectedCount }} 项</span>
+            <span v-if="isSelectionMode" class="hidden md:inline text-sm font-medium text-gray-500 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-full mt-0.5">已选择 {{ effectiveSelectedCount }} 项</span>
           </h1>
         </div>
 
@@ -57,15 +67,33 @@
             <button @click="handleEnterSelectionMode" class="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" title="选择">
               <CheckSquare class="w-5 h-5 text-gray-700 dark:text-gray-300" />
             </button>
-            <button class="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
-               <MoreVertical class="w-5 h-5 text-gray-700 dark:text-gray-300" />
-            </button>
+            <el-dropdown trigger="click" placement="bottom-end">
+              <button class="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors" title="更多操作">
+                 <MoreVertical class="w-5 h-5 text-gray-700 dark:text-gray-300" />
+              </button>
+              <template #dropdown>
+                <el-dropdown-menu>
+                  <el-dropdown-item :disabled="totalCount === 0 || isPurging" @click="handleRestoreAll">
+                    <div class="flex items-center gap-2">
+                      <RefreshCcw class="w-4 h-4" />
+                      <span>全部恢复</span>
+                    </div>
+                  </el-dropdown-item>
+                  <el-dropdown-item :disabled="totalCount === 0 || isPurging" divided @click="handleEmptyRecycleBin">
+                    <div class="flex items-center gap-2 text-red-500">
+                      <Trash2 class="w-4 h-4" />
+                      <span>清空回收站</span>
+                    </div>
+                  </el-dropdown-item>
+                </el-dropdown-menu>
+              </template>
+            </el-dropdown>
           </template>
           <!-- Selection Actions -->
           <template v-else>
             <!-- PC Select All -->
             <button @click="toggleSelectAll" class="hidden md:block text-primary-600 dark:text-primary-400 font-medium px-3 py-1.5 hover:bg-primary-50 dark:hover:bg-primary-900/30 rounded-full transition-colors mr-2">
-              {{ isAllSelected ? '取消全选' : '全选' }}
+              {{ isEverythingSelected ? '取消全选' : '全选' }}
             </button>
             <button @click="cancelSelection" class="text-primary-600 dark:text-primary-400 font-medium px-2 py-1 hover:bg-primary-50 dark:hover:bg-primary-900/30 rounded-full transition-colors">
               取消
@@ -76,6 +104,37 @@
       <!-- Hint Text -->
       <div class="px-4 pb-3 text-xs md:text-sm text-gray-500 dark:text-gray-400">
         已删除的内容仅保留{{ retentionDays }}天，逾期将永久删除。
+      </div>
+    </div>
+
+    <!-- Purge progress. A big purge runs as a background job on the server, so the
+         page stays interactive and reports real progress instead of freezing on a
+         request that would otherwise outlive the HTTP timeout. -->
+    <Transition name="bar-slide">
+      <div v-if="isPurging" class="mx-auto w-full px-4 pb-3">
+        <div class="rounded-xl border border-gray-200 bg-white/90 px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800/90">
+          <div class="mb-2 flex items-center justify-between text-sm">
+            <span class="flex items-center gap-2 font-medium text-gray-700 dark:text-gray-200">
+              <Loader2 class="h-4 w-4 animate-spin text-primary-500" />
+              正在清理回收站…
+            </span>
+            <span class="text-gray-500 dark:text-gray-400">{{ purgeProcessed }} / {{ purgeTotal }}</span>
+          </div>
+          <div class="h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+            <div
+              class="h-full rounded-full bg-primary-500 transition-[width] duration-300"
+              :style="{ width: `${purgeProgress}%` }"
+            ></div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
+    <!-- "Select all" spans the whole bin, not just the loaded pages. Say so explicitly
+         so a destructive action is never ambiguous. -->
+    <div v-if="isSelectionMode && selectAllAcrossPages && totalCount > photos.length" class="mx-auto w-full px-4 pb-2">
+      <div class="rounded-lg bg-primary-50 px-3 py-2 text-xs text-primary-700 dark:bg-primary-900/30 dark:text-primary-300">
+        已选中回收站中的全部 {{ totalCount }} 项（包含尚未加载的 {{ totalCount - photos.length }} 项）
       </div>
     </div>
 
@@ -108,6 +167,22 @@
            </div>
         </template>
       </FlatPhotoGallery>
+
+      <!-- Explicit pagination control. Infinite scroll alone is fragile (nested
+           scroll containers, short viewports), and it was the only way to reach
+           the rest of the bin. -->
+      <div v-if="photos.length > 0" class="flex flex-col items-center gap-2 py-6 text-sm text-gray-500 dark:text-gray-400">
+        <button
+          v-if="hasMore"
+          type="button"
+          :disabled="loading"
+          class="rounded-full border border-gray-200 px-5 py-2 font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:opacity-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+          @click="loadMore"
+        >
+          {{ loading ? '加载中…' : '加载更多' }}
+        </button>
+        <span>已加载 {{ photos.length }}{{ totalCount ? ` / ${totalCount}` : '' }} 项</span>
+      </div>
     </div>
 
     <!-- Floating selection action bar (restore / delete) -->
@@ -118,10 +193,10 @@
       >
         <div class="pointer-events-auto flex items-center justify-around w-full max-w-[280px] bg-white/95 dark:bg-gray-800/95 backdrop-blur-md shadow-xl border border-gray-200/50 dark:border-gray-700/50 rounded-[2rem] px-6 py-2.5">
           <button 
-            @click="handleRestore(selectedIds)" 
-            :disabled="selectedIds.length === 0"
+            @click="handleRestoreSelection" 
+            :disabled="effectiveSelectedCount === 0 || isPurging"
             class="flex flex-col items-center justify-center gap-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-1"
-            :class="selectedIds.length === 0 ? 'text-gray-400' : 'text-primary-500 hover:text-primary-600'"
+            :class="effectiveSelectedCount === 0 ? 'text-gray-400' : 'text-primary-500 hover:text-primary-600'"
           >
             <RefreshCcw class="w-5 h-5" />
             <span class="text-[11px] font-medium">恢复</span>
@@ -131,10 +206,10 @@
           <div class="w-px h-8 bg-gray-200 dark:bg-gray-700 mx-2"></div>
 
           <button 
-            @click="handlePermanentDelete(selectedIds)" 
-            :disabled="selectedIds.length === 0"
+            @click="handleDeleteSelection" 
+            :disabled="effectiveSelectedCount === 0 || isPurging"
             class="flex flex-col items-center justify-center gap-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-1"
-            :class="selectedIds.length === 0 ? 'text-gray-400' : 'text-red-500 hover:text-red-600'"
+            :class="effectiveSelectedCount === 0 ? 'text-gray-400' : 'text-red-500 hover:text-red-600'"
           >
             <Trash2 class="w-5 h-5" />
             <span class="text-[11px] font-medium">删除</span>
@@ -171,11 +246,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed, watch } from 'vue'
+import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAppBack } from '@/composables/useAppBack'
 import { ElMessage } from 'element-plus'
-import { RefreshCcw, ArrowLeft, Trash2, Clock, X, CheckSquare, MoreVertical, Disc } from 'lucide-vue-next'
+import { RefreshCcw, ArrowLeft, Trash2, Clock, X, CheckSquare, MoreVertical, Disc, Loader2 } from 'lucide-vue-next'
 import FlatPhotoGallery from '@/components/FlatPhotoGallery.vue'
 import PhotoLightbox from '@/components/PhotoLightbox.vue'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
@@ -194,19 +269,47 @@ const loading = ref(false)
 const photos = ref<AlbumImage[]>([])
 const pendingRemoveIds = ref(new Set<string>())
 const skip = ref(0)
-const limit = 100
+// Larger page: the bin is a flat grid of thumbnails, and 100 meant a user had to
+// scroll five times before "select all" could even reach 500 items.
+const limit = 200
 const hasMore = ref(true)
+// Server-reported size of the whole bin, so "select all" and "empty bin" no longer
+// depend on how much has been scrolled into the browser.
+const totalCount = ref(0)
+// Whether totalCount came from the authoritative stats endpoint. Without this the
+// pagination fallback would overwrite a real total with the loaded-page length.
+const hasStats = ref(false)
 
 const galleryRef = ref<InstanceType<typeof FlatPhotoGallery> | null>(null)
 const selectedIds = ref<string[]>([])
 const isSelectionMode = ref(false)
+// True when the user asked for "everything in the bin" rather than "the ids
+// currently on screen". Actions then target the server-side set, so the client
+// never has to enumerate tens of thousands of ids.
+const selectAllAcrossPages = ref(false)
 
 // 同步到全局 UI 状态：移动端底部 Tab 栏 / Agent FAB 在选择模式激活时隐藏
 const uiStore = useUiStore()
 watch(isSelectionMode, (v) => uiStore.setSelectionActive(v))
 
-const isAllSelected = computed(() => {
+const allLoadedSelected = computed(() => {
   return photos.value.length > 0 && selectedIds.value.length === photos.value.length
+})
+
+// "Everything" means the whole bin when we know its size, otherwise every loaded item.
+const isEverythingSelected = computed(() => {
+  if (selectAllAcrossPages.value) return true
+  return allLoadedSelected.value && !hasMore.value
+})
+
+const effectiveSelectedCount = computed(() => {
+  if (selectAllAcrossPages.value) return Math.max(totalCount.value, selectedIds.value.length)
+  return selectedIds.value.length
+})
+
+const mobileSubtitle = computed(() => {
+  const retention = `已删除的内容仅保留${retentionDays.value}天`
+  return totalCount.value > 0 ? `${retention} · 共 ${totalCount.value} 项` : retention
 })
 
 const handleEnterSelectionMode = () => {
@@ -215,8 +318,24 @@ const handleEnterSelectionMode = () => {
 }
 
 const toggleSelectAll = () => {
-  const allIds = photos.value.map(p => p.id)
-  galleryRef.value?.selectAll(allIds)
+  const loadedIds = photos.value.map(p => p.id)
+
+  if (isEverythingSelected.value) {
+    // Clear the whole-bin intent first so the resulting selection-change event
+    // does not immediately re-derive it.
+    selectAllAcrossPages.value = false
+    // useSelection.selectAll() toggles: passing an already fully selected list
+    // deselects it, which keeps us in selection mode.
+    if (loadedIds.length > 0) galleryRef.value?.selectAll(loadedIds)
+    return
+  }
+
+  // Tick every loaded thumbnail for immediate feedback, and flag the whole-bin
+  // intent so pages that were never scrolled into view are covered too.
+  const unselected = loadedIds.filter(id => !selectedIds.value.includes(id))
+  if (unselected.length > 0) galleryRef.value?.selectAll(unselected)
+  selectAllAcrossPages.value = totalCount.value > 0 || hasMore.value
+
   if (!isSelectionMode.value) {
     galleryRef.value?.enterSelectionMode()
     isSelectionMode.value = true
@@ -224,6 +343,11 @@ const toggleSelectAll = () => {
 }
 
 const handleSelectionChange = (ids: string[]) => {
+  // Unticking a single item must cancel the whole-bin intent, otherwise the
+  // action bar would still delete items the user just excluded.
+  if (selectAllAcrossPages.value && ids.length < photos.value.length) {
+    selectAllAcrossPages.value = false
+  }
   selectedIds.value = ids
   if (ids.length > 0) {
     isSelectionMode.value = true
@@ -234,6 +358,7 @@ const handleSelectionChange = (ids: string[]) => {
 
 const cancelSelection = () => {
   isSelectionMode.value = false
+  selectAllAcrossPages.value = false
   galleryRef.value?.exitSelectionMode()
 }
 
@@ -300,47 +425,181 @@ const handlePhotoDelete = (photoId: string) => {
   showDeleteConfirm.value = true
   confirmMessage.value = '确定要永久删除这张照片吗？该操作不可恢复！'
   pendingDeleteIds.value = [photoId]
+  pendingDeleteAll.value = false
 }
 
 // Delete Confirm state
 const showDeleteConfirm = ref(false)
 const confirmMessage = ref('')
 const pendingDeleteIds = ref<string[]>([])
+// `null` photo_ids tells the server "purge my whole bin", which is what makes
+// emptying the bin possible without listing every id in the browser first.
+const pendingDeleteAll = ref(false)
 let deleteCallback: ((success: boolean) => void) | null = null
+
+// Purge progress (async server job)
+const isPurging = ref(false)
+const purgeTotal = ref(0)
+const purgeProcessed = ref(0)
+const purgeProgress = computed(() => {
+  if (purgeTotal.value === 0) return 0
+  return Math.min(100, Math.round((purgeProcessed.value / purgeTotal.value) * 100))
+})
+let pollTimer: ReturnType<typeof setTimeout> | null = null
+
+const stopPolling = () => {
+  if (pollTimer !== null) {
+    clearTimeout(pollTimer)
+    pollTimer = null
+  }
+}
 
 const handlePermanentDelete = (ids: string[], callback?: (success: boolean) => void) => {
   showDeleteConfirm.value = true
   confirmMessage.value = `确定要永久删除这 ${ids.length} 张照片吗？该操作不可恢复！`
   pendingDeleteIds.value = ids
+  pendingDeleteAll.value = false
   deleteCallback = callback || null
 }
 
-const confirmDelete = async () => {
-  const ids = pendingDeleteIds.value
-  if (ids.length === 0) return
-  
-  try {
-    await request.delete('/api/photos/recycle-bin/permanent', { data: { photo_ids: ids } })
-    ElMessage.success(`成功永久删除 ${ids.length} 张照片`)
-    photos.value = photos.value.filter(p => !ids.includes(p.id))
-    if (lightboxImage.value && ids.includes(lightboxImage.value.id)) {
-        closeLightbox()
+const handleDeleteSelection = () => {
+  if (selectAllAcrossPages.value) {
+    showDeleteConfirm.value = true
+    confirmMessage.value = `确定要永久删除回收站中的全部 ${effectiveSelectedCount.value} 张照片吗？该操作不可恢复！`
+    pendingDeleteIds.value = []
+    pendingDeleteAll.value = true
+    deleteCallback = null
+    return
+  }
+  handlePermanentDelete(selectedIds.value)
+}
+
+const handleEmptyRecycleBin = () => {
+  if (totalCount.value === 0) {
+    ElMessage.info('回收站已经是空的')
+    return
+  }
+  showDeleteConfirm.value = true
+  confirmMessage.value = `确定要清空回收站吗？将永久删除 ${totalCount.value} 张照片，该操作不可恢复！`
+  pendingDeleteIds.value = []
+  pendingDeleteAll.value = true
+  deleteCallback = null
+}
+
+/** Poll a background purge job until it finishes, keeping the progress bar live. */
+const pollPurgeJob = (jobId: string) => {
+  stopPolling()
+  pollTimer = setTimeout(async () => {
+    try {
+      const { data } = await request.get(`/api/photos/recycle-bin/purge/${jobId}`)
+      purgeProcessed.value = data?.processed ?? purgeProcessed.value
+      purgeTotal.value = data?.total ?? purgeTotal.value
+
+      if (data?.status === 'completed') {
+        finishPurge(`成功永久删除 ${data.deleted ?? purgeTotal.value} 张照片`)
+        return
+      }
+      if (data?.status === 'failed') {
+        finishPurge(null)
+        ElMessage.error(`清理失败：${data.error || '未知错误'}`)
+        return
+      }
+      pollPurgeJob(jobId)
+    } catch (error) {
+      console.error(error)
+      // The job itself may still be running server-side; stop polling and let a
+      // manual refresh reflect reality rather than spinning forever.
+      finishPurge(null)
     }
-    if (deleteCallback) {
+  }, 1000)
+}
+
+const finishPurge = (successMessage: string | null) => {
+  stopPolling()
+  isPurging.value = false
+  purgeProcessed.value = 0
+  purgeTotal.value = 0
+  if (successMessage) ElMessage.success(successMessage)
+  cancelSelection()
+  refresh()
+}
+
+const confirmDelete = async () => {
+  const deleteAll = pendingDeleteAll.value
+  const ids = pendingDeleteIds.value
+  if (!deleteAll && ids.length === 0) return
+
+  showDeleteConfirm.value = false
+
+  try {
+    const { data } = await request.post('/api/photos/recycle-bin/purge', {
+      photo_ids: deleteAll ? null : ids,
+    })
+
+    if (data?.mode === 'async' && data?.job_id) {
+      // Big batch: the server is working in the background. Show progress
+      // instead of blocking the UI on a request that would likely time out.
+      isPurging.value = true
+      purgeTotal.value = data.total ?? ids.length
+      purgeProcessed.value = data.processed ?? 0
+      ElMessage.info(`正在后台清理 ${purgeTotal.value} 张照片，可继续浏览`)
+      pollPurgeJob(data.job_id)
+      if (deleteCallback) {
         deleteCallback(true)
         deleteCallback = null
+      }
+      return
+    }
+
+    const deleted = data?.deleted ?? ids.length
+    ElMessage.success(`成功永久删除 ${deleted} 张照片`)
+
+    if (deleteAll) {
+      photos.value = []
+      totalCount.value = 0
+      hasMore.value = false
+      closeLightbox()
+    } else {
+      photos.value = photos.value.filter(p => !ids.includes(p.id))
+      totalCount.value = Math.max(0, totalCount.value - deleted)
+      if (lightboxImage.value && ids.includes(lightboxImage.value.id)) {
+        closeLightbox()
+      }
+    }
+
+    if (deleteCallback) {
+      deleteCallback(true)
+      deleteCallback = null
     }
     cancelSelection()
   } catch (error) {
     console.error(error)
     ElMessage.error('永久删除失败')
     if (deleteCallback) {
-        deleteCallback(false)
-        deleteCallback = null
+      deleteCallback(false)
+      deleteCallback = null
     }
   } finally {
-    showDeleteConfirm.value = false
     pendingDeleteIds.value = []
+    pendingDeleteAll.value = false
+  }
+}
+
+/** Load the bin size so "select all" / "empty bin" can act on the whole set. */
+const fetchStats = async () => {
+  try {
+    const { data } = await request.get('/api/photos/recycle-bin/stats')
+    // Guard the shape: this path is easy to shadow with a broad `/recycle-bin*`
+    // mock or an older server, and a bad value must not break the page.
+    if (data && typeof data.total === 'number') {
+      totalCount.value = data.total
+      hasStats.value = true
+    }
+    if (data && typeof data.retention_days === 'number' && data.retention_days > 0) {
+      retentionDays.value = data.retention_days
+    }
+  } catch (e) {
+    console.error('Failed to load recycle bin stats', e)
   }
 }
 
@@ -371,6 +630,25 @@ const fetchPhotos = async (isLoadMore = false) => {
     }
     skip.value += data.length
 
+    // Keep a whole-bin selection consistent as new pages arrive, so the
+    // checkmarks match what the pending action will actually delete.
+    if (selectAllAcrossPages.value && mappedPhotos.length > 0) {
+      const newIds = mappedPhotos
+        .map((p: AlbumImage) => p.id)
+        .filter((id: string) => !selectedIds.value.includes(id))
+      if (newIds.length > 0) galleryRef.value?.selectAll(newIds)
+    }
+
+    // The stats endpoint is authoritative for the bin size. Only fall back to
+    // the loaded length when it is unavailable (older server / failed request),
+    // otherwise a short first page would clobber the real total.
+    if (!hasStats.value) {
+      if (!hasMore.value) {
+        totalCount.value = photos.value.length
+      } else if (photos.value.length > totalCount.value) {
+        totalCount.value = photos.value.length
+      }
+    }
   } catch (error) {
     console.error(error)
     ElMessage.error('加载回收站照片失败')
@@ -383,12 +661,17 @@ const loadMore = () => {
   fetchPhotos(true)
 }
 
+const refresh = async () => {
+  await Promise.all([fetchStats(), fetchPhotos(false)])
+}
+
 const handleRestore = async (ids: string[]) => {
   if (ids.length === 0) return
   try {
     await request.post('/api/photos/recycle-bin/restore', { photo_ids: ids })
     ElMessage.success(`成功恢复 ${ids.length} 张照片`)
     photos.value = photos.value.filter(p => !ids.includes(p.id))
+    totalCount.value = Math.max(0, totalCount.value - ids.length)
     cancelSelection()
   } catch (error) {
     console.error(error)
@@ -396,11 +679,37 @@ const handleRestore = async (ids: string[]) => {
   }
 }
 
+/** Restore the entire bin server-side — no id enumeration in the browser. */
+const handleRestoreAll = async () => {
+  if (totalCount.value === 0) {
+    ElMessage.info('回收站已经是空的')
+    return
+  }
+  try {
+    const { data } = await request.post('/api/photos/recycle-bin/restore-all')
+    ElMessage.success(`成功恢复 ${data?.restored ?? totalCount.value} 张照片`)
+    cancelSelection()
+    await refresh()
+  } catch (error) {
+    console.error(error)
+    ElMessage.error('恢复失败')
+  }
+}
+
+const handleRestoreSelection = () => {
+  if (selectAllAcrossPages.value) {
+    handleRestoreAll()
+    return
+  }
+  handleRestore(selectedIds.value)
+}
+
 const scrollContainer = ref<HTMLElement | Window>(window)
 const { y: windowScrollY } = useScroll(scrollContainer)
 
 onMounted(async () => {
   await fetchConfig()
+  fetchStats()
   fetchPhotos()
   
   const mainEl = document.querySelector('main')
@@ -408,6 +717,8 @@ onMounted(async () => {
     scrollContainer.value = mainEl
   }
 })
+
+onUnmounted(stopPolling)
 
 watch(windowScrollY, (y) => {
     if (!hasMore.value || loading.value) return

--- a/package/website/tests/e2e/specs/recycle-bin/recycle-bin-bulk-cleanup.spec.ts
+++ b/package/website/tests/e2e/specs/recycle-bin/recycle-bin-bulk-cleanup.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * P1 - 回收站清理优化（src/views/RecycleBinPage.vue）
+ *
+ * 覆盖本次新增的交互，这些路径原先完全没有 e2e：
+ *  - 「全选」跨页语义：stats 报告 500 项但列表只返回 1 页时，标题应显示总量
+ *    而非已加载数量，并出现「包含尚未加载的 N 项」提示。
+ *  - 「清空回收站」：不带任何 id 调用 POST /purge（photo_ids = null），
+ *    这是不下拉加载也能清空的关键契约。
+ *  - 大批量转异步：purge 返回 mode=async 时出现进度条，并轮询 job 接口，
+ *    完成后刷新列表 —— 前端不再阻塞在一个会超时的请求上。
+ *  - 「加载更多」按钮：无限滚动在嵌套滚动容器下不可靠，显式按钮是兜底。
+ *
+ * 全部用 page.route mock 后端，因此不依赖真实照片数据。注意 mock 顺序：
+ * 更具体的 /stats、/purge 必须在宽泛的列表路由之前注册，否则会被前者吞掉。
+ */
+
+import { test, expect } from '@playwright/test';
+import { ensureAuthSession } from '../../helpers/auth';
+
+/** 造 n 条回收站照片，字段与 mapPhotoToImage 期望的形状一致 */
+function makePhotos(n: number, offset = 0) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `photo-${offset + i}`,
+    filename: `p${offset + i}.jpg`,
+    file_type: 'image',
+    takenAt: new Date(Date.now() - 2 * 86400_000).toISOString(),
+    size: 1234,
+    width: 100,
+    height: 100,
+    deleted_at: new Date(Date.now() - 86400_000).toISOString(),
+  }));
+}
+
+test.describe('P1 - 回收站清理优化 @recycle-bin', () => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    if (!(await ensureAuthSession(request, page, testInfo, { photoBucket: 'smoke' }))) return;
+  });
+
+  test('stats 提供总量 - 标题显示「共 N 项」而非已加载数', async ({ page }) => {
+    await page.route('**/api/photos/recycle-bin/stats**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: { total: 500, retention_days: 7 } }),
+      }),
+    );
+    // 列表只回 3 条，与 total=500 故意不一致，用于证明总量来自 stats
+    await page.route('**/api/photos/recycle-bin?**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: makePhotos(3) }),
+      }),
+    );
+
+    await page.goto('/recycle-bin');
+    await expect(page.getByText('共 500 项')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('清空回收站 - 请求体 photo_ids 为 null（无需枚举 id）', async ({ page }) => {
+    await page.route('**/api/photos/recycle-bin/stats**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: { total: 42, retention_days: 7 } }),
+      }),
+    );
+
+    let purgeBody: any = null;
+    await page.route('**/api/photos/recycle-bin/purge', async (route) => {
+      purgeBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 0,
+          msg: 'success',
+          data: { mode: 'sync', total: 42, deleted: 42, message: 'ok' },
+        }),
+      });
+    });
+
+    await page.route('**/api/photos/recycle-bin?**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: makePhotos(2) }),
+      }),
+    );
+
+    await page.goto('/recycle-bin');
+    await expect(page.getByText('共 42 项')).toBeVisible({ timeout: 10_000 });
+
+    // 桌面端「更多操作」下拉里的「清空回收站」
+    await page.locator('button[title="更多操作"]').click();
+    await page.getByText('清空回收站').click();
+
+    // 确认对话框
+    const confirmBtn = page.getByRole('button', { name: '确定' }).last();
+    await expect(confirmBtn).toBeVisible({ timeout: 5_000 });
+    await confirmBtn.click();
+
+    await expect.poll(() => purgeBody, { timeout: 8_000 }).not.toBeNull();
+    // 关键契约：清空不枚举 id
+    expect(purgeBody).toHaveProperty('photo_ids', null);
+  });
+
+  test('大批量转异步 - 出现进度条并轮询 job 状态', async ({ page }) => {
+    await page.route('**/api/photos/recycle-bin/stats**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: { total: 5000, retention_days: 7 } }),
+      }),
+    );
+
+    await page.route('**/api/photos/recycle-bin/purge', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 0,
+          msg: 'success',
+          data: { mode: 'async', job_id: 'job-e2e', status: 'running', total: 5000, processed: 0, progress: 0 },
+        }),
+      }),
+    );
+
+    let polls = 0;
+    await page.route('**/api/photos/recycle-bin/purge/job-e2e', (route) => {
+      polls += 1;
+      // 前两次仍在跑，第三次完成 —— 验证轮询真的在循环
+      const done = polls >= 3;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 0,
+          msg: 'success',
+          data: {
+            job_id: 'job-e2e',
+            status: done ? 'completed' : 'running',
+            total: 5000,
+            processed: done ? 5000 : 2000,
+            deleted: done ? 5000 : 0,
+            progress: done ? 100 : 40,
+          },
+        }),
+      });
+    });
+
+    await page.route('**/api/photos/recycle-bin?**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: makePhotos(2) }),
+      }),
+    );
+
+    await page.goto('/recycle-bin');
+    await expect(page.getByText('共 5000 项')).toBeVisible({ timeout: 10_000 });
+
+    await page.locator('button[title="更多操作"]').click();
+    await page.getByText('清空回收站').click();
+    await page.getByRole('button', { name: '确定' }).last().click();
+
+    // 进度条出现，说明没有阻塞在同步请求上
+    await expect(page.getByText('正在清理回收站…')).toBeVisible({ timeout: 8_000 });
+    // 轮询确实发生了多次
+    await expect.poll(() => polls, { timeout: 15_000 }).toBeGreaterThanOrEqual(3);
+    // 完成后进度条消失
+    await expect(page.getByText('正在清理回收站…')).toBeHidden({ timeout: 10_000 });
+  });
+
+  test('「加载更多」按钮存在并追加下一页', async ({ page }) => {
+    await page.route('**/api/photos/recycle-bin/stats**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: { total: 400, retention_days: 7 } }),
+      }),
+    );
+
+    // 第一页满 200 条 => hasMore=true => 按钮可见
+    let call = 0;
+    await page.route('**/api/photos/recycle-bin?**', (route) => {
+      const page1 = call === 0;
+      call += 1;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 0,
+          msg: 'success',
+          data: page1 ? makePhotos(200) : makePhotos(5, 200),
+        }),
+      });
+    });
+
+    await page.goto('/recycle-bin');
+    const moreBtn = page.getByRole('button', { name: /加载更多/ });
+    await expect(moreBtn).toBeVisible({ timeout: 10_000 });
+
+    await moreBtn.click();
+    // 第二页返回 5 条(<200) => hasMore=false => 按钮消失
+    await expect(moreBtn).toBeHidden({ timeout: 10_000 });
+    await expect(page.getByText(/已加载 205/)).toBeVisible();
+  });
+
+  test('stats 接口异常时页面仍可用（降级不崩）', async ({ page }) => {
+    await page.route('**/api/photos/recycle-bin/stats**', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }),
+    );
+    await page.route('**/api/photos/recycle-bin?**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, msg: 'success', data: makePhotos(3) }),
+      }),
+    );
+
+    await page.goto('/recycle-bin');
+
+    // 列表照常渲染，标题仍在，说明 stats 失败只是降级
+    await expect(page.locator('h1', { hasText: '最近删除' })).toBeVisible({ timeout: 10_000 });
+    await expect(page).toHaveURL(/\/recycle-bin/);
+  });
+});


### PR DESCRIPTION
清空大回收站会让后端长时间无响应、前端请求超时。根因有三处：

1. batch_delete_photos_db 逐张处理：每张照片触发一次人脸依赖 SELECT、 两次聚类查询、一次 ORM 级联删除（懒加载四张子表），且每个受影响相册 单独 commit。1 万张照片产生 13 万条 SQL，全部挤在一个事务里， 写锁长期不释放导致其他请求排队。
2. album_photos / photo_clusters 缺少 photo_id 索引，删除时数据库需全表 扫描才能执行 ON DELETE CASCADE，使耗时随数据量超线性恶化。
3. 前端全选只覆盖已加载的 100 条，且后端没有清空接口，用户必须反复下拉 到底才能全选，上万张照片还要把 id 全塞进请求体。

后端改动：
- batch_delete_photos_db 改为集合化，按 200 条分块提交：单条 DELETE 配合 FK 级联替代 ORM 级联，人脸默认头像与聚类计数批量修正，文件删除移到 commit 之后并行执行。分块提交让写锁频繁释放，并通过 progress_cb 上报进度。
- 新增 count_recycle_bin_photos / get_recycle_bin_photo_ids，使"选择全部 N 项" 与"清空回收站"无需客户端枚举 id。
- 新增 recycle_bin_purge 服务：超过 200 张转后台线程执行，返回 job_id 供轮询， 避免请求超时；限制并发任务数并按用户隔离任务可见性。
- 新增接口 GET /recycle-bin/stats、POST /recycle-bin/purge、 GET /recycle-bin/purge/{job_id}、POST /recycle-bin/restore-all。
- 补 album_photos、photo_clusters 索引及 PG / SQLite 迁移。PG 侧使用 CREATE INDEX CONCURRENTLY 避免锁表，并会清理中断遗留的 INVALID 索引。 photo_tag_relations 的唯一约束已以 photo_id 为前导列，无需额外索引。

顺带修复的既有缺陷：
- RecyclePhoto.deleted_at 原为必填，但该列可为空。一行缺失时间戳的数据会让 整个回收站列表接口返回 500 且用户无法自救，现改为可选。
- remove_photo_from_clusters 在多张照片同属一个聚类时，计数每次只减 1， 批量版本按实际移除数量扣减。

前端改动：
- 全选改为跨页语义（基于 stats 总量），并显式提示包含未加载项；取消勾选任一 项会自动退出跨页选择，避免误删。
- 新增"清空回收站""全部恢复"入口、后台任务进度条、显式"加载更多"按钮， 单页 100 提升至 200。

实测（真实 PostgreSQL，1 万张，每张含元数据/人脸/描述/相册/聚类）：
耗时 22.209s -> 0.854s（26x），SQL 131005 -> 2404 条，
清理期间并发读最差延迟 60ms -> 8ms，耗时恢复线性增长。

测试：新增 36 个后端用例（含真实后台线程与 HTTP 层集成）、5 个 e2e；
回收站 e2e 12/12 通过；受影响模块 129 个用例全绿。

## 描述
<!-- 请简要描述您的更改。如果是修复 Bug，请链接相关 Issue。 -->

## 变更类型
<!-- 请删除不相关的选项 -->
- [ ] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [ ] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue
<!-- 例如：Fixes #123 -->

## 如何测试
<!-- 请描述您是如何测试这些更改的 -->

## 检查清单
- [ ] 我已阅读并遵循项目的贡献指南
- [ ] 我的代码遵循项目的代码风格
- [ ] 我已添加/更新了必要的测试
- [ ] 所有测试均已通过
- [ ] 我已更新了相关文档
