### PR TITLE
feat: 手机 App 网络仅通过自部署 Server

### DIFF
--- a/doc/mobile_offline_network.md
+++ b/doc/mobile_offline_network.md
@@ -1,0 +1,20 @@
+# 手机 App 单一 Server 网络边界
+
+TrailSnap 手机 App 的运行原则是：安装包包含前端代码、字体、图标、默认图片和其他静态资源；运行时只连接用户选定的自部署 TrailSnap Server。这里的“离线”指 App 不直连任何第三方服务，Server 是否允许访问互联网由部署者决定。
+
+## 已实施的边界
+
+- Android WebView 在原生层按协议、主机和端口校验每个 HTTP(S) 请求。首次连接设置完成后，仅 Capacitor 本地资源与所选 Server 同源请求可通过。
+- iOS/Android 共用的浏览器层策略同时限制 `fetch`、XHR、EventSource、WebSocket 和 `sendBeacon`；手机 App 内的外部链接不会跳转或唤起外部站点。
+- 天地图 SDK、瓦片、搜索和地理编码均通过 `/api/system/map-proxy/...` 转发。代理只允许天地图官方固定域名，不能作为通用代理使用。
+- 天地图浏览器端 Key 仍可使用。Server 会以自身公开 Origin 生成 `Referer`/`Origin`；启用域名白名单时必须将自部署 Server 的域名或 IP 加入白名单。
+- Server 的定时更新任务每 6 小时检查版本并将最新 Android APK 原子下载到 `TS_DATA_DIR/app_updates/`。App 检查更新时只会收到 `/api/system/app-update-download/{version}`，Android 原生下载器还会拒绝非当前 Server 地址以及跨源重定向。
+- 默认头像、空相册封面和软木纹理已经本地化，不再从公共占位图或纹理站点加载。
+
+## 首次连接例外
+
+尚未保存 Server 地址时，连接页需要探测 mDNS/LAN 服务或测试用户手动输入的公网自部署地址，因此网络白名单尚未收紧。地址保存后策略立即变为精确同源；清除 App 数据会重新进入首次连接状态。
+
+## 上架构建注意事项
+
+当前 Android 自托管分发包包含 `REQUEST_INSTALL_PACKAGES`，用于用户确认后的 APK 自更新。Google Play 等商店通常会严格审核这项权限；正式商店渠道应建立单独 flavor，移除该权限和 App 内安装入口，交由应用商店更新。该渠道差异不改变 App 业务流量只访问自部署 Server 的原则。

--- a/package/server/app/api/system.py
+++ b/package/server/app/api/system.py
@@ -1,4 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException
+import re
+
+import aiohttp
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import FileResponse, Response
 from app.core.system_config import system_config
 from app.api.deps import get_current_user
 from app.db.models.user import User
@@ -7,6 +11,89 @@ import logging
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+_TIANDITU_HOST = re.compile(
+    r"^(?:api|location|t[0-7])\.tianditu\.(?:gov\.cn|com)$",
+    re.IGNORECASE,
+)
+
+
+def _rewrite_tianditu_text(value: str) -> str:
+    """Route URLs constructed inside the Tianditu SDK back through TrailSnap.
+
+    The SDK builds most endpoints by concatenating protocol, host and path, so
+    replacing only literal absolute URLs is insufficient.  These two source
+    expressions cover the API/service bundles; map tiles are explicitly
+    replaced by the client with TrailSnap's tile proxy.
+    """
+    proxy_api = '"/api/system/map-proxy/api.tianditu.gov.cn"'
+    value = value.replace('T.Protocol.value+"api.tianditu."+T.Domain', proxy_api)
+    value = value.replace(
+        'T.Protocol.value+"location.tianditu.gov.cn"',
+        '"/api/system/map-proxy/location.tianditu.gov.cn"',
+    )
+    return re.sub(
+        r"https?:\/\/((?:api|location|t[0-7])\.tianditu\.(?:gov\.cn|com))",
+        r"/api/system/map-proxy/\1",
+        value,
+        flags=re.IGNORECASE,
+    )
+
+
+def _public_request_origin(request: Request) -> str:
+    """Build the browser-key origin represented by the self-hosted gateway."""
+    forwarded_proto = request.headers.get("x-forwarded-proto", "").split(",", 1)[0].strip().lower()
+    scheme = forwarded_proto if forwarded_proto in {"http", "https"} else request.url.scheme
+    forwarded_host = request.headers.get("x-forwarded-host", "").split(",", 1)[0].strip()
+    host = forwarded_host or request.headers.get("host", "")
+    return f"{scheme}://{host}" if host else ""
+
+
+@router.get("/map-proxy/{host}/{path:path}", include_in_schema=False)
+async def proxy_tianditu_resource(host: str, path: str, request: Request):
+    """Strict reverse proxy used by the mobile app for Tianditu resources.
+
+    ``host`` is allow-listed to avoid turning a self-hosted TrailSnap instance
+    into an open proxy or SSRF primitive.  The phone therefore talks only to
+    TrailSnap; all third-party traffic originates from the server.
+    """
+    if not _TIANDITU_HOST.fullmatch(host):
+        raise HTTPException(status_code=404, detail="Unsupported map host")
+    upstream = f"https://{host}/{path}"
+    timeout = aiohttp.ClientTimeout(total=30, connect=8)
+    headers = {
+        "Accept": request.headers.get("accept", "*/*"),
+        "User-Agent": "TrailSnap-Map-Proxy/1.0",
+    }
+    # Tianditu browser keys can be restricted by an allowed web origin.  From
+    # Tianditu's perspective the self-hosted gateway is now the caller, so use
+    # its public origin rather than Capacitor's synthetic http://localhost.
+    public_origin = _public_request_origin(request)
+    if public_origin:
+        headers["Referer"] = f"{public_origin}/"
+        headers["Origin"] = public_origin
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(upstream, params=request.query_params, headers=headers) as response:
+                body = await response.read()
+                content_type = response.headers.get("Content-Type", "application/octet-stream")
+                if "javascript" in content_type or "text/" in content_type:
+                    charset = response.charset or "utf-8"
+                    body = _rewrite_tianditu_text(body.decode(charset, errors="replace")).encode("utf-8")
+                    content_type = content_type.split(";", 1)[0] + "; charset=utf-8"
+                return Response(
+                    content=body,
+                    status_code=response.status,
+                    media_type=None,
+                    headers={
+                        "Content-Type": content_type,
+                        "Cache-Control": "public, max-age=86400",
+                        "X-Content-Type-Options": "nosniff",
+                    },
+                )
+    except aiohttp.ClientError as error:
+        logger.warning("Tianditu proxy failed for %s: %s", upstream, error)
+        raise HTTPException(status_code=502, detail="Map service is unavailable") from error
 
 @router.get("/config")
 def get_system_config(current_user: User = Depends(get_current_user)):
