### PR TITLE
perf(face): run clustering as its own task instead of inside recognition

### DIFF
--- a/package/server/app/crud/task.py
+++ b/package/server/app/crud/task.py
@@ -94,7 +94,7 @@ def get_grouped_status(db: Session, paused_categories: set) -> List[Dict[str, An
     stats = []
     categories = [
         TaskType.PROCESS_BASIC, TaskType.EXTRACT_METADATA,
-        TaskType.RECOGNIZE_FACE, TaskType.RECOGNIZE_TICKET,
+        TaskType.RECOGNIZE_FACE, TaskType.CLUSTER_FACES, TaskType.RECOGNIZE_TICKET,
         TaskType.CLASSIFY_IMAGE, TaskType.VISUAL_DESCRIPTION,
         TaskType.OCR, TaskType.IMAGE_EMBEDDING, TaskType.GENERATE_THUMBNAIL
     ]

--- a/package/server/app/db/models/task.py
+++ b/package/server/app/db/models/task.py
@@ -20,6 +20,10 @@ class TaskType(str, enum.Enum):
     EXTRACT_METADATA = "EXTRACT_METADATA" # Heavy metadata, geolocation
     CLASSIFY_IMAGE = "CLASSIFY_IMAGE"
     RECOGNIZE_FACE = "RECOGNIZE_FACE"
+    # Clustering is deliberately a separate type from RECOGNIZE_FACE: it is a
+    # CPU-bound whole-library pass, so running it inline held the single 'face'
+    # resource slot and blocked further recognition batches.
+    CLUSTER_FACES = "CLUSTER_FACES"
     RECOGNIZE_TICKET = "RECOGNIZE_TICKET"
     REBUILD_METADATA = "REBUILD_METADATA"
     OCR = "OCR"
@@ -45,6 +49,11 @@ DEFAULT_PRIORITIES = {
     TaskType.EXTRACT_METADATA: 97,
     TaskType.REBUILD_METADATA: 96,
     TaskType.RECOGNIZE_FACE: 9,
+    # Below RECOGNIZE_FACE so a fresh import round finishes recognising before
+    # the clustering row is picked up. Priority alone is not enough (the two
+    # types live in different category queues), hence the explicit defer guard
+    # in ClusterFacesStrategy.
+    TaskType.CLUSTER_FACES: 3,
     TaskType.CLASSIFY_IMAGE: 10,
     TaskType.IMAGE_EMBEDDING: 8,
     TaskType.OCR: 7,
@@ -65,6 +74,7 @@ CATEGORY_DESCRIPTION_MAP = {
     TaskType.EXTRACT_METADATA: '用于提取文件元数据（GPS位置、拍摄参数等）',
     TaskType.REBUILD_METADATA: '用于重建文件元数据',
     TaskType.RECOGNIZE_FACE: '用于识别图片中的人脸',
+    TaskType.CLUSTER_FACES: '用于将识别出的人脸聚合成人物',
     TaskType.RECOGNIZE_TICKET: '用于识别火车票、飞机票等',
     TaskType.CLASSIFY_IMAGE: '用于场景分类',
     TaskType.VISUAL_DESCRIPTION: '用于生成图片的视觉描述',
@@ -84,6 +94,7 @@ CATEGORY_NAME_MAP = {
     TaskType.PROCESS_BASIC: '基本处理',
     TaskType.EXTRACT_METADATA: '元数据提取',
     TaskType.RECOGNIZE_FACE: '人脸识别',
+    TaskType.CLUSTER_FACES: '人脸聚类',
     TaskType.RECOGNIZE_TICKET: '车票识别',
     TaskType.CLASSIFY_IMAGE: '场景识别',
     TaskType.VISUAL_DESCRIPTION: '大模型智能分析',

--- a/package/server/app/service/face_cluster.py
+++ b/package/server/app/service/face_cluster.py
@@ -675,8 +675,12 @@ class FaceClusterService:
         对未分配的人脸做DBSCAN聚类，合并相似簇后创建新Identity
         """
         try:
-            # 1. 查询未分配的人脸
-            unassigned_query = self.db.query(Face).filter(
+            # 1. 查询未分配的人脸。
+            # Only the id and the embedding are needed, so select scalars
+            # instead of whole ORM entities: hydrating a Face object per
+            # unassigned face was a large part of the runtime and of the peak
+            # RSS on six-figure libraries.
+            unassigned_query = self.db.query(Face.id, Face.face_feature).filter(
                 Face.face_identity_id == None,
                 Face.is_deleted == False,
                 Face.face_feature.isnot(None)
@@ -693,7 +697,7 @@ class FaceClusterService:
                         )
                     )
                 )
-            unassigned_faces = unassigned_query.all()
+            unassigned_faces = unassigned_query.order_by(Face.id).all()
 
             face_count = len(unassigned_faces)
             if face_count < self.DBSCAN_MIN_SAMPLES:
@@ -702,16 +706,18 @@ class FaceClusterService:
             # 2. 提取并归一化向量
             embeddings = []
             face_ids = []
-            for face in unassigned_faces:
-                emb = self.normalize_embedding(face.face_feature)
+            for face_id, face_feature in unassigned_faces:
+                emb = self.normalize_embedding(face_feature)
                 embeddings.append(emb)
-                face_ids.append(face.id)
+                face_ids.append(face_id)
 
-            X = np.array(embeddings)
+            X = np.asarray(embeddings, dtype=np.float32)
+
+            logger.info("开始对 %s 个未分配人脸聚类（owner=%s）", face_count, owner_id)
 
             # 3. DBSCAN聚类（宽松参数，避免拆分）
             clustering = DBSCAN(
-                eps=config_manager.config.ai.face_cluster_threshold,
+                eps=self.DBSCAN_EPS,
                 min_samples=self.DBSCAN_MIN_SAMPLES,
                 metric='cosine'
             ).fit(X)
@@ -776,30 +782,37 @@ class FaceClusterService:
                 create_identity_data = schemas.FaceIdentityCreate(identity_name="未命名")
                 new_identity = crud_face.create_identity(self.db, create_identity_data, owner_id)
 
-                # 分配人脸到新Identity
-                first_face_id = None
-                for f_id in cluster:
-                    face = crud_face.get_face(self.db, f_id)
-                    if not face:
-                        continue
+                # 分配人脸到新Identity。
+                # One bulk UPDATE per cluster instead of a get_face +
+                # update_face round trip per member: a 1000-face cluster used
+                # to cost 2000 statements.
+                assigned_ids = [
+                    row[0]
+                    for row in self.db.query(Face.id).filter(
+                        Face.id.in_(cluster),
+                        Face.is_deleted.is_(False),
+                    ).order_by(Face.id).all()
+                ]
+                if not assigned_ids:
+                    continue
 
-                    update_data = schemas.FaceUpdate(
-                        face_identity_id=new_identity.id,
-                        recognize_confidence=0.9
-                    )
-                    crud_face.update_face(self.db, f_id, update_data)
-
-                    if not first_face_id:
-                        first_face_id = face.id
+                self.db.query(Face).filter(Face.id.in_(assigned_ids)).update(
+                    {
+                        Face.face_identity_id: new_identity.id,
+                        Face.recognize_confidence: 0.9,
+                    },
+                    synchronize_session=False,
+                )
 
                 # 设置默认人脸
-                if first_face_id:
-                    update_identity_data = schemas.FaceIdentityUpdate(default_face_id=first_face_id)
-                    crud_face.update_identity(self.db, new_identity.id, update_identity_data)
+                update_identity_data = schemas.FaceIdentityUpdate(default_face_id=assigned_ids[0])
+                crud_face.update_identity(self.db, new_identity.id, update_identity_data)
 
                 logger.info(
-                    f"创建新Identity {new_identity.id}，包含 {cluster_size} 个人脸（合并后）"
+                    f"创建新Identity {new_identity.id}，包含 {len(assigned_ids)} 个人脸（合并后）"
                 )
+
+            self.db.commit()
 
         except PendingRollbackError:
             self.db.rollback()

--- a/package/server/app/service/task_worker.py
+++ b/package/server/app/service/task_worker.py
@@ -26,7 +26,7 @@ from app.crud import task as crud_task
 from app.service.task_strategy import TaskStrategyFactory
 from app.service.adaptive_limiter import AdaptiveResourceLimiter
 # Import tasks to register strategies
-from app.service.tasks import thumbnail, metadata, album, scan, face, ocr, classification, image_embedding, visual_description, basic, duplicate, similar, tickets, organize, rename, time_from_filename, emotion
+from app.service.tasks import thumbnail, metadata, album, scan, face, face_cluster, ocr, classification, image_embedding, visual_description, basic, duplicate, similar, tickets, organize, rename, time_from_filename, emotion
 
 class TaskQueueManager:
     def __init__(self):
@@ -91,6 +91,10 @@ def get_chunk_size(task_type):
         chunk_size = 2 if level == 'high' else 1
     elif task_type == TaskType.RECOGNIZE_FACE:
         chunk_size = 4 if level == 'high' else 2
+    elif task_type == TaskType.CLUSTER_FACES:
+        # One whole-library pass per batch. Batching several owners together
+        # would serialise their clustering inside a single timeout window.
+        chunk_size = 1
     elif task_type == TaskType.PROCESS_BASIC or task_type == TaskType.EXTRACT_METADATA:
         chunk_size = 16
     elif task_type == TaskType.CLASSIFY_IMAGE:
@@ -241,6 +245,10 @@ class TaskWorker:
             "classification": 1,
             "ocr": 1,
             "face": 1,
+            # Own slot so clustering never competes with recognition. Kept at 1
+            # on every level: the pass is single-threaded CPU work and running
+            # several at once would starve the rest of the pipeline.
+            "face_cluster": 1,
             "embedding": 1,
             "tickets": 1,
             "visual_llm": 1,

--- a/package/server/app/service/tasks/face.py
+++ b/package/server/app/service/tasks/face.py
@@ -9,6 +9,7 @@ from app.db.models.task import Task, TaskType
 from app.db.models.photo import Photo, FileType
 from app.db.models.face import Face
 from app.service.face_cluster import FaceClusterService, crud_face
+from app.service.tasks.face_cluster import enqueue_cluster_faces
 from typing import Dict, Any, List
 from app.core.config_manager import config_manager
 from app.service import storage
@@ -225,17 +226,21 @@ class RecognizeFaceStrategy(BaseTaskStrategy):
                                     count += 1
                                     if face.face_feature:
                                         try:
-                                            assigned_id = cluster_service.assign_face_to_identity(face.id, face.face_feature)
+                                            # owner_id must be passed: without
+                                            # it the pgvector nearest-neighbour
+                                            # query scans every user's faces.
+                                            assigned_id = cluster_service.assign_face_to_identity(
+                                                face.id, face.face_feature, owner_id
+                                            )
                                             if not assigned_id:
                                                 has_unassigned = True
                                         except Exception as ce:
                                             logger.error(f"Clustering failed for face {face.id}: {ce}")
                                 if has_unassigned:
-                                    # Defer clustering to the end of the batch:
-                                    # process_unassigned_faces rescans every
-                                    # unassigned face in the library, so running
-                                    # it per photo repeated the same O(n^2)
-                                    # DBSCAN once per photo.
+                                    # Commit the faces so the clustering task
+                                    # can see them. Clustering itself is now a
+                                    # separate CLUSTER_FACES task registered in
+                                    # handle_completion.
                                     batch_has_unassigned = True
                                     db.commit()
 
@@ -253,14 +258,19 @@ class RecognizeFaceStrategy(BaseTaskStrategy):
                                     'task_id': task.id,
                                     'task_type': task.type,
                                     'status': 'completed',
-                                    'result': {'status': 'success', 'faces_found': count}
+                                    'result': {
+                                        'status': 'success',
+                                        'faces_found': count,
+                                        'has_unassigned': has_unassigned,
+                                        'owner_id': str(owner_id) if owner_id else None,
+                                    }
                                 })
 
                             if batch_has_unassigned:
-                                try:
-                                    cluster_service.process_unassigned_faces(owner_id)
-                                except Exception as ce:
-                                    logger.error(f"Batch clustering failed: {ce}")
+                                logger.info(
+                                    "Owner %s has unassigned faces; clustering deferred to a CLUSTER_FACES task",
+                                    owner_id,
+                                )
                         else:
                             err_msg = f"AI Service error: {resp.status}"
                             for task in valid_tasks:
@@ -327,19 +337,21 @@ class RecognizeFaceStrategy(BaseTaskStrategy):
                             count += 1
                             if face.face_feature:
                                 try:
-                                    assigned_id = cluster_service.assign_face_to_identity(face.id, face.face_feature)
+                                    assigned_id = cluster_service.assign_face_to_identity(
+                                        face.id, face.face_feature, photo.owner_id
+                                    )
                                     if not assigned_id:
                                         has_unassigned = True
                                 except Exception as ce:
                                     logging.error(f"Clustering failed for face {face.id}: {ce}")
 
                         if has_unassigned:
-                             # Commit faces first to ensure they exist for clustering
+                             # Commit faces first so the clustering task can see
+                             # them. Clustering itself runs as a separate
+                             # CLUSTER_FACES task, not inline: doing it here
+                             # held the single 'face' resource slot and blocked
+                             # all further recognition.
                              db.commit()
-                             try:
-                                 cluster_service.process_unassigned_faces(photo.owner_id)
-                             except Exception as ce:
-                                 logging.error(f"Batch clustering failed: {ce}")
 
                         tasks_status = dict(photo.processed_tasks or {})
                         tasks_status['face'] = True
@@ -351,7 +363,12 @@ class RecognizeFaceStrategy(BaseTaskStrategy):
                             from app.crud.album import trigger_conditional_albums_update
                             trigger_conditional_albums_update(db, photo.owner_id, [photo.id])
                             
-                        return {'status': 'success', 'faces_found': count}
+                        return {
+                            'status': 'success',
+                            'faces_found': count,
+                            'has_unassigned': has_unassigned,
+                            'owner_id': str(photo.owner_id) if photo.owner_id else None,
+                        }
                     else:
                         return {'status': 'failed', 'error': f"AI Service error: {resp.status}"}
         except Exception as e:
@@ -362,6 +379,31 @@ class RecognizeFaceStrategy(BaseTaskStrategy):
             db.add(photo)
             db.commit()
             raise e
+
+    async def handle_completion(self, worker, items: List[Dict], db: Session) -> None:
+        """Register one clustering task per owner that produced unassigned faces.
+
+        ``enqueue_cluster_faces`` reuses an outstanding PENDING/PROCESSING row,
+        so a large import round collapses into a single clustering pass instead
+        of one per batch.
+        """
+        owner_ids = set()
+        for item in items:
+            if item.get('status') != 'completed':
+                continue
+            result = item.get('result')
+            if not isinstance(result, dict) or not result.get('has_unassigned'):
+                continue
+            owner_id = result.get('owner_id')
+            if owner_id:
+                owner_ids.add(owner_id)
+
+        for owner_id in owner_ids:
+            try:
+                enqueue_cluster_faces(db, owner_id)
+            except Exception as exc:
+                db.rollback()
+                logger.error(f"Failed to enqueue face clustering for owner {owner_id}: {exc}")
 
     def release_resources(self) -> None:
         pass

--- a/package/server/app/service/tasks/face_cluster.py
+++ b/package/server/app/service/tasks/face_cluster.py
@@ -1,0 +1,174 @@
+"""Standalone face-clustering task.
+
+Clustering used to run inline at the end of every ``RECOGNIZE_FACE`` batch.
+That was wrong for three independent reasons, all of which showed up together
+on a NAS deployment as "recognition is slow, the AI container is idle, and the
+server container burns 90%+ CPU":
+
+1. ``resource_key == 'face'`` is limited to 1 concurrent slot (2 on
+   medium/high). The slot is held for the whole of ``process_batch``, so a
+   multi-minute clustering pass inside it stopped every further recognition
+   batch from being dispatched at all.
+2. ``process_unassigned_faces`` is synchronous CPU work. Called from a
+   coroutine it blocks the worker's event loop, freezing the producer loop,
+   the other two consumers and SSE progress. ``asyncio.wait_for`` cannot
+   interrupt it either, so the batch timeout was ineffective.
+3. It ran once per batch (previously once per photo), repeating the same
+   whole-library O(n^2) DBSCAN pass over and over during a large import.
+
+Splitting it out fixes all three: clustering now runs on the CPU queue under
+its own resource key, off the event loop, and at most once per import round.
+"""
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.db.models.task import Task, TaskStatus, TaskType
+from app.service.task_strategy import BaseTaskStrategy, TaskStrategyFactory
+
+logger = logging.getLogger(__name__)
+
+# How long to wait before re-checking whether recognition has finished.
+DEFER_SECONDS = 60
+
+
+def enqueue_cluster_faces(db: Session, owner_id) -> Optional[Task]:
+    """Register at most one outstanding clustering task per owner.
+
+    Called from ``RecognizeFaceStrategy.handle_completion``. Reusing an
+    existing PENDING/PROCESSING row is what collapses a whole import round
+    into a single clustering pass.
+    """
+    if owner_id is None:
+        return None
+
+    from app.crud import task as crud_task
+
+    existing = crud_task.get_latest_task_by_type_and_owner(
+        db,
+        TaskType.CLUSTER_FACES,
+        owner_id,
+        [TaskStatus.PENDING, TaskStatus.PROCESSING],
+    )
+    if existing:
+        return existing
+
+    return crud_task.add_task(
+        db,
+        TaskType.CLUSTER_FACES,
+        {'owner_id': str(owner_id)},
+        owner_id=owner_id,
+    )
+
+
+def _cluster_in_thread(owner_id: UUID) -> None:
+    """Run the clustering pass with its own Session.
+
+    A ``Session`` is not thread-safe, so the caller's session must not be
+    reused here. This function is the executor payload; keep it free of any
+    ORM object that came from another thread.
+    """
+    from app.db.session import SessionLocal
+    from app.service.face_cluster import FaceClusterService
+
+    db = SessionLocal()
+    try:
+        FaceClusterService(db, owner_id).process_unassigned_faces(owner_id)
+    finally:
+        db.close()
+
+
+@TaskStrategyFactory.register(TaskType.CLUSTER_FACES)
+class ClusterFacesStrategy(BaseTaskStrategy):
+    @property
+    def task_category(self) -> str:
+        return 'CPU'
+
+    @property
+    def resource_key(self) -> str:
+        # Deliberately not 'face': sharing the recognition key would recreate
+        # the stall this task type exists to remove.
+        return 'face_cluster'
+
+    @property
+    def timeout(self) -> int:
+        # A whole-library DBSCAN pass on a six-figure library takes far longer
+        # than the 5 minute default. Timing out here would also be counted as
+        # a transient failure and retried, burning the same CPU three times.
+        return 60 * 60
+
+    async def process(self, worker, task: Task, db: Session) -> Optional[Dict[str, Any]]:
+        owner_id = task.owner_id
+        if owner_id is None:
+            return {'status': 'skipped', 'reason': 'missing owner_id'}
+
+        if self._recognition_in_flight(db, owner_id):
+            self._defer(db, task)
+            logger.info(
+                "Deferring face clustering for owner %s: recognition still running",
+                owner_id,
+            )
+            return None
+
+        loop = asyncio.get_running_loop()
+        # ``None`` uses the loop's default executor on purpose.
+        # ``worker.thread_pool`` is torn down by ``_manage_pool_lifecycle``
+        # whenever no IO task is active, which could kill a running pass.
+        await loop.run_in_executor(None, _cluster_in_thread, owner_id)
+        return {'status': 'success'}
+
+    async def process_batch(self, worker, tasks: List[Task], db: Session) -> List[Dict]:
+        results = []
+        for task in tasks:
+            try:
+                res = await self.process(worker, task, db)
+            except Exception as exc:
+                logger.error("Face clustering task %s failed: %s", task.id, exc, exc_info=True)
+                results.append({
+                    'task_id': task.id,
+                    'task_type': task.type,
+                    'status': 'failed',
+                    'error': str(exc),
+                })
+                continue
+
+            if res is None:
+                # Deferred. The row is back to PENDING with next_retry_at set;
+                # omitting it from ``results`` is what keeps _flush_results
+                # from treating it as completed and deleting it. Returning
+                # something like {'status': 'deferred'} would silently drop
+                # the task and clustering would never happen.
+                continue
+
+            results.append({
+                'task_id': task.id,
+                'task_type': task.type,
+                'status': 'completed',
+                'result': res,
+            })
+        return results
+
+    @staticmethod
+    def _recognition_in_flight(db: Session, owner_id) -> bool:
+        return db.query(Task.id).filter(
+            Task.type == TaskType.RECOGNIZE_FACE,
+            Task.owner_id == owner_id,
+            Task.status.in_([TaskStatus.PENDING, TaskStatus.PROCESSING]),
+        ).first() is not None
+
+    @staticmethod
+    def _defer(db: Session, task: Task) -> None:
+        task.status = TaskStatus.PENDING
+        task.next_retry_at = datetime.now() + timedelta(seconds=DEFER_SECONDS)
+        task.error = None
+        # attempt_count is intentionally left alone: waiting for recognition is
+        # not a failed attempt, and a long import would otherwise exhaust
+        # max_attempts and mark clustering FAILED.
+        db.commit()
+
+    def release_resources(self) -> None:
+        pass

--- a/package/server/tests/unit/test_face_cluster_task_split.py
+++ b/package/server/tests/unit/test_face_cluster_task_split.py
@@ -1,0 +1,299 @@
+"""Regression tests for the standalone CLUSTER_FACES task.
+
+Clustering used to run inline inside RECOGNIZE_FACE. The three properties
+asserted here are exactly the ones whose absence caused the NAS symptom
+"recognition is slow, AI container idle, server container at 90%+ CPU":
+
+* it does not share the recognition resource slot,
+* it does not block the event loop,
+* deferring must not silently drop the task (the worker deletes anything it
+  sees as completed, so a ``{'status': 'deferred'}`` return value would mean
+  clustering never happens).
+"""
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+_UNSET = object()
+
+
+def _task(owner_id=_UNSET, **kw):
+    base = {
+        "id": uuid4(),
+        "type": "CLUSTER_FACES",
+        "owner_id": uuid4() if owner_id is _UNSET else owner_id,
+        "payload": {},
+        "status": "processing",
+        "attempt_count": 1,
+        "next_retry_at": None,
+        "error": "previous",
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _strategy():
+    from app.service.tasks.face_cluster import ClusterFacesStrategy
+
+    return ClusterFacesStrategy()
+
+
+def _db(recognition_pending: bool):
+    db = MagicMock(name="db")
+    q = MagicMock()
+    q.filter.return_value = q
+    q.first.return_value = object() if recognition_pending else None
+    db.query.return_value = q
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Strategy declaration
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_faces_uses_cpu_queue_and_dedicated_resource_key():
+    s = _strategy()
+    assert s.task_category == "CPU"
+    # Sharing 'face' would hold the single recognition slot, which is the
+    # stall this task type exists to remove.
+    assert s.resource_key == "face_cluster"
+
+
+def test_cluster_faces_timeout_is_longer_than_the_default():
+    from app.service.task_strategy import BaseTaskStrategy
+
+    # The 5 minute default would abort a large pass, and the timeout message
+    # matches _is_retryable_error, so the same CPU work would be burned three
+    # times before the task finally failed.
+    assert _strategy().timeout > BaseTaskStrategy.timeout.fget(BaseTaskStrategy)
+    assert _strategy().timeout == 3600
+
+
+def test_cluster_faces_is_registered_with_a_dedicated_chunk_size():
+    from app.db.models.task import TaskType
+    from app.service.task_strategy import TaskStrategyFactory
+    from app.service.task_worker import get_chunk_size
+
+    assert TaskStrategyFactory.get_strategy(TaskType.CLUSTER_FACES) is not None
+    # Batching several owners together would serialise their passes inside one
+    # timeout window.
+    assert get_chunk_size(TaskType.CLUSTER_FACES) == 1
+
+
+def test_cluster_faces_priority_is_below_recognition():
+    from app.db.models.task import DEFAULT_PRIORITIES, TaskType
+
+    assert (
+        DEFAULT_PRIORITIES[TaskType.CLUSTER_FACES]
+        < DEFAULT_PRIORITIES[TaskType.RECOGNIZE_FACE]
+    )
+
+
+def test_cluster_faces_resource_limit_stays_one_on_every_level():
+    from app.service import task_worker
+
+    worker = task_worker.TaskWorker()
+    for level in ("low", "medium", "high"):
+        with patch.object(task_worker, "resolve_concurrency_level", lambda _l, _v=level: _v):
+            assert worker._get_resource_limits()["face_cluster"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Defer guard
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_faces_defers_while_recognition_is_in_flight():
+    db = _db(recognition_pending=True)
+    task = _task()
+    s = _strategy()
+
+    with patch("app.service.tasks.face_cluster._cluster_in_thread") as cluster:
+        result = _run(s.process(MagicMock(), task, db))
+
+    cluster.assert_not_called()
+    assert result is None
+    assert task.status == "pending"
+    assert isinstance(task.next_retry_at, datetime)
+    db.commit.assert_called_once()
+
+
+def test_cluster_faces_defer_does_not_consume_a_retry_attempt():
+    """Waiting is not a failed attempt.
+
+    Counting it would let a long import exhaust max_attempts and mark
+    clustering FAILED.
+    """
+    db = _db(recognition_pending=True)
+    task = _task(attempt_count=2)
+    _run(_strategy().process(MagicMock(), task, db))
+    assert task.attempt_count == 2
+
+
+def test_cluster_faces_deferred_task_is_omitted_from_results():
+    """A deferred row must not be reported as completed.
+
+    ``_flush_results`` deletes every completed task, so reporting the defer
+    would drop the row and clustering would never run.
+    """
+    db = _db(recognition_pending=True)
+    task = _task()
+    results = _run(_strategy().process_batch(MagicMock(), [task], db))
+    assert results == []
+
+
+def test_cluster_faces_defer_guard_is_scoped_to_the_owner():
+    from app.db.models.task import Task
+
+    db = _db(recognition_pending=False)
+    task = _task()
+    with patch("app.service.tasks.face_cluster._cluster_in_thread"):
+        _run(_strategy().process(MagicMock(), task, db))
+
+    filters = db.query.return_value.filter.call_args.args
+    assert any(
+        getattr(getattr(f, "left", None), "key", None) == "owner_id" for f in filters
+    ), f"owner_id filter missing from {filters}"
+    db.query.assert_called_with(Task.id)
+
+
+# ---------------------------------------------------------------------------
+# Clustering execution
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_faces_runs_off_the_event_loop():
+    """The pass must go through an executor.
+
+    Calling it directly from the coroutine froze the producer loop, the other
+    consumers and SSE progress, and made asyncio.wait_for ineffective.
+    """
+    db = _db(recognition_pending=False)
+    owner_id = uuid4()
+    task = _task(owner_id=owner_id)
+    seen = {}
+
+    real_loop_getter = asyncio.get_running_loop
+
+    async def _drive():
+        loop = real_loop_getter()
+        original = loop.run_in_executor
+
+        def _spy(executor, func, *args):
+            seen["called"] = True
+            seen["args"] = args
+            return original(executor, func, *args)
+
+        with patch.object(loop, "run_in_executor", _spy), \
+             patch("app.service.tasks.face_cluster._cluster_in_thread") as cluster:
+            result = await _strategy().process(MagicMock(), task, db)
+        return result, cluster
+
+    result, cluster = _run(_drive())
+
+    assert seen.get("called") is True
+    assert seen["args"] == (owner_id,)
+    cluster.assert_called_once_with(owner_id)
+    assert result == {"status": "success"}
+
+
+def test_cluster_faces_skips_task_without_owner():
+    db = _db(recognition_pending=False)
+    task = _task(owner_id=None)
+    with patch("app.service.tasks.face_cluster._cluster_in_thread") as cluster:
+        result = _run(_strategy().process(MagicMock(), task, db))
+    cluster.assert_not_called()
+    assert result["status"] == "skipped"
+
+
+def test_cluster_faces_uses_its_own_session_in_the_worker_thread():
+    """A Session is not thread-safe, so the pass must open its own."""
+    from app.service.tasks import face_cluster
+
+    owner_id = uuid4()
+    session = MagicMock(name="session")
+    service = MagicMock(name="service")
+
+    with patch("app.db.session.SessionLocal", return_value=session), \
+         patch("app.service.face_cluster.FaceClusterService", return_value=service) as factory:
+        face_cluster._cluster_in_thread(owner_id)
+
+    factory.assert_called_once_with(session, owner_id)
+    service.process_unassigned_faces.assert_called_once_with(owner_id)
+    session.close.assert_called_once()
+
+
+def test_cluster_faces_reports_failure_for_the_batch():
+    db = _db(recognition_pending=False)
+    task = _task()
+    with patch(
+        "app.service.tasks.face_cluster._cluster_in_thread",
+        side_effect=RuntimeError("dbscan exploded"),
+    ):
+        results = _run(_strategy().process_batch(MagicMock(), [task], db))
+
+    assert len(results) == 1
+    assert results[0]["status"] == "failed"
+    assert "dbscan exploded" in results[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# enqueue_cluster_faces
+# ---------------------------------------------------------------------------
+
+
+def test_enqueue_cluster_faces_reuses_an_outstanding_task():
+    """Deduplication is what collapses an import round into one pass."""
+    from app.service.tasks.face_cluster import enqueue_cluster_faces
+
+    existing = _task()
+    db = MagicMock()
+    with patch("app.crud.task.get_latest_task_by_type_and_owner", return_value=existing), \
+         patch("app.crud.task.add_task") as add_task:
+        result = enqueue_cluster_faces(db, existing.owner_id)
+
+    assert result is existing
+    add_task.assert_not_called()
+
+
+def test_enqueue_cluster_faces_creates_a_pending_task():
+    from app.db.models.task import TaskStatus, TaskType
+    from app.service.tasks.face_cluster import enqueue_cluster_faces
+
+    owner_id = uuid4()
+    db = MagicMock()
+    with patch("app.crud.task.get_latest_task_by_type_and_owner", return_value=None) as lookup, \
+         patch("app.crud.task.add_task", return_value="created") as add_task:
+        result = enqueue_cluster_faces(db, owner_id)
+
+    assert result == "created"
+    assert lookup.call_args.args[1] == TaskType.CLUSTER_FACES
+    assert lookup.call_args.args[3] == [TaskStatus.PENDING, TaskStatus.PROCESSING]
+    assert add_task.call_args.args[1] == TaskType.CLUSTER_FACES
+    assert add_task.call_args.kwargs["owner_id"] == owner_id
+
+
+def test_enqueue_cluster_faces_ignores_missing_owner():
+    from app.service.tasks.face_cluster import enqueue_cluster_faces
+
+    db = MagicMock()
+    with patch("app.crud.task.add_task") as add_task:
+        assert enqueue_cluster_faces(db, None) is None
+    add_task.assert_not_called()

--- a/package/server/tests/unit/test_nightly_face_cluster_cluster_find_gaps_20260830.py
+++ b/package/server/tests/unit/test_nightly_face_cluster_cluster_find_gaps_20260830.py
@@ -79,6 +79,55 @@ def _patch_dbscan(labels):
     return cls
 
 
+def _cluster_db(rows, *, live_ids=None):
+    """Fake Session for the scalar-select / bulk-update clustering flow.
+
+    ``_cluster_unassigned_faces`` no longer hydrates ORM ``Face`` entities nor
+    writes members one by one, so the old
+    ``db.query().filter().all()`` stub no longer matches. Three query shapes
+    are dispatched here:
+
+    * ``query(Face.id, Face.face_feature)`` -- the unassigned scalar select,
+      answered with ``rows`` of ``(face_id, embedding)``.
+    * ``query(Face)`` -- the per-cluster bulk UPDATE.
+    * anything else -- the live-member id select (and the owner subquery),
+      answered with ``live_ids``.
+    """
+    from app.db.models.face import Face
+
+    if live_ids is None:
+        live_ids = [row[0] for row in rows]
+
+    db = MagicMock(name="db")
+    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    update_calls = []
+
+    def _query(*args):
+        q = MagicMock()
+        q.filter.return_value = q
+        q.join.return_value = q
+        q.order_by.return_value = q
+        if len(args) == 2:
+            q.all.return_value = list(rows)
+        elif args and args[0] is Face:
+            def _update(values, **kwargs):
+                update_calls.append(values)
+                return len(live_ids)
+            q.update.side_effect = _update
+        else:
+            q.all.return_value = [(face_id,) for face_id in live_ids]
+        return q
+
+    db.query.side_effect = _query
+    db.update_calls = update_calls
+    return db
+
+
+def _rows(count, *, start=1):
+    """(face_id, embedding) pairs shaped like the scalar select's output."""
+    return [(index + start, _unit_vec(dim=4, seed=index)) for index in range(count)]
+
+
 # ---------------------------------------------------------------------------
 # _find_matching_face_ids: pgvector branch
 # ---------------------------------------------------------------------------
@@ -126,12 +175,11 @@ def test_find_matching_face_ids_pg_branch_empty_prototypes_skips_query():
 def test_cluster_unassigned_faces_creates_identity_for_large_cluster():
     """When DBSCAN returns >= MIN_CLUSTER_SIZE_FOR_IDENTITY members in one
     cluster, a new FaceIdentity is created and faces are reassigned."""
-    db = MagicMock(name="db")
-    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
-    svc = _service(db)
+    from app.db.models.face import Face
 
-    faces = [_face(id_=i + 1, feature=_unit_vec(dim=4, seed=i)) for i in range(6)]
-    db.query.return_value.filter.return_value.all.return_value = faces
+    rows = _rows(6)
+    db = _cluster_db(rows)
+    svc = _service(db)
 
     dbscan_cls = _patch_dbscan(np.array([0, 0, 0, 0, 0, 0]))
 
@@ -140,55 +188,70 @@ def test_cluster_unassigned_faces_creates_identity_for_large_cluster():
 
     with patch("app.service.face_cluster.DBSCAN", dbscan_cls), \
          patch("app.service.face_cluster.crud_face.create_identity", return_value=new_identity) as create_identity, \
-         patch("app.service.face_cluster.crud_face.update_face") as update_face, \
-         patch("app.service.face_cluster.crud_face.get_face", side_effect=lambda d, fid: next((f for f in faces if f.id == fid), None)), \
          patch("app.service.face_cluster.crud_face.update_identity") as update_identity:
         svc._cluster_unassigned_faces(owner_id=None)
 
     create_identity.assert_called_once()
-    assert update_face.call_count == 6
+    # One bulk UPDATE for the whole cluster, not one statement per member.
+    assert len(db.update_calls) == 1
+    values = db.update_calls[0]
+    assert values[Face.face_identity_id] == new_identity_id
+    assert values[Face.recognize_confidence] == 0.9
+
     update_identity.assert_called_once()
     call = update_identity.call_args
     if call.kwargs:
-        assert call.kwargs["default_face_id"] == faces[0].id
+        assert call.kwargs["default_face_id"] == rows[0][0]
     else:
-        assert call.args[2].default_face_id == faces[0].id
+        assert call.args[2].default_face_id == rows[0][0]
+    db.commit.assert_called()
+
+
+def test_cluster_unassigned_faces_uses_per_user_eps_not_global_config():
+    """eps must come from the user's resolved threshold.
+
+    Reading ``config_manager.config`` here applied the global default to every
+    user, silently ignoring a per-user face_cluster_threshold.
+    """
+    db = _cluster_db(_rows(6))
+    svc = _service(db)
+    svc.DBSCAN_EPS = 0.33
+
+    dbscan_cls = _patch_dbscan(np.array([-1] * 6))
+
+    with patch("app.service.face_cluster.DBSCAN", dbscan_cls), \
+         patch("app.service.face_cluster.crud_face.create_identity"):
+        svc._cluster_unassigned_faces(owner_id=None)
+
+    assert dbscan_cls.call_args.kwargs["eps"] == 0.33
 
 
 def test_cluster_unassigned_faces_skips_small_cluster_below_min_size():
     """A cluster whose size < MIN_CLUSTER_SIZE_FOR_IDENTITY must NOT create
     an identity."""
-    db = MagicMock(name="db")
-    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    db = _cluster_db(_rows(6))
     svc = _service(db)
-
-    faces = [_face(id_=i + 1, feature=_unit_vec(dim=4, seed=i)) for i in range(6)]
-    db.query.return_value.filter.return_value.all.return_value = faces
 
     dbscan_cls = _patch_dbscan(np.array([0, 0, -1, -1, -1, -1]))
 
     with patch("app.service.face_cluster.DBSCAN", dbscan_cls), \
          patch("app.service.face_cluster.crud_face.create_identity") as create_identity, \
-         patch("app.service.face_cluster.crud_face.update_face") as update_face, \
          patch("app.service.face_cluster.crud_face.update_identity") as update_identity:
         svc._cluster_unassigned_faces(owner_id=None)
 
+    dbscan_cls.assert_called_once()
     create_identity.assert_not_called()
-    update_face.assert_not_called()
     update_identity.assert_not_called()
+    assert db.update_calls == []
 
 
 def test_cluster_unassigned_faces_handles_two_clusters():
     """Two DBSCAN clusters of sufficient size should each create their own
     identity (or be merged if centers are close)."""
-    db = MagicMock(name="db")
-    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
-    svc = _service(db)
-
     # MIN_CLUSTER_SIZE_FOR_IDENTITY defaults to 5; build 6 faces per cluster
     # plus 2 noise (14 total) so both clusters exceed the minimum.
-    faces = [_face(id_=i + 1, feature=_unit_vec(dim=4, seed=i)) for i in range(14)]
-    db.query.return_value.filter.return_value.all.return_value = faces
+    db = _cluster_db(_rows(14))
+    svc = _service(db)
 
     labels = np.array([0] * 6 + [1] * 6 + [-1, -1])
     dbscan_cls = _patch_dbscan(labels)
@@ -198,26 +261,21 @@ def test_cluster_unassigned_faces_handles_two_clusters():
 
     with patch("app.service.face_cluster.DBSCAN", dbscan_cls), \
          patch("app.service.face_cluster.crud_face.create_identity", side_effect=[new_identity_a, new_identity_b]) as create_identity, \
-         patch("app.service.face_cluster.crud_face.update_face") as update_face, \
-         patch("app.service.face_cluster.crud_face.get_face", side_effect=lambda d, fid: next((f for f in faces if f.id == fid), None)), \
          patch("app.service.face_cluster.crud_face.update_identity"):
         svc._cluster_unassigned_faces(owner_id=None)
 
     # Two clusters of size 6 each, both >= MIN_CLUSTER_SIZE_FOR_IDENTITY=5;
     # random unit vectors will not be close enough to merge.
     assert 1 <= create_identity.call_count <= 2
-    assert update_face.call_count >= 6
+    assert len(db.update_calls) == create_identity.call_count
 
 
 def test_cluster_unassigned_faces_short_circuits_when_below_min_samples():
     """When there are fewer than DBSCAN_MIN_SAMPLES unassigned faces,
     the DBSCAN call should be skipped entirely."""
-    db = MagicMock(name="db")
-    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    db = _cluster_db(_rows(4))
     svc = _service(db)
-
-    faces = [_face(id_=i + 1, feature=_unit_vec(dim=4, seed=i)) for i in range(svc.DBSCAN_MIN_SAMPLES - 1)]
-    db.query.return_value.filter.return_value.all.return_value = faces
+    assert svc.DBSCAN_MIN_SAMPLES == 5
 
     dbscan_cls = MagicMock(name="DBSCAN-class")
     with patch("app.service.face_cluster.DBSCAN", dbscan_cls) as dbs, \
@@ -232,12 +290,8 @@ def test_cluster_unassigned_faces_rolls_back_on_pending_rollback_error():
     """PendingRollbackError triggers db.rollback() and re-raises."""
     from sqlalchemy.exc import PendingRollbackError
 
-    db = MagicMock(name="db")
-    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    db = _cluster_db(_rows(6))
     svc = _service(db)
-
-    faces = [_face(id_=i + 1, feature=_unit_vec(dim=4, seed=i)) for i in range(6)]
-    db.query.return_value.filter.return_value.all.return_value = faces
     dbscan_cls = _patch_dbscan(np.array([0, 0, 0, 0, 0, 0]))
 
     with patch("app.service.face_cluster.DBSCAN", dbscan_cls), \
@@ -252,12 +306,8 @@ def test_cluster_unassigned_faces_rolls_back_on_sqlalchemy_error():
     """SQLAlchemyError triggers db.rollback() and re-raises."""
     from sqlalchemy.exc import SQLAlchemyError
 
-    db = MagicMock(name="db")
-    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    db = _cluster_db(_rows(6))
     svc = _service(db)
-
-    faces = [_face(id_=i + 1, feature=_unit_vec(dim=4, seed=i)) for i in range(6)]
-    db.query.return_value.filter.return_value.all.return_value = faces
     dbscan_cls = _patch_dbscan(np.array([0, 0, 0, 0, 0, 0]))
 
     with patch("app.service.face_cluster.DBSCAN", dbscan_cls), \
@@ -268,39 +318,45 @@ def test_cluster_unassigned_faces_rolls_back_on_sqlalchemy_error():
     db.rollback.assert_called_once()
 
 
-def test_cluster_unassigned_faces_skips_missing_face_member():
-    """If crud_face.get_face returns None for a member, the iteration should
-    skip it gracefully and still set the default face from the remaining
-    members."""
-    db = MagicMock(name="db")
-    db.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
-    svc = _service(db)
+def test_cluster_unassigned_faces_skips_vanished_face_member():
+    """A member deleted between the select and the write is excluded.
 
-    faces = [_face(id_=i + 1, feature=_unit_vec(dim=4, seed=i)) for i in range(6)]
-    db.query.return_value.filter.return_value.all.return_value = faces
+    The live-id re-check replaces the old per-member ``get_face`` lookup, and
+    the default face must come from the surviving members.
+    """
+    rows = _rows(6)
+    # Face 1 disappeared (deleted) after the unassigned select ran.
+    db = _cluster_db(rows, live_ids=[row[0] for row in rows[1:]])
+    svc = _service(db)
     dbscan_cls = _patch_dbscan(np.array([0, 0, 0, 0, 0, 0]))
 
-    new_identity_id = uuid4()
-    new_identity = SimpleNamespace(id=new_identity_id)
-
-    def fake_get(d, fid):
-        if fid == 1:
-            return None
-        return next(f for f in faces if f.id == fid)
+    new_identity = SimpleNamespace(id=uuid4())
 
     with patch("app.service.face_cluster.DBSCAN", dbscan_cls), \
          patch("app.service.face_cluster.crud_face.create_identity", return_value=new_identity), \
-         patch("app.service.face_cluster.crud_face.update_face") as update_face, \
-         patch("app.service.face_cluster.crud_face.get_face", side_effect=fake_get), \
          patch("app.service.face_cluster.crud_face.update_identity") as update_identity:
         svc._cluster_unassigned_faces(owner_id=None)
 
-    assert update_face.call_count == 5
     call = update_identity.call_args
     if call.kwargs:
-        assert call.kwargs["default_face_id"] == faces[1].id
+        assert call.kwargs["default_face_id"] == rows[1][0]
     else:
-        assert call.args[2].default_face_id == faces[1].id
+        assert call.args[2].default_face_id == rows[1][0]
+
+
+def test_cluster_unassigned_faces_skips_cluster_with_no_live_members():
+    """If every member vanished, no identity write happens for that cluster."""
+    db = _cluster_db(_rows(6), live_ids=[])
+    svc = _service(db)
+    dbscan_cls = _patch_dbscan(np.array([0, 0, 0, 0, 0, 0]))
+
+    with patch("app.service.face_cluster.DBSCAN", dbscan_cls), \
+         patch("app.service.face_cluster.crud_face.create_identity", return_value=SimpleNamespace(id=uuid4())), \
+         patch("app.service.face_cluster.crud_face.update_identity") as update_identity:
+        svc._cluster_unassigned_faces(owner_id=None)
+
+    assert db.update_calls == []
+    update_identity.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/package/server/tests/unit/test_nightly_face_process_batch_gaps_20260816.py
+++ b/package/server/tests/unit/test_nightly_face_process_batch_gaps_20260816.py
@@ -422,7 +422,35 @@ def test_face_process_single_photo_success_with_embedding(monkeypatch):
     res = _run(s.process_single_photo(MagicMock(), p, MagicMock()))
     assert res["status"] == "success"
     assert res["faces_found"] == 1
-    cluster.process_unassigned_faces.assert_called_once()
+    # Clustering must NOT run inline: it held the single 'face' resource slot
+    # and blocked every subsequent recognition batch. It is reported via
+    # has_unassigned and handled by a separate CLUSTER_FACES task instead.
+    cluster.process_unassigned_faces.assert_not_called()
+    assert res["has_unassigned"] is True
+    assert res["owner_id"] == str(p.owner_id)
+
+
+def test_face_process_single_photo_passes_owner_id_to_assignment(monkeypatch):
+    """assign_face_to_identity must receive owner_id.
+
+    Without it the pgvector nearest-neighbour query scans every user's faces.
+    """
+    from app.service.tasks.face import RecognizeFaceStrategy
+    p = _photo()
+    monkeypatch.setattr("app.service.tasks.face.storage.get_available_photo_path", lambda *a, **kw: "/tmp/x.jpg")
+    _patch_open_ok(monkeypatch)
+    monkeypatch.setattr("app.service.tasks.face.storage.get_image_dimensions", lambda *a, **kw: (10, 10, None))
+    session = _FakeSession([_FakeResp(200, {"results": [{"faces": [
+        {"det_score": 0.9, "embedding": [0.1, 0.2]},
+    ]}]})])
+    _patch_aiohttp(monkeypatch, session)
+    _patch_user_config(monkeypatch)
+    cluster = _patch_cluster(monkeypatch)
+    monkeypatch.setattr("app.service.tasks.face.crud_face.delete_faces_by_photo", lambda db, pid: None)
+    monkeypatch.setattr("app.crud.album.trigger_conditional_albums_update", lambda *a, **kw: None)
+    s = RecognizeFaceStrategy()
+    _run(s.process_single_photo(MagicMock(), p, MagicMock()))
+    assert cluster.assign_face_to_identity.call_args.args[2] == p.owner_id
 
 
 def test_face_process_single_photo_face_no_embedding(monkeypatch):
@@ -469,24 +497,41 @@ def test_face_process_single_photo_cluster_exception_swallowed(monkeypatch):
     assert res["faces_found"] == 1
 
 
-def test_face_process_single_photo_unassigned_faces_exception(monkeypatch):
-    """process_unassigned_faces raising is swallowed; photo still success."""
+def test_face_handle_completion_enqueues_one_task_per_owner(monkeypatch):
+    """Only owners with unassigned faces get a clustering task, once each."""
     from app.service.tasks.face import RecognizeFaceStrategy
-    p = _photo()
-    monkeypatch.setattr("app.service.tasks.face.storage.get_available_photo_path", lambda *a, **kw: "/tmp/x.jpg")
-    _patch_open_ok(monkeypatch)
-    monkeypatch.setattr("app.service.tasks.face.storage.get_image_dimensions", lambda *a, **kw: (10, 10, None))
-    session = _FakeSession([_FakeResp(200, {"results": [{"faces": [
-        {"det_score": 0.9, "embedding": [0.1]},
-    ]}]})])
-    _patch_aiohttp(monkeypatch, session)
-    _patch_user_config(monkeypatch)
-    _patch_cluster(monkeypatch, process_unassigned_faces=MagicMock(side_effect=RuntimeError("batch down")))
-    monkeypatch.setattr("app.service.tasks.face.crud_face.delete_faces_by_photo", lambda db, pid: None)
-    monkeypatch.setattr("app.crud.album.trigger_conditional_albums_update", lambda *a, **kw: None)
+    calls = []
+    monkeypatch.setattr(
+        "app.service.tasks.face.enqueue_cluster_faces",
+        lambda db, owner_id: calls.append(owner_id),
+    )
+    owner_a = str(uuid4())
+    owner_b = str(uuid4())
+    items = [
+        {"status": "completed", "result": {"has_unassigned": True, "owner_id": owner_a}},
+        {"status": "completed", "result": {"has_unassigned": True, "owner_id": owner_a}},
+        {"status": "completed", "result": {"has_unassigned": False, "owner_id": owner_b}},
+        {"status": "failed", "error": "boom"},
+        {"status": "completed", "result": {"status": "skipped", "reason": "already processed"}},
+    ]
     s = RecognizeFaceStrategy()
-    res = _run(s.process_single_photo(MagicMock(), p, MagicMock()))
-    assert res["status"] == "success"
+    _run(s.handle_completion(MagicMock(), items, MagicMock()))
+    assert calls == [owner_a]
+
+
+def test_face_handle_completion_swallows_enqueue_failure(monkeypatch):
+    """A failed enqueue must not fail the recognition tasks that just finished."""
+    from app.service.tasks.face import RecognizeFaceStrategy
+
+    def _boom(db, owner_id):
+        raise RuntimeError("enqueue down")
+
+    monkeypatch.setattr("app.service.tasks.face.enqueue_cluster_faces", _boom)
+    db = MagicMock()
+    items = [{"status": "completed", "result": {"has_unassigned": True, "owner_id": str(uuid4())}}]
+    s = RecognizeFaceStrategy()
+    _run(s.handle_completion(MagicMock(), items, db))
+    db.rollback.assert_called_once()
 
 
 def test_face_process_single_photo_outer_exception_marks_false_and_reraises(monkeypatch):

--- a/package/server/tests/unit/test_nightly_task_crud_gaps_20260814.py
+++ b/package/server/tests/unit/test_nightly_task_crud_gaps_20260814.py
@@ -144,8 +144,10 @@ def test_get_grouped_status_returns_categories_sorted_by_priority_desc():
     db.query.side_effect = [pending_query, failed_query]
 
     out = crud_task.get_grouped_status(db, paused_categories={TaskType.RECOGNIZE_FACE})
-    # All 9 categories surfaced
-    assert len(out) == 9
+    # All 10 categories surfaced (CLUSTER_FACES joined the panel when
+    # clustering was split out of RECOGNIZE_FACE).
+    assert len(out) == 10
+    assert any(row["category"] == TaskType.CLUSTER_FACES for row in out)
     priorities = [row["priority"] for row in out]
     assert priorities == sorted(priorities, reverse=True)
     # RECOGNIZE_FACE entry should be marked 'paused'


### PR DESCRIPTION
Face clustering ran inline at the end of every RECOGNIZE_FACE batch. On a NAS deployment that surfaced as "recognition is slow, the AI container is idle, and the server container sits at 90%+ CPU". Three separate defects combined to produce it.

1. Recognition is admitted through resource_key 'face', limited to 1 concurrent slot (2 on medium/high). The slot is held for the whole of process_batch, so a multi-minute clustering pass inside it stopped every further recognition batch from being dispatched at all. Recognition was not slow; it was blocked.

2. process_unassigned_faces is synchronous CPU work. Called from a coroutine it blocked the worker's event loop, freezing the producer loop, the other two consumers and SSE progress. asyncio.wait_for cannot interrupt synchronous code, so the batch timeout was ineffective too.

3. It ran once per batch, and process_single_photo still ran it once per photo, repeating the same whole-library DBSCAN pass throughout an import.

11504d0 (#164) reduced the trigger rate from per-photo to per-batch and vectorised the SQLite nearest-neighbour path, but that work sits behind `dialect.name == "sqlite"` branches. _cluster_unassigned_faces has no dialect branch, so PostgreSQL deployments kept the full sklearn DBSCAN, still inline, still on the event loop.

Changes
-------
* Add TaskType.CLUSTER_FACES (priority 3, below RECOGNIZE_FACE's 9) and app/service/tasks/face_cluster.py. Task.type is a plain String column, so no migration is required.

* ClusterFacesStrategy runs on the CPU queue under its own resource_key 'face_cluster', so clustering can never hold the recognition slot. Priority alone would not achieve this: the two types live in different category queues and are dispatched independently.

* The pass runs through run_in_executor with its own Session, keeping the event loop free. The default executor is used rather than worker.thread_pool because _manage_pool_lifecycle tears that pool down whenever no IO task is active, which could kill a running pass.

* timeout is raised to 3600s. The 5 minute default would abort a large pass, and the timeout text matches _is_retryable_error, so the same CPU work would be burned max_attempts times before finally failing.

* A defer guard re-queues the task while RECOGNIZE_FACE rows are still pending or processing for that owner. Deferring must not report a status: _flush_results deletes anything it sees as completed and PRESERVED_TASK_TYPES is empty, so returning {'status': 'deferred'} would drop the row and clustering would silently never happen. The deferred task id is therefore omitted from the batch results. attempt_count is left untouched, since waiting is not a failed attempt and a long import would otherwise exhaust max_attempts.

* RecognizeFaceStrategy.handle_completion registers one clustering task per owner that produced unassigned faces, reusing an outstanding PENDING/PROCESSING row. An import round now collapses to a single pass.

* Fix a missing owner_id on both assign_face_to_identity call sites. On PostgreSQL the nearest-neighbour query scanned every user's faces; on SQLite _shard_key collapsed all owners into one global cache shard, degrading the per-owner sharding added in 11504d0.

* _cluster_unassigned_faces: select (id, face_feature) scalars instead of hydrating a Face entity per unassigned face, use the per-user DBSCAN_EPS instead of the global config value (which ignored a per-user face_cluster_threshold), and write each cluster with one bulk UPDATE instead of a get_face + update_face round trip per member.

* CLUSTER_FACES gets chunk_size 1 so several owners' passes are not serialised inside a single timeout window, and appears in the task panel as a distinct "人脸聚类" stage.

Scope
-----
This removes the repeated passes and the two forms of blocking. A single pass over a six-figure library is still O(n^2) inside sklearn; replacing that kernel with a pgvector/HNSW neighbour graph is left for follow-up.

Tests
-----
Add tests/unit/test_face_cluster_task_split.py: the dedicated resource key, the raised timeout, chunk_size, the priority ordering, the defer guard, that a deferred row is omitted from results rather than reported, that the pass goes through an executor with its own Session, and enqueue deduplication.

Three existing clustering tests were passing vacuously: MagicMock.__len__ returns 0, so face_count < DBSCAN_MIN_SAMPLES short-circuited before DBSCAN was ever reached. They are rewritten against the scalar-select and bulk-update contract, with new cases for the per-user eps and for members deleted between the select and the write.

## 描述
<!-- 请简要描述您的更改。如果是修复 Bug，请链接相关 Issue。 -->

## 变更类型
<!-- 请删除不相关的选项 -->
- [ ] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [ ] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue
<!-- 例如：Fixes #123 -->

## 如何测试
<!-- 请描述您是如何测试这些更改的 -->

## 检查清单
- [ ] 我已阅读并遵循项目的贡献指南
- [ ] 我的代码遵循项目的代码风格
- [ ] 我已添加/更新了必要的测试
- [ ] 所有测试均已通过
- [ ] 我已更新了相关文档
