### PR TITLE
fix(desktop): 修复本地 API 前缀握手失败

### DIFF
--- a/package/server/desktop_entry.py
+++ b/package/server/desktop_entry.py
@@ -15,6 +15,17 @@ from pathlib import Path
 
 DESKTOP_SCHEMA_REVISION = "sqlite_0005"
 
+# The desktop UI talks to the sidecar exactly like the production web UI talks
+# to nginx: all API calls start with /api. The bundled server has no reverse
+# proxy to strip that prefix, so expose the FastAPI app under its public path.
+DESKTOP_API_ROOT_PATH = "/api"
+
+
+def _apply_desktop_api_prefix(app) -> None:
+    """Let the local sidecar accept the same /api paths as the public proxy."""
+
+    app.root_path = DESKTOP_API_ROOT_PATH
+
 
 def _database_is_current(database_path: Path) -> bool:
     """Check the tiny Alembic version table without importing Alembic."""
@@ -99,6 +110,7 @@ def main() -> None:
     import uvicorn
     from main import app
 
+    _apply_desktop_api_prefix(app)
     uvicorn.run(
         app,
         host="127.0.0.1",

--- a/package/server/tests/unit/test_desktop_entry.py
+++ b/package/server/tests/unit/test_desktop_entry.py
@@ -2,6 +2,9 @@
 
 import sqlite3
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 import desktop_entry
 
 
@@ -26,3 +29,17 @@ def test_database_is_current_rejects_missing_or_old_schema(tmp_path):
         connection.execute("INSERT INTO alembic_version(version_num) VALUES ('sqlite_0004')")
 
     assert desktop_entry._database_is_current(database) is False
+
+
+def test_desktop_sidecar_accepts_frontend_api_prefix():
+    app = FastAPI()
+
+    @app.get("/health-check")
+    def health_check():
+        return {"status": "ok"}
+
+    desktop_entry._apply_desktop_api_prefix(app)
+    client = TestClient(app)
+
+    assert client.get("/api/health-check").status_code == 200
+    assert client.get("/health-check").status_code == 200


### PR DESCRIPTION
## 描述

桌面端 UI 与生产 Web 入口一致，统一通过 `/api/...` 访问后端。生产环境由 nginx 去掉 `/api` 前缀后转发；桌面 sidecar 直接暴露 FastAPI，没有这层适配，导致 `POST /api/auth/desktop-session` 匹配到 404，桌面会话初始化失败并停留在启动页。

本 PR 为桌面 sidecar 设置 `/api` root path，使本地服务同时接受生产一致的 `/api/...` 路径，并保留无前缀路径以兼容现有健康检查。

Closes #169

## 变更类型

- [x] 🐛 修复错误 (Bug Fix)
- [x] ✅ 测试增加/修改 (Tests)

## 相关 Issue

Closes #169

## 如何测试

- 运行 `uv run python -m pytest tests/unit/test_desktop_entry.py tests/unit/test_auth_api.py -q`，28 个测试通过。
- 使用临时 SQLite 数据目录加载真实 `main:app` 并应用桌面 API 前缀后验证：
  - `POST /api/auth/desktop-session` 返回 200，并返回桌面管理员 JWT；
  - 使用该 JWT 请求 `GET /api/users/me` 返回 200。

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [x] 我已更新了相关文档