@@ -79,9 +166,26 @@ async def check_app_update_endpoint(version: str, platform: str = "android"):
     """手机 App 自更新检查。
 
     与 ``/update-check`` 不同：这里的 ``version`` 是 App 自身安装的
-    ``versionName``（由客户端传入），返回值携带 APK 直链和文件大小，
-    App 可以直接下载并唤起系统安装器。
+    ``versionName``（由客户端传入），返回值仅携带当前 Server 的 APK
+    缓存路径和文件大小，App 不接触外部发布服务器。
     """
     from app.service.app_update import check_app_update
 
     return await check_app_update(current_version=version, platform=platform)
+
+
+@router.get("/app-update-download/{version}", include_in_schema=False)
+async def download_cached_app_update(version: str):
+    """Serve only APKs already downloaded and validated by this Server."""
+    from app.service.app_update import cached_apk_path, normalize_version
+
+    normalized = normalize_version(version)
+    path = cached_apk_path(normalized)
+    if not normalized or not path:
+        raise HTTPException(status_code=404, detail="App update is not cached")
+    return FileResponse(
+        path,
+        filename=f"TrailSnap-{normalized}.apk",
+        media_type="application/vnd.android.package-archive",
+        headers={"Cache-Control": "private, max-age=3600", "X-Content-Type-Options": "nosniff"},
+    )

--- a/package/server/app/service/app_update.py
+++ b/package/server/app/service/app_update.py
@@ -8,12 +8,13 @@
 
 版本清单仍然复用官网的 ``version.json``（唯一版本事实来源），
 拿到最新版本号后再向 GitHub Releases API 查询该 tag 下的 APK 资产以获取
-精确的直链与体积；GitHub 不可达（限流 / 内网）时回退到 CI 的固定命名约定，
-此时 ``size`` 为 0，客户端跳过大小校验。
+精确的直链与体积。安装包先下载到自部署 Server 的持久化缓存，App
+永远只拿到 Server 同源下载路径，不接触 GitHub 或对象存储。
 """
 import logging
 import os
 import re
+import uuid
 from typing import Any, Dict, List, Optional
 
 import aiohttp
@@ -23,6 +24,7 @@ from app.service.update_checker import (
     compare_versions,
     fetch_remote_update_info,
 )
+from app.core.paths import DATA_DIR
 
 logger = logging.getLogger("app.service.app_update")
 
@@ -38,6 +40,7 @@ APK_FALLBACK_URL = (
 )
 
 _VERSION_PATTERN = re.compile(r"^\d+(\.\d+)*$")
+APP_UPDATE_CACHE_DIR = os.path.join(DATA_DIR, "app_updates")
 
 
 def normalize_version(value: Optional[str]) -> str:
@@ -93,6 +96,82 @@ async def fetch_release_apk(
     }
 
 
+def cached_apk_path(version: str) -> Optional[str]:
+    """Return the validated cached package path for a version, if present."""
+    version = normalize_version(version)
+    if not version:
+        return None
+    path = os.path.join(APP_UPDATE_CACHE_DIR, f"TrailSnap-{version}.apk")
+    return path if os.path.isfile(path) and os.path.getsize(path) > 0 else None
+
+
+async def cache_release_apk(version: str, asset: Dict[str, Any]) -> Optional[str]:
+    """Download an APK atomically on the Server and return its local path."""
+    version = normalize_version(version)
+    url = str(asset.get("download_url") or "")
+    if not version or not url.startswith("https://"):
+        return None
+    existing = cached_apk_path(version)
+    expected_size = int(asset.get("size") or 0)
+    if existing and (not expected_size or os.path.getsize(existing) == expected_size):
+        return existing
+
+    os.makedirs(APP_UPDATE_CACHE_DIR, exist_ok=True)
+    target = os.path.join(APP_UPDATE_CACHE_DIR, f"TrailSnap-{version}.apk")
+    temporary = f"{target}.{uuid.uuid4().hex}.part"
+    timeout = aiohttp.ClientTimeout(total=None, connect=15, sock_read=90)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, headers={"Accept": "application/octet-stream"}) as response:
+                if response.status != 200:
+                    logger.warning("APK predownload HTTP %s for v%s", response.status, version)
+                    return None
+                downloaded = 0
+                with open(temporary, "wb") as output:
+                    async for chunk in response.content.iter_chunked(256 * 1024):
+                        output.write(chunk)
+                        downloaded += len(chunk)
+        if downloaded <= 0 or (expected_size and downloaded != expected_size):
+            logger.warning("APK predownload size mismatch for v%s", version)
+            return None
+        os.replace(temporary, target)
+        logger.info("Cached Android App v%s (%s bytes)", version, downloaded)
+        return target
+    except Exception as error:
+        logger.warning("APK predownload failed for v%s: %s", version, error)
+        return None
+    finally:
+        try:
+            if os.path.exists(temporary):
+                os.remove(temporary)
+        except OSError:
+            pass
+
+
+async def ensure_cached_apk(version: str, repo: str = GITHUB_REPO) -> Optional[str]:
+    existing = cached_apk_path(version)
+    if existing:
+        return existing
+    asset = await fetch_release_apk(version, repo=repo)
+    if asset is None:
+        asset = {
+            "download_url": APK_FALLBACK_URL.format(repo=repo, version=version),
+            "size": 0,
+            "file_name": APK_ASSET_TEMPLATE.format(version=version),
+        }
+    return await cache_release_apk(version, asset)
+
+
+async def prefetch_latest_app_update(
+    manifest_url: str = DEFAULT_UPDATE_URL,
+    repo: str = GITHUB_REPO,
+) -> Optional[str]:
+    """Scheduled Server-side predownload for the latest Android package."""
+    info = await fetch_remote_update_info(url=manifest_url, current_version="0.0.0")
+    latest = normalize_version(info.get("latest_version")) if info else ""
+    return await ensure_cached_apk(latest, repo=repo) if latest else None
+
+
 async def check_app_update(
     current_version: str,
     platform: str = "android",
@@ -137,14 +216,11 @@ async def check_app_update(
         return result
 
     result["has_update"] = True
-    asset = await fetch_release_apk(latest, repo=repo)
-    if asset:
-        result["download_url"] = asset["download_url"]
-        result["size"] = asset["size"]
-        result["file_name"] = asset["file_name"]
+    cached = await ensure_cached_apk(latest, repo=repo)
+    if cached:
+        result["download_url"] = f"/api/system/app-update-download/{latest}"
+        result["size"] = os.path.getsize(cached)
+        result["file_name"] = os.path.basename(cached)
     else:
-        # GitHub 不可达时退回 CI 命名约定，size 未知交由客户端跳过校验。
-        result["download_url"] = APK_FALLBACK_URL.format(repo=repo, version=latest)
-        result["file_name"] = APK_ASSET_TEMPLATE.format(version=latest)
-        result["size"] = 0
+        result["error"] = "新版安装包尚未缓存到当前 Server，请稍后重试"
     return result

--- a/package/server/app/service/jobs/update_check.py
+++ b/package/server/app/service/jobs/update_check.py
@@ -3,6 +3,7 @@
 调度由 ``JobScheduler`` 负责（默认每 6 小时一次），本函数仅作为
 ``UpdateCheckScheduler.tick()`` 的薄封装，便于在日志里区分是定时触发。
 """
+import asyncio
 import logging
 
 from app.service.update_checker import UpdateCheckScheduler
@@ -13,5 +14,9 @@ logger = logging.getLogger("app.service.jobs.update_check")
 def update_check_job():
     try:
         UpdateCheckScheduler().tick()
+        # The phone is intentionally forbidden from reaching release hosts.
+        # Keep the newest APK ready on this self-hosted Server instead.
+        from app.service.app_update import prefetch_latest_app_update
+        asyncio.run(prefetch_latest_app_update())
     except Exception as e:
         logger.error(f"update_check_job failed: {e}")

--- a/package/server/tests/unit/test_app_update.py
+++ b/package/server/tests/unit/test_app_update.py
@@ -150,39 +150,38 @@ def test_check_app_update_returns_apk_asset_when_newer():
         "update_info": "新功能",
         "download_url": "http://page/v1.1.0",
     }
-    asset = {"download_url": "http://dl/apk", "size": 4096, "file_name": "TrailSnap-1.1.0.apk"}
     with (
         patch.object(app_update, "fetch_remote_update_info", side_effect=_async_return(info)),
-        patch.object(app_update, "fetch_release_apk", side_effect=_async_return(asset)),
+        patch.object(app_update, "ensure_cached_apk", side_effect=_async_return("/cache/TrailSnap-1.1.0.apk")),
+        patch.object(app_update.os.path, "getsize", return_value=4096),
     ):
         result = _run(app_update.check_app_update("v1.0.0"))
 
     assert result["has_update"] is True
     assert result["current_version"] == "1.0.0"
     assert result["latest_version"] == "1.1.0"
-    assert result["download_url"] == "http://dl/apk"
+    assert result["download_url"] == "/api/system/app-update-download/1.1.0"
     assert result["size"] == 4096
     assert result["file_name"] == "TrailSnap-1.1.0.apk"
     assert result["update_info"] == "新功能"
 
 
-def test_check_app_update_falls_back_to_ci_naming_when_github_unreachable():
-    """GitHub 限流/内网时仍要给出可用直链，size=0 让客户端跳过大小校验。"""
+def test_check_app_update_withholds_external_url_when_server_cache_unavailable():
+    """缓存失败时不能把 GitHub 地址泄漏给 App。"""
     from app.service import app_update
 
     info = {"latest_version": "1.1.0", "has_update": True, "update_info": "", "download_url": None}
     with (
         patch.object(app_update, "fetch_remote_update_info", side_effect=_async_return(info)),
-        patch.object(app_update, "fetch_release_apk", side_effect=_async_return(None)),
+        patch.object(app_update, "ensure_cached_apk", side_effect=_async_return(None)),
     ):
         result = _run(app_update.check_app_update("1.0.0", repo="LC044/TrailSnap"))
 
     assert result["has_update"] is True
-    assert result["download_url"] == (
-        "https://github.com/LC044/TrailSnap/releases/download/v1.1.0/TrailSnap-1.1.0-debug.apk"
-    )
-    assert result["file_name"] == "TrailSnap-1.1.0-debug.apk"
+    assert result["download_url"] is None
+    assert result["file_name"] is None
     assert result["size"] == 0
+    assert "尚未缓存" in result["error"]
 
 
 def test_check_app_update_reports_error_when_manifest_unavailable():

--- a/package/server/tests/unit/test_system_api.py
+++ b/package/server/tests/unit/test_system_api.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+from starlette.requests import Request
 
 from app.api import system as system_api
 from app.core.config_manager import VERSION
@@ -224,4 +225,36 @@ def test_check_app_update_endpoint_defaults_to_android():
         result = asyncio.run(system_api.check_app_update_endpoint(version="0.12.1"))
 
     assert result["platform"] == "android"
+
+
+def test_tianditu_sdk_urls_are_rewritten_to_server_proxy():
+    source = (
+        'T.w={E:T.Protocol.value+"api.tianditu."+T.Domain,'
+        'IPSERVER:T.Protocol.value+"location.tianditu.gov.cn"};'
+        'var fallback="https://t3.tianditu.gov.cn/vec_w/wmts";'
+    )
+    rewritten = system_api._rewrite_tianditu_text(source)
+
+    assert '"/api/system/map-proxy/api.tianditu.gov.cn"' in rewritten
+    assert '"/api/system/map-proxy/location.tianditu.gov.cn"' in rewritten
+    assert "/api/system/map-proxy/t3.tianditu.gov.cn/vec_w/wmts" in rewritten
+    assert "https://t3.tianditu.gov.cn" not in rewritten
+
+
+def test_map_proxy_uses_public_server_origin_for_browser_key():
+    request = Request({
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("server", 8000),
+        "path": "/system/map-proxy/api.tianditu.gov.cn/api",
+        "query_string": b"",
+        "headers": [
+            (b"host", b"server:8000"),
+            (b"x-forwarded-proto", b"https"),
+            (b"x-forwarded-host", b"photos.example.com"),
+        ],
+    })
+
+    assert system_api._public_request_origin(request) == "https://photos.example.com"
 

--- a/package/website/android/app/src/main/java/cn/trailsnap/app/AppUpdaterPlugin.java
+++ b/package/website/android/app/src/main/java/cn/trailsnap/app/AppUpdaterPlugin.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
+import android.content.Context;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -45,6 +46,8 @@ public class AppUpdaterPlugin extends Plugin {
     private static final int CONNECT_TIMEOUT_MS = 15000;
     private static final int READ_TIMEOUT_MS = 60000;
     private static final int MAX_REDIRECTS = 5;
+    private static final String PREFERENCES_GROUP = "CapacitorStorage";
+    private static final String SERVER_URL_KEY = "trailsnap_server_url";
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final AtomicBoolean downloading = new AtomicBoolean(false);
@@ -95,6 +98,10 @@ public class AppUpdaterPlugin extends Plugin {
         String url = call.getString("url");
         if (url == null || url.isEmpty()) {
             call.reject("缺少安装包下载地址", "INVALID_URL");
+            return;
+        }
+        if (!isConfiguredServerUrl(url)) {
+            call.reject("安装包必须从当前 TrailSnap Server 下载", "EXTERNAL_DOWNLOAD_BLOCKED");
             return;
         }
         String version = sanitize(call.getString("version", "latest"));
@@ -249,6 +256,9 @@ public class AppUpdaterPlugin extends Plugin {
                     throw new IllegalStateException("重定向缺少 Location 头");
                 }
                 current = new URL(new URL(current), location).toString();
+                if (!isConfiguredServerUrl(current)) {
+                    throw new SecurityException("Server 下载地址重定向到了外部服务器");
+                }
                 continue;
             }
             return connection;
@@ -262,6 +272,28 @@ public class AppUpdaterPlugin extends Plugin {
         data.put("total", total);
         data.put("percent", total > 0 ? (int) Math.min(100, downloaded * 100 / total) : 0);
         notifyListeners(EVENT_PROGRESS, data, true);
+    }
+
+    private boolean isConfiguredServerUrl(String candidate) {
+        String configured = getContext()
+            .getSharedPreferences(PREFERENCES_GROUP, Context.MODE_PRIVATE)
+            .getString(SERVER_URL_KEY, "");
+        if (configured == null || configured.isEmpty()) return false;
+        try {
+            URL expected = new URL(configured);
+            URL actual = new URL(candidate);
+            return expected.getProtocol().equalsIgnoreCase(actual.getProtocol())
+                && expected.getHost().equalsIgnoreCase(actual.getHost())
+                && effectivePort(expected) == effectivePort(actual)
+                && actual.getPath().startsWith("/api/system/app-update-download/");
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private int effectivePort(URL url) {
+        if (url.getPort() >= 0) return url.getPort();
+        return url.getDefaultPort();
     }
 
     private boolean canRequestInstall() {

--- a/package/website/android/app/src/main/java/cn/trailsnap/app/MainActivity.java
+++ b/package/website/android/app/src/main/java/cn/trailsnap/app/MainActivity.java
@@ -12,6 +12,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(LanDiscoveryPlugin.class);
         registerPlugin(AppUpdaterPlugin.class);
         super.onCreate(savedInstanceState);
+        bridge.setWebViewClient(new OfflineOnlyWebViewClient(bridge, this));
         handleGalleryBackupAction(getIntent());
     }
 

--- a/package/website/android/app/src/main/java/cn/trailsnap/app/OfflineOnlyWebViewClient.java
+++ b/package/website/android/app/src/main/java/cn/trailsnap/app/OfflineOnlyWebViewClient.java
@@ -1,0 +1,96 @@
+package cn.trailsnap.app;
+
+import android.content.Context;
+import android.net.Uri;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebView;
+
+import com.getcapacitor.Bridge;
+import com.getcapacitor.BridgeWebViewClient;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Native network boundary for the packaged App.
+ *
+ * Once a TrailSnap Server is selected, WebView HTTP(S) requests are accepted
+ * only for that exact origin.  Before onboarding, private/LAN hosts are allowed
+ * so discovery and connection testing can work.  App assets remain available
+ * from Capacitor's localhost origin.
+ */
+public final class OfflineOnlyWebViewClient extends BridgeWebViewClient {
+    private static final String PREFERENCES_GROUP = "CapacitorStorage";
+    private static final String SERVER_URL_KEY = "trailsnap_server_url";
+
+    private final Context context;
+
+    public OfflineOnlyWebViewClient(Bridge bridge, Context context) {
+        super(bridge);
+        this.context = context.getApplicationContext();
+    }
+
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        Uri uri = request.getUrl();
+        if (isAllowed(uri)) return super.shouldInterceptRequest(view, request);
+        byte[] body = "Blocked by TrailSnap offline network policy".getBytes(StandardCharsets.UTF_8);
+        return new WebResourceResponse(
+            "text/plain", "UTF-8", 403, "Blocked", null, new ByteArrayInputStream(body)
+        );
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+        Uri uri = request.getUrl();
+        if (!isAllowed(uri)) return true;
+        return super.shouldOverrideUrlLoading(view, request);
+    }
+
+    private boolean isAllowed(Uri uri) {
+        String scheme = lower(uri.getScheme());
+        if (scheme.equals("data") || scheme.equals("blob") || scheme.equals("file")
+            || scheme.equals("content") || scheme.equals("capacitor")) return true;
+        if (!scheme.equals("http") && !scheme.equals("https")) return false;
+
+        String host = lower(uri.getHost());
+        if (host.equals("localhost") || host.equals("127.0.0.1") || host.equals("::1")) return true;
+
+        String configured = context
+            .getSharedPreferences(PREFERENCES_GROUP, Context.MODE_PRIVATE)
+            .getString(SERVER_URL_KEY, "");
+        // Onboarding must be able to test a user-entered public or LAN URL.
+        // The exact-origin boundary becomes active immediately after it is saved.
+        if (configured == null || configured.isEmpty()) return true;
+        Uri server = Uri.parse(configured);
+        return scheme.equals(lower(server.getScheme()))
+            && host.equals(lower(server.getHost()))
+            && effectivePort(uri) == effectivePort(server);
+    }
+
+    private static int effectivePort(Uri uri) {
+        if (uri.getPort() >= 0) return uri.getPort();
+        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+    }
+
+    private static boolean isPrivateLanHost(String host) {
+        if (host.endsWith(".local")) return true;
+        if (host.startsWith("10.") || host.startsWith("192.168.")) return true;
+        if (host.startsWith("169.254.")) return true;
+        if (host.startsWith("172.")) {
+            String[] parts = host.split("\\.");
+            if (parts.length == 4) {
+                try {
+                    int second = Integer.parseInt(parts[1]);
+                    return second >= 16 && second <= 31;
+                } catch (NumberFormatException ignored) {}
+            }
+        }
+        return host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:");
+    }
+
+    private static String lower(String value) {
+        return value == null ? "" : value.toLowerCase(java.util.Locale.ROOT);
+    }
+}

--- a/package/website/src/api/system.ts
+++ b/package/website/src/api/system.ts
@@ -15,7 +15,7 @@ export interface AppUpdateCheckResult {
   latest_version: string | null
   has_update: boolean
   update_info: string
-  /** APK 直链，App 直接下载 */
+  /** 当前自部署 Server 上的 APK 同源下载路径 */
   download_url: string | null
   file_name: string | null
   /** 服务端已知的安装包大小；为 0 表示未知，客户端跳过大小校验 */

--- a/package/website/src/assets/default-avatar.svg
+++ b/package/website/src/assets/default-avatar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-label="默认头像">
+  <rect width="96" height="96" rx="48" fill="#e5e7eb"/>
+  <circle cx="48" cy="36" r="18" fill="#9ca3af"/>
+  <path d="M18 88c3-20 15-30 30-30s27 10 30 30" fill="#9ca3af"/>
+</svg>

--- a/package/website/src/components/annual-report/SectionFarthestCity.vue
+++ b/package/website/src/components/annual-report/SectionFarthestCity.vue
@@ -48,7 +48,7 @@
         <!-- Corkboard Background -->
         <div class="absolute inset-0 bg-[#E8DCC4] dark:bg-[#3E3328] rounded-xl shadow-[inset_0_0_20px_rgba(0,0,0,0.1)] overflow-hidden border-8 border-[#D4B996] dark:border-[#5C4D3C]">
            <!-- Texture overlay -->
-           <div class="absolute inset-0 opacity-30 bg-[url('https://www.transparenttextures.com/patterns/cork-board.png')] mix-blend-multiply dark:mix-blend-overlay"></div>
+           <div class="cork-texture absolute inset-0 opacity-30 mix-blend-multiply dark:mix-blend-overlay"></div>
            
            <!-- Shadow edge -->
            <div class="absolute inset-0 shadow-[inset_0_0_30px_rgba(0,0,0,0.15)] pointer-events-none z-10 rounded-lg"></div>
@@ -244,6 +244,13 @@ const getPhotoUrl = (photo: Photo) => {
 .font-handwriting {
   font-family: 'Comic Sans MS', 'Chalkboard SE', 'Marker Felt', sans-serif; /* Fallback to system handwriting fonts */
   /* Ideally we would import a webfont like 'Caveat' or 'Ma Shan Zheng' */
+}
+
+.cork-texture {
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(120, 90, 55, 0.28) 0 1px, transparent 1.5px),
+    radial-gradient(circle at 75% 65%, rgba(255, 255, 255, 0.28) 0 1px, transparent 1.5px);
+  background-size: 11px 13px, 17px 19px;
 }
 
 /* Animations */

--- a/package/website/src/components/annual-report/SectionPhotoWall.vue
+++ b/package/website/src/components/annual-report/SectionPhotoWall.vue
@@ -104,7 +104,6 @@ const positions = ref<{ x: number; y: number; z: number; rX: number; rY: number;
 
 const getPhotoUrl = (photo: Photo) => {
     return thumbnailUrl(photo.id, 'small', photo.owner_id);
-    return `https://picsum.photos/seed/${photo.id}/400/600`;
 }
 
 // Fetch Photos

--- a/package/website/src/composables/useAppUpdate.ts
+++ b/package/website/src/composables/useAppUpdate.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import { Preferences } from '@capacitor/preferences'
 import type { PluginListenerHandle } from '@capacitor/core'
 import { systemApi, type AppUpdateCheckResult } from '@/api/system'
+import { toServerUrl } from '@/config/server'
 import {
   appUpdaterNative,
   supportsAppUpdate,
@@ -92,7 +93,7 @@ async function attachProgressListener(): Promise<void> {
 function applyResult(result: AppUpdateCheckResult): boolean {
   latestVersion.value = result.latest_version || ''
   updateInfo.value = result.update_info || ''
-  pendingUrl = result.download_url || ''
+  pendingUrl = result.download_url ? toServerUrl(result.download_url) : ''
   pendingSize = result.size || 0
   return result.has_update && !!pendingUrl
 }

--- a/package/website/src/composables/useExternalLinks.ts
+++ b/package/website/src/composables/useExternalLinks.ts
@@ -1,4 +1,4 @@
-import { isTauriApp } from '@/config/server'
+import { getServerUrl, isMobileApp, isTauriApp } from '@/config/server'
 
 let installed = false
 
@@ -16,7 +16,12 @@ function isExternalUrl(href: string): boolean {
   if (/^(mailto:|tel:)/i.test(href)) return true
   if (!/^https?:/i.test(href)) return false
   try {
-    return new URL(href, window.location.href).origin !== window.location.origin
+    const origin = new URL(href, window.location.href).origin
+    if (origin === window.location.origin) return false
+    if (isMobileApp() && getServerUrl()) {
+      return origin !== new URL(getServerUrl(), window.location.href).origin
+    }
+    return true
   } catch {
     return false
   }
@@ -34,8 +39,20 @@ async function openExternal(href: string): Promise<void> {
  * Web 与移动端环境下为空操作。
  */
 export async function registerExternalLinkOpener(): Promise<void> {
-  if (!isTauriApp() || installed) return
+  if ((!isTauriApp() && !isMobileApp()) || installed) return
   installed = true
+
+  if (isMobileApp()) {
+    document.addEventListener('click', (event) => {
+      const link = (event.target as HTMLElement | null)?.closest?.('a')
+      const href = link?.href || link?.getAttribute('href') || ''
+      if (!isExternalUrl(href)) return
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      console.warn('[TrailSnap] blocked external link in packaged App')
+    }, true)
+    return
+  }
 
   // 预热 opener 模块，避免首次点击因动态 import 产生可感延迟
   void import('@tauri-apps/plugin-opener').catch(() => {})

--- a/package/website/src/composables/useLocationMap.ts
+++ b/package/website/src/composables/useLocationMap.ts
@@ -1,5 +1,5 @@
 import { ref, onUnmounted, nextTick, watch } from 'vue'
-import { loadMapScript, MapLoadError } from '@/utils/mapLoader'
+import { getTiandituTileTemplate, loadMapScript, MapLoadError } from '@/utils/mapLoader'
 import { injectTheme } from '@/composables/useTheme'
 
 declare const T: any
@@ -54,8 +54,9 @@ export function useLocationMap(callbacks?: {
   })
 
   const initMap = async (opts: LocationMapOptions) => {
+    let apiKey = ''
     try {
-      await loadMapScript()
+      apiKey = await loadMapScript()
     } catch (e: any) {
       mapError.value = e instanceof MapLoadError ? e.code : 'UNKNOWN'
       return
@@ -76,7 +77,15 @@ export function useLocationMap(callbacks?: {
       : new T.LngLat(104.195, 35.861)
     const zoom = opts.initialZoom || (hasCoords ? 14 : 4)
 
-    map = new T.Map(opts.containerId)
+    const vecTileUrl = getTiandituTileTemplate('vec_w', apiKey)
+    const cvaTileUrl = getTiandituTileTemplate('cva_w', apiKey)
+    map = vecTileUrl && cvaTileUrl
+      ? new T.Map(opts.containerId, { layers: [] })
+      : new T.Map(opts.containerId)
+    if (vecTileUrl && cvaTileUrl) {
+      map.addOverLay(new T.TileLayer(vecTileUrl, { minZoom: 1, maxZoom: 18 }))
+      map.addOverLay(new T.TileLayer(cvaTileUrl, { minZoom: 1, maxZoom: 18 }))
+    }
     map.centerAndZoom(center, zoom)
     map.enableScrollWheelZoom()
 

--- a/package/website/src/config/nativeNetworkPolicy.ts
+++ b/package/website/src/config/nativeNetworkPolicy.ts
@@ -1,0 +1,70 @@
+import { getServerUrl, isMobileApp } from './server'
+
+let installed = false
+
+function isAllowed(value: string | URL): boolean {
+  const raw = value.toString()
+  if (/^(?:data:|blob:|file:|content:|capacitor:)/i.test(raw)) return true
+  let target: URL
+  try {
+    target = new URL(raw, window.location.href)
+  } catch {
+    return false
+  }
+  if (!['http:', 'https:', 'ws:', 'wss:'].includes(target.protocol)) return false
+  if (target.hostname === 'localhost' || target.hostname === '127.0.0.1' || target.hostname === '[::1]') return true
+
+  const configured = getServerUrl()
+  // The connection screen must be able to test the address the user enters.
+  // Once saved, the exact-origin rule below becomes mandatory.
+  if (!configured) return true
+  const server = new URL(configured, window.location.href)
+  const targetProtocol = target.protocol.replace(/^ws/, 'http')
+  return targetProtocol === server.protocol && target.host === server.host
+}
+
+function reject(kind: string, value: string | URL): never {
+  console.warn(`[TrailSnap] blocked external ${kind}`)
+  throw new TypeError('TrailSnap App 仅允许连接当前自部署 Server')
+}
+
+/** Browser-layer guard, primarily for iOS and WebSocket/sendBeacon coverage. */
+export function installNativeNetworkPolicy(): void {
+  if (!isMobileApp() || installed) return
+  installed = true
+
+  const originalFetch = window.fetch.bind(window)
+  window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = input instanceof Request ? input.url : input
+    if (!isAllowed(url)) return Promise.reject(new TypeError('TrailSnap App 已阻止外部网络请求'))
+    return originalFetch(input, init)
+  }) as typeof window.fetch
+
+  const originalOpen = XMLHttpRequest.prototype.open
+  XMLHttpRequest.prototype.open = function(method: string, url: string | URL, ...rest: any[]) {
+    if (!isAllowed(url)) reject('XMLHttpRequest', url)
+    return originalOpen.call(this, method, url, ...rest as [boolean?, string?, string?])
+  } as typeof XMLHttpRequest.prototype.open
+
+  const NativeEventSource = window.EventSource
+  window.EventSource = new Proxy(NativeEventSource, {
+    construct(target, args, newTarget) {
+      if (!isAllowed(args[0])) reject('EventSource', args[0])
+      return Reflect.construct(target, args, newTarget)
+    },
+  })
+
+  const NativeWebSocket = window.WebSocket
+  window.WebSocket = new Proxy(NativeWebSocket, {
+    construct(target, args, newTarget) {
+      if (!isAllowed(args[0])) reject('WebSocket', args[0])
+      return Reflect.construct(target, args, newTarget)
+    },
+  })
+
+  const originalBeacon = navigator.sendBeacon?.bind(navigator)
+  if (originalBeacon) {
+    navigator.sendBeacon = ((url: string | URL, data?: BodyInit | null) =>
+      isAllowed(url) ? originalBeacon(url, data) : false) as typeof navigator.sendBeacon
+  }
+}

--- a/package/website/src/config/server.ts
+++ b/package/website/src/config/server.ts
@@ -144,8 +144,20 @@ export async function saveServerUrl(value: string): Promise<string> {
 
 /** Convert relative API/media paths into URLs on the configured public origin. */
 export function toServerUrl(path: string): string {
-  if (/^(?:https?:|blob:|data:)/i.test(path)) return path
+  if (/^(?:blob:|data:)/i.test(path)) return path
   const base = getServerUrl()
+  if (/^https?:/i.test(path)) {
+    if (!isMobileApp()) return path
+    try {
+      const target = new URL(path)
+      const appOrigin = new URL(window.location.href).origin
+      if (target.origin === appOrigin || (base && target.origin === new URL(base).origin)) return path
+    } catch {
+      // Invalid absolute URLs are rejected below for the packaged App.
+    }
+    console.warn('[TrailSnap] blocked external native resource URL')
+    return ''
+  }
   if (!base) return path
   return `${base}${path.startsWith('/') ? path : `/${path}`}`
 }

--- a/package/website/src/main.ts
+++ b/package/website/src/main.ts
@@ -22,10 +22,12 @@ import { registerExternalLinkOpener } from '@/composables/useExternalLinks'
 import { registerElementPlusOverlayBridge } from '@/composables/useOverlayStack'
 import { useUserStore } from '@/stores/user'
 import { registerConnectionDeepLinks } from '@/config/serverConnection'
+import { installNativeNetworkPolicy } from '@/config/nativeNetworkPolicy'
 
 async function bootstrap() {
   document.documentElement.classList.toggle('tauri-desktop', isTauriApp())
   await initializeServerConfig()
+  installNativeNetworkPolicy()
   document.documentElement.classList.toggle('capacitor-native', isNativeApp())
   const app = createApp(App);
   // 2. 创建 Pinia 实例

--- a/package/website/src/stores/albumStore.ts
+++ b/package/website/src/stores/albumStore.ts
@@ -62,9 +62,11 @@ export const useAlbumStore = defineStore('album', () => {
     return apiAlbums.value.map(album => {
       const cover: AlbumImage = album.cover ? mapPhotoToImage(album.cover) : {
         id: '',
-        url: 'https://placehold.co/400x300?text=Empty',
-        thumbnail: 'https://placehold.co/400x300?text=Empty',
-        preview: 'https://placehold.co/400x300?text=Empty',
+        // Empty covers are rendered by the component fallback.  A data URL
+        // keeps the native app fully local instead of leaking to placehold.co.
+        url: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
+        thumbnail: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
+        preview: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
         srcset: '',
         timestamp: Date.now(),
         albumIds: [],

--- a/package/website/src/utils/mapKeyTester.ts
+++ b/package/website/src/utils/mapKeyTester.ts
@@ -24,7 +24,11 @@ export async function testTiandituBrowserKey(
   })
 
   try {
-    const response = await fetch(`https://api.tianditu.gov.cn/geocoder?${params}`, {
+    const { isMobileApp, toServerUrl } = await import('@/config/server')
+    const endpoint = isMobileApp()
+      ? toServerUrl(`/api/system/map-proxy/api.tianditu.gov.cn/geocoder?${params}`)
+      : `https://api.tianditu.gov.cn/geocoder?${params}`
+    const response = await fetch(endpoint, {
       signal: controller.signal,
     })
     let data: any = null

--- a/package/website/src/utils/mapLoader.ts
+++ b/package/website/src/utils/mapLoader.ts
@@ -20,10 +20,11 @@ let loadingPromise: Promise<string> | null = null
  * route and must keep using Tianditu's default layers.
  */
 export const getTiandituTileTemplate = (layer: 'vec_w' | 'cva_w', key: string): string | null => {
-  const path = `/tianditu-tiles/DataServer?T=${layer}&x={x}&y={y}&l={z}&tk=${encodeURIComponent(key)}`
+  const nginxPath = `/tianditu-tiles/DataServer?T=${layer}&x={x}&y={y}&l={z}&tk=${encodeURIComponent(key)}`
+  const serverPath = `/api/system/map-proxy/t0.tianditu.gov.cn/DataServer?T=${layer}&x={x}&y={y}&l={z}&tk=${encodeURIComponent(key)}`
 
-  if (isMobileApp()) return toServerUrl(path)
-  if (import.meta.env.PROD && !isNativeApp()) return path
+  if (isMobileApp()) return toServerUrl(serverPath)
+  if (import.meta.env.PROD && !isNativeApp()) return nginxPath
   return null
 }
 
@@ -80,7 +81,13 @@ const loadTianditu = (key: string) => {
     }
 
     const script = document.createElement('script')
-    script.src = `https://api.tianditu.gov.cn/api?v=4.0&tk=${key}`
+    // Capacitor must never contact Tianditu directly.  The self-hosted server
+    // is the sole network boundary and proxies (and caches) every SDK request.
+    // Keep the browser path direct in development so existing web deployments
+    // are not forced to expose this endpoint.
+    script.src = isMobileApp()
+      ? toServerUrl(`/api/system/map-proxy/api.tianditu.gov.cn/api?v=4.0&tk=${encodeURIComponent(key)}`)
+      : `https://api.tianditu.gov.cn/api?v=4.0&tk=${encodeURIComponent(key)}`
     script.type = 'text/javascript'
     script.onload = () => resolve()
     script.onerror = () => reject(new MapLoadError('Failed to load map script', 'SCRIPT_LOAD_ERROR'))

--- a/package/website/src/views/settings/BasicSettings.vue
+++ b/package/website/src/views/settings/BasicSettings.vue
@@ -94,7 +94,7 @@
                 </div>
                 <div>
                   <h3 class="font-medium text-gray-900 dark:text-white">天地图 Web API</h3>
-                  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">配置一个或多个 Key，系统会随机选择使用。保存前会自动验证每个 Key。</p>
+                  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">配置一个或多个浏览器端 Key，系统会随机选择使用。若 Key 启用了域名白名单，请加入当前自部署 Server 的域名或 IP。保存前会自动验证每个 Key。</p>
                 </div>
               </div>
               <el-select v-model="mapForm.provider" aria-label="地图提供商" class="w-full sm:w-48" @change="resetMapKeyTests">

--- a/package/website/src/views/settings/MobileAppConnection.vue
+++ b/package/website/src/views/settings/MobileAppConnection.vue
@@ -28,7 +28,7 @@
           {{ androidDownloadUrl }}
         </p>
         <p class="text-xs leading-5 text-gray-500 dark:text-gray-400">
-          安装时 Android 可能要求允许浏览器“安装未知应用”。请确认地址属于 TrailSnap 官方 GitHub 仓库。
+          安装包由上方填写的自部署 TrailSnap Server 提供，手机无需连接外部下载站点。
         </p>
       </div>
 
@@ -122,7 +122,6 @@ const address = ref(currentOrigin)
 const connectionQrCode = ref('')
 const downloadQrCode = ref('')
 const appVersion = packageMetadata.version
-const androidDownloadUrl = `https://github.com/LC044/TrailSnap/releases/download/v${appVersion}/TrailSnap-${appVersion}-debug.apk`
 
 const normalizedAddress = computed(() => {
   try {
@@ -130,6 +129,11 @@ const normalizedAddress = computed(() => {
   } catch {
     return ''
   }
+})
+
+const androidDownloadUrl = computed(() => {
+  const origin = normalizedAddress.value || currentOrigin
+  return `${origin}/api/system/app-update-download/${appVersion}`
 })
 
 const addressError = computed(() => {
@@ -163,15 +167,17 @@ watch(normalizedAddress, async value => {
   }
 }, { immediate: true })
 
-QRCode.toDataURL(androidDownloadUrl, {
-  width: 320,
-  margin: 1,
-  errorCorrectionLevel: 'M',
-}).then(dataUrl => {
-  downloadQrCode.value = dataUrl
-}).catch(() => {
-  downloadQrCode.value = ''
-})
+watch(androidDownloadUrl, value => {
+  QRCode.toDataURL(value, {
+    width: 320,
+    margin: 1,
+    errorCorrectionLevel: 'M',
+  }).then(dataUrl => {
+    downloadQrCode.value = dataUrl
+  }).catch(() => {
+    downloadQrCode.value = ''
+  })
+}, { immediate: true })
 
 async function writeClipboard(value: string): Promise<void> {
   if (navigator.clipboard?.writeText) {

--- a/package/website/src/views/settings/ProfileSettings.vue
+++ b/package/website/src/views/settings/ProfileSettings.vue
@@ -67,7 +67,7 @@ import { toServerUrl } from '@/config/server'
 import { thumbnailPath } from '@/utils/mediaUrl'
 
 const userStore = useUserStore()
-const defaultAvatar = 'https://cube.elemecdn.com/3/7c/3ea6beec64369c2642b92c6726f1epng.png'
+const defaultAvatar = new URL('../../assets/default-avatar.svg', import.meta.url).href
 
 const form = reactive({
   username: '',

--- a/package/website/tests/e2e/specs/login/mobile-server-login.spec.ts
+++ b/package/website/tests/e2e/specs/login/mobile-server-login.spec.ts
@@ -153,8 +153,8 @@ test.describe('手机 App 天地图瓦片 @p0', () => {
     await expect.poll(() => page.evaluate(() => (
       (window as typeof window & { __tiandituTileTemplates?: string[] }).__tiandituTileTemplates || []
     ))).toEqual([
-      'http://192.168.1.10:8082/tianditu-tiles/DataServer?T=vec_w&x={x}&y={y}&l={z}&tk=mobile-map-key',
-      'http://192.168.1.10:8082/tianditu-tiles/DataServer?T=cva_w&x={x}&y={y}&l={z}&tk=mobile-map-key',
+      'http://192.168.1.10:8082/api/system/map-proxy/t0.tianditu.gov.cn/DataServer?T=vec_w&x={x}&y={y}&l={z}&tk=mobile-map-key',
+      'http://192.168.1.10:8082/api/system/map-proxy/t0.tianditu.gov.cn/DataServer?T=cva_w&x={x}&y={y}&l={z}&tk=mobile-map-key',
     ])
   })
 })

--- a/package/website/tests/e2e/specs/settings/settings-tabs-extra.spec.ts
+++ b/package/website/tests/e2e/specs/settings/settings-tabs-extra.spec.ts
@@ -39,7 +39,10 @@ test.describe('Smoke - 设置中心剩余 Tab 切换 @smoke', () => {
     await expect(page.getByRole('heading', { name: '连接手机 App', exact: true })).toBeVisible();
     await expect(page.getByRole('heading', { name: '下载 Android App' })).toBeVisible();
     await expect(page.getByText(/当前版本：TrailSnap v\d+\.\d+\.\d+/)).toBeVisible();
-    await expect(page.getByRole('link', { name: '下载 Android APK' })).toHaveAttribute('href', /github\.com\/LC044\/TrailSnap\/releases\/download\/v\d+\.\d+\.\d+\/TrailSnap-\d+\.\d+\.\d+-debug\.apk/);
+    await expect(page.getByRole('link', { name: '下载 Android APK' })).toHaveAttribute(
+      'href',
+      /\/api\/system\/app-update-download\/\d+\.\d+\.\d+$/,
+    );
     await expect(page.getByAltText('TrailSnap Android App 下载二维码')).toBeVisible();
     await expect(page.getByRole('heading', { name: '连接到这台 TrailSnap' })).toBeVisible();
 


### PR DESCRIPTION
## 描述

将手机 App 的运行时网络边界收敛到用户选择的自部署 TrailSnap Server：

- Android WebView 原生拦截非当前 Server 的 HTTP/HTTPS 请求，Web 层补充 Fetch、XHR、SSE、WebSocket、Beacon 与外链限制。
- 天地图 SDK、瓦片、搜索和逆地理编码统一通过 Server 白名单代理；代理以 Server 公开 Origin 设置 Referer/Origin，兼容启用域名白名单的浏览器端 Key。
- Server 定时预下载最新版 Android APK，App 仅从当前 Server 下载，并拒绝外部下载地址和跨源重定向。
- 默认头像、空相册封面及纹理资源本地化。
- 增加首次连接例外和应用商店权限说明。

## 变更类型

- [x] ✨ 新功能 (New Feature)
- [x] 📝 文档更新 (Documentation)
- [x] ✅ 测试增加/修改 (Tests)

## 相关 Issue

Closes #179

## 如何测试

- 前端生产构建：通过。
- Server 更新与系统单测：32 项通过。
- 手机连接及地图 E2E：5 项通过。
- 使用真实天地图 SDK 响应检查重写结果，无残留直连天地图 API 地址。
- 新增 Android WebView 拦截器使用 Android 36 与 Capacitor classpath 单独编译通过。

当前 Windows 环境执行完整 Gradle 构建时，Gradle 在任务启动前因 Unable to establish loopback connection 退出；交由 PR CI 在 Linux 环境完成完整 Android 构建。

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 相关测试均已通过
- [x] 我已更新了相关文档