### PR TITLE
feat(agent): 实现只读 MCP Server 与令牌权限隔离

### DIFF
--- a/doc/mcp_server.md
+++ b/doc/mcp_server.md
@@ -1,0 +1,70 @@
+# TrailSnap MCP Server
+
+TrailSnap 内置一个只读的 Model Context Protocol（MCP）服务，使外部 AI Agent 可以安全查询当前用户的照片、相册、人物和回忆线索。MCP 与内置 LangGraph Agent 复用相同的相册领域服务，但拥有独立的协议入口和工具权限检查。
+
+## 连接地址
+
+- 通过 TrailSnap 前端或反向代理访问：`https://你的域名/api/mcp/`
+- 直接访问后端：`http://127.0.0.1:8000/mcp/`
+- 传输协议：Streamable HTTP
+- 鉴权：`Authorization: Bearer ts_xxx`
+
+Agent Token 可在「设置 → 令牌管理」中创建。创建时可以只授权任务实际需要的 MCP 权限。
+
+通用客户端配置示例：
+
+```json
+{
+  "mcpServers": {
+    "trailsnap": {
+      "type": "http",
+      "url": "https://你的域名/api/mcp/",
+      "headers": {
+        "Authorization": "Bearer ts_xxx"
+      }
+    }
+  }
+}
+```
+
+配置文件的具体位置和字段名由 MCP 客户端决定。不要把真实令牌提交到 Git 仓库或粘贴给不受信任的 Agent。
+
+## 工具
+
+| 工具 | Scope | 用途 |
+| --- | --- | --- |
+| `search_photos` | `photos:read` | 按日期、地点、OCR、媒体类型、方向、人物和评分搜索照片 |
+| `list_albums` | `albums:read` | 分页查询可访问的相册、封面和照片数量 |
+| `list_people` | `people:read` | 查询可见人物和人物 ID |
+| `investigate_memory` | `photos:read` | 融合模糊日期、地点、人物、文字和语义照片线索，生成候选回忆事件 |
+| `get_person_timeline` | `people:read` | 生成人物的年份、事件、地点、同行者和代表照片时间线 |
+
+所有工具都会从经过验证的 Agent Token 解析用户身份，数据库查询强制按该用户隔离。照片结果只返回安全元数据和缩略图 URL，不返回原始文件路径。回忆侦探给出的是可解释候选，而不是自动确认的事实。
+
+## 部署配置
+
+本机访问无需额外设置。通过域名、局域网 IP 或反向代理部署时，推荐配置：
+
+```dotenv
+TRAILSNAP_PUBLIC_URL=https://photos.example.com
+```
+
+此时 MCP 的公开资源地址自动成为 `https://photos.example.com/api/mcp/`，并把公开主机加入 DNS rebinding 防护白名单。
+
+如果 MCP 使用独立地址，可以覆盖：
+
+```dotenv
+TRAILSNAP_MCP_URL=https://mcp.example.com/mcp/
+TRAILSNAP_MCP_ALLOWED_HOSTS=mcp.example.com,192.168.1.10:8000
+```
+
+`TRAILSNAP_MCP_ALLOWED_HOSTS` 以逗号分隔。只添加实际由 TrailSnap 服务的主机，不要为方便而关闭 Host 校验。
+
+## 当前边界
+
+- MCP P3 MVP 仅开放只读工具。
+- 不开放删除照片、修改相册、文件写入和 HTML 执行。
+- 内置 LangGraph Agent 不被 MCP 替换；两者分别服务站内交互和外部 Agent 接入。
+- Agent Token 的 scopes 当前用于 MCP 工具授权；历史 REST/CLI 接口仍保持原有兼容行为。
+
+后续写工具应使用新的独立 scopes（例如 `artifacts:write`、`albums:propose`），并在服务端生成预览或计划，得到用户明确确认后才能执行。

--- a/package/server/alembic/versions/a91f2d6c4e38_0038_add_agent_token_scopes.py
+++ b/package/server/alembic/versions/a91f2d6c4e38_0038_add_agent_token_scopes.py
@@ -1,0 +1,35 @@
+"""Add least-privilege scopes to Agent Tokens.
+
+Revision ID: a91f2d6c4e38
+Revises: f32ad910c441
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "a91f2d6c4e38"
+down_revision = "f32ad910c441"
+branch_labels = None
+depends_on = None
+
+DEFAULT_READ_SCOPES = ["photos:read", "albums:read", "people:read"]
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_tokens",
+        sa.Column(
+            "scopes",
+            sa.JSON(),
+            server_default=sa.text(f"'{json.dumps(DEFAULT_READ_SCOPES)}'::json"),
+            nullable=False,
+        ),
+    )
+    op.alter_column("agent_tokens", "scopes", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("agent_tokens", "scopes")

--- a/package/server/alembic_sqlite/versions/0012_add_agent_token_scopes.py
+++ b/package/server/alembic_sqlite/versions/0012_add_agent_token_scopes.py
@@ -1,0 +1,35 @@
+"""Add least-privilege scopes to Agent Tokens (SQLite).
+
+Revision ID: sqlite_0012
+Revises: sqlite_0011
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "sqlite_0012"
+down_revision = "sqlite_0011"
+branch_labels = None
+depends_on = None
+
+DEFAULT_READ_SCOPES = ["photos:read", "albums:read", "people:read"]
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("agent_tokens") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "scopes",
+                sa.JSON(),
+                server_default=json.dumps(DEFAULT_READ_SCOPES),
+                nullable=False,
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("agent_tokens") as batch_op:
+        batch_op.drop_column("scopes")

--- a/package/server/app/api/agent_token.py
+++ b/package/server/app/api/agent_token.py
@@ -2,7 +2,7 @@ from typing import Any, List
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from app.schemas.agent_token import AgentTokenResponse, AgentTokenCreateAPI
+from app.schemas.agent_token import AGENT_TOKEN_READ_SCOPES, AgentTokenResponse, AgentTokenCreateAPI
 from app.crud import agent_token as crud_agent_token
 from app.crud import user as crud_user
 from app.dependencies import get_db
@@ -35,11 +35,18 @@ def create_token(
     if not user_auth:
         raise HTTPException(status_code=400, detail="密码错误")
 
+    invalid_scopes = sorted(set(token_in.scopes) - set(AGENT_TOKEN_READ_SCOPES))
+    if invalid_scopes:
+        raise HTTPException(status_code=400, detail=f"不支持的令牌权限: {', '.join(invalid_scopes)}")
+    if not token_in.scopes:
+        raise HTTPException(status_code=400, detail="至少选择一个令牌权限")
+
     return crud_agent_token.create_agent_token(
         db=db,
         user_id=current_user.id,
         name=token_in.name,
-        expires_at=token_in.expires_at
+        expires_at=token_in.expires_at,
+        scopes=list(dict.fromkeys(token_in.scopes)),
     )
 
 @router.delete("/{token_id}")

--- a/package/server/app/crud/agent_token.py
+++ b/package/server/app/crud/agent_token.py
@@ -15,13 +15,20 @@ def generate_token_string(length: int = 32) -> str:
     alphabet = string.ascii_letters + string.digits
     return "ts_" + ''.join(secrets.choice(alphabet) for _ in range(length))
 
-def create_agent_token(db: Session, user_id: UUID, name: str, expires_at: datetime) -> AgentToken:
+def create_agent_token(
+    db: Session,
+    user_id: UUID,
+    name: str,
+    expires_at: datetime,
+    scopes: Optional[List[str]] = None,
+) -> AgentToken:
     token_str = generate_token_string()
     db_obj = AgentToken(
         user_id=user_id,
         name=name,
         token=token_str,
         expires_at=expires_at,
+        scopes=scopes or ["photos:read", "albums:read", "people:read"],
         is_deleted=False
     )
     db.add(db_obj)

--- a/package/server/app/db/models/agent_token.py
+++ b/package/server/app/db/models/agent_token.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import JSON, Column, String, Boolean, DateTime, ForeignKey
 from app.db.types import UUID
 import uuid
 from datetime import datetime
@@ -12,4 +12,9 @@ class AgentToken(Base):
     token = Column(String, unique=True, index=True, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     expires_at = Column(DateTime, nullable=False)
+    scopes = Column(
+        JSON,
+        nullable=False,
+        default=lambda: ["photos:read", "albums:read", "people:read"],
+    )
     is_deleted = Column(Boolean, default=False, nullable=False)

--- a/package/server/app/schemas/agent_token.py
+++ b/package/server/app/schemas/agent_token.py
@@ -1,7 +1,9 @@
-from typing import Optional
+from typing import List
 from datetime import datetime
 from uuid import UUID
 from pydantic import BaseModel, Field
+
+AGENT_TOKEN_READ_SCOPES = ("photos:read", "albums:read", "people:read")
 
 class AgentTokenBase(BaseModel):
     name: str = Field(..., description="令牌名称")
@@ -9,6 +11,10 @@ class AgentTokenBase(BaseModel):
 class AgentTokenCreateAPI(AgentTokenBase):
     expires_at: datetime = Field(..., description="过期时间")
     password: str = Field(..., description="用户密码，用于验证")
+    scopes: List[str] = Field(
+        default_factory=lambda: list(AGENT_TOKEN_READ_SCOPES),
+        description="令牌权限；当前仅开放只读 MCP 权限",
+    )
 
 class AgentTokenResponse(AgentTokenBase):
     id: UUID
@@ -16,6 +22,7 @@ class AgentTokenResponse(AgentTokenBase):
     token: str
     created_at: datetime
     expires_at: datetime
+    scopes: List[str]
     is_deleted: bool
 
     class Config:

--- a/package/server/app/service/mcp_server.py
+++ b/package/server/app/service/mcp_server.py
@@ -1,0 +1,311 @@
+"""TrailSnap's read-only Model Context Protocol surface.
+
+The MCP transport deliberately reuses Agent Tokens instead of accepting user
+JWTs. Each tool resolves the owner from the verified token and checks its own
+least-privilege scope before touching the database.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+from urllib.parse import urlparse
+from uuid import UUID
+
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import ToolAnnotations
+from sqlalchemy import String, cast, func, or_
+
+from app.crud import album as crud_album
+from app.crud.agent_token import get_token_by_string
+from app.db.models.face import Face, FaceIdentity
+from app.db.models.image_description import ImageDescription
+from app.db.models.ocr import OCR
+from app.db.models.photo import Photo
+from app.db.models.photo_metadata import PhotoMetadata
+from app.db.session import SessionLocal
+from app.service.agent.album_p0 import build_person_timeline, investigate_memory_clues, photo_contexts
+
+
+READ_SCOPES = frozenset({"photos:read", "albums:read", "people:read"})
+READ_ONLY_ANNOTATIONS = ToolAnnotations(
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=False,
+)
+
+
+class AgentTokenVerifier(TokenVerifier):
+    """Adapt TrailSnap Agent Tokens to the MCP SDK resource-server contract."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not token.startswith("ts_"):
+            return None
+        with SessionLocal() as db:
+            agent_token = get_token_by_string(db, token)
+            if not agent_token or agent_token.expires_at < datetime.now(timezone.utc).replace(tzinfo=None):
+                return None
+            scopes = [scope for scope in (agent_token.scopes or []) if scope in READ_SCOPES]
+            return AccessToken(
+                token=token,
+                client_id=str(agent_token.id),
+                subject=str(agent_token.user_id),
+                scopes=scopes,
+                expires_at=int(agent_token.expires_at.replace(tzinfo=timezone.utc).timestamp()),
+                claims={"token_name": agent_token.name},
+            )
+
+
+def _endpoint_urls() -> tuple[str, str]:
+    explicit = os.getenv("TRAILSNAP_MCP_URL", "").strip().rstrip("/")
+    if explicit:
+        parsed = urlparse(explicit)
+        return f"{parsed.scheme}://{parsed.netloc}", f"{explicit}/"
+    public = os.getenv("TRAILSNAP_PUBLIC_URL", "").strip().rstrip("/")
+    if public:
+        return f"{public}/api", f"{public}/api/mcp/"
+    return "http://localhost:8000", "http://localhost:8000/mcp/"
+
+
+def _transport_security() -> TransportSecuritySettings | None:
+    """Keep localhost-safe defaults, but support the configured public host."""
+    _, resource_url = _endpoint_urls()
+    parsed = urlparse(resource_url)
+    configured = [item.strip() for item in os.getenv("TRAILSNAP_MCP_ALLOWED_HOSTS", "").split(",") if item.strip()]
+    if not os.getenv("TRAILSNAP_PUBLIC_URL", "").strip() and not os.getenv("TRAILSNAP_MCP_URL", "").strip() and not configured:
+        return None
+    hosts = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+    if parsed.hostname:
+        hosts.extend([parsed.hostname, f"{parsed.hostname}:*"])
+    hosts.extend(configured)
+    origins = [f"{parsed.scheme}://{parsed.netloc}"] if parsed.scheme and parsed.netloc else []
+    return TransportSecuritySettings(
+        allowed_hosts=list(dict.fromkeys(hosts)),
+        allowed_origins=origins,
+    )
+
+
+def _principal(required_scope: str) -> UUID:
+    access_token = get_access_token()
+    if not access_token or not access_token.subject:
+        raise ToolError("无法识别 Agent Token 所属用户")
+    if required_scope not in access_token.scopes:
+        raise ToolError(f"Agent Token 缺少权限: {required_scope}")
+    try:
+        return UUID(access_token.subject)
+    except ValueError as exc:  # pragma: no cover - verifier always emits UUID subjects
+        raise ToolError("Agent Token 用户标识无效") from exc
+
+
+def _parse_date(value: str | None, label: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ToolError(f"{label}格式必须为 YYYY-MM-DD") from exc
+
+
+issuer_url, resource_url = _endpoint_urls()
+mcp = MCPServer(
+    "TrailSnap",
+    title="TrailSnap 相册",
+    description="安全查询当前用户的照片、相册、人物与回忆线索。",
+    instructions="所有结果均属于 Agent Token 的所有者。候选回忆是可解释线索，不应被当作已确认事实。",
+    version="0.1.0",
+    token_verifier=AgentTokenVerifier(),
+    auth=AuthSettings(
+        issuer_url=issuer_url,
+        resource_server_url=resource_url,
+        required_scopes=[],
+    ),
+)
+
+
+@mcp.tool(structured_output=True, annotations=READ_ONLY_ANNOTATIONS)
+def search_photos(
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    location: Optional[str] = None,
+    ocr_text: Optional[str] = None,
+    media_type: Optional[str] = None,
+    orientation: Optional[str] = None,
+    has_people: Optional[bool] = None,
+    min_quality_score: Optional[float] = None,
+    min_memory_score: Optional[float] = None,
+    cursor: int = 0,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """多维搜索照片，返回安全元数据和缩略图 URL，不返回原始文件路径。"""
+    user_id = _principal("photos:read")
+    start, end = _parse_date(start_date, "开始日期"), _parse_date(end_date, "结束日期")
+    if start and end and start > end:
+        raise ToolError("开始日期不能晚于结束日期")
+    if orientation and orientation not in {"landscape", "portrait", "square"}:
+        raise ToolError("orientation 只能是 landscape、portrait 或 square")
+    offset, page_size = max(cursor, 0), min(max(limit, 1), 30)
+
+    with SessionLocal() as db:
+        query = (
+            db.query(Photo.id, Photo.photo_time)
+            .outerjoin(PhotoMetadata, PhotoMetadata.photo_id == Photo.id)
+            .outerjoin(ImageDescription, ImageDescription.photo_id == Photo.id)
+            .filter(Photo.owner_id == user_id, Photo.is_deleted.is_(False))
+        )
+        if start:
+            query = query.filter(Photo.photo_time >= start)
+        if end:
+            query = query.filter(Photo.photo_time < end + timedelta(days=1))
+        if location:
+            pattern = f"%{location}%"
+            query = query.filter(or_(
+                PhotoMetadata.country.ilike(pattern), PhotoMetadata.province.ilike(pattern),
+                PhotoMetadata.city.ilike(pattern), PhotoMetadata.district.ilike(pattern),
+                PhotoMetadata.address.ilike(pattern),
+            ))
+        if ocr_text:
+            query = query.join(OCR, OCR.photo_id == Photo.id).filter(OCR.text.ilike(f"%{ocr_text}%"))
+        if media_type:
+            query = query.filter(cast(Photo.file_type, String) == media_type)
+        if orientation == "landscape":
+            query = query.filter(Photo.width > Photo.height)
+        elif orientation == "portrait":
+            query = query.filter(Photo.height > Photo.width)
+        elif orientation == "square":
+            query = query.filter(Photo.height == Photo.width)
+        if has_people is True:
+            query = query.filter(Photo.faces.any(Face.is_deleted.is_(False)))
+        elif has_people is False:
+            query = query.filter(~Photo.faces.any(Face.is_deleted.is_(False)))
+        if min_quality_score is not None:
+            query = query.filter(ImageDescription.quality_score >= min_quality_score)
+        if min_memory_score is not None:
+            query = query.filter(ImageDescription.memory_score >= min_memory_score)
+
+        total = query.order_by(None).distinct().count()
+        ids = [
+            str(row[0]) for row in query.distinct()
+            .order_by(Photo.photo_time.desc().nulls_last())
+            .offset(offset).limit(page_size).all()
+        ]
+        return {
+            "total": total,
+            "returned": len(ids),
+            "next_cursor": offset + len(ids) if offset + len(ids) < total else None,
+            "photos": photo_contexts(db, str(user_id), ids),
+        }
+
+
+@mcp.tool(structured_output=True, annotations=READ_ONLY_ANNOTATIONS)
+def list_albums(cursor: int = 0, limit: int = 30) -> dict[str, Any]:
+    """列出当前用户可访问的相册及封面、类型和照片数量。"""
+    user_id = _principal("albums:read")
+    offset, page_size = max(cursor, 0), min(max(limit, 1), 100)
+    with SessionLocal() as db:
+        albums = crud_album.get_albums(db, skip=offset, limit=page_size + 1, user_id=user_id)
+        has_more = len(albums) > page_size
+        albums = albums[:page_size]
+        return {
+            "next_cursor": offset + page_size if has_more else None,
+            "albums": [{
+                "album_id": str(album.id),
+                "name": album.name,
+                "description": album.description,
+                "type": album.type,
+                "photo_count": album.num_photos or 0,
+                "created_at": album.create_time.isoformat() if album.create_time else None,
+                "cover_photo_id": str(album.cover_id) if album.cover_id else None,
+                "cover_thumbnail_url": f"/api/medias/{album.cover_id}/thumbnail" if album.cover_id else None,
+                "shared_with_me": album.owner_id != user_id,
+            } for album in albums],
+        }
+
+
+@mcp.tool(structured_output=True, annotations=READ_ONLY_ANNOTATIONS)
+def list_people(cursor: int = 0, limit: int = 30) -> dict[str, Any]:
+    """列出当前用户的可见人物及其照片数量，供人物时间线选择 identity_id。"""
+    user_id = _principal("people:read")
+    offset, page_size = max(cursor, 0), min(max(limit, 1), 100)
+    with SessionLocal() as db:
+        counts = (
+            db.query(Face.face_identity_id, func.count(func.distinct(Face.photo_id)).label("photo_count"))
+            .join(Photo, Photo.id == Face.photo_id)
+            .filter(Photo.owner_id == user_id, Photo.is_deleted.is_(False), Face.is_deleted.is_(False))
+            .group_by(Face.face_identity_id).subquery()
+        )
+        query = (
+            db.query(FaceIdentity, func.coalesce(counts.c.photo_count, 0))
+            .outerjoin(counts, counts.c.face_identity_id == FaceIdentity.id)
+            .filter(
+                FaceIdentity.owner_id == user_id,
+                FaceIdentity.is_deleted.is_(False),
+                FaceIdentity.is_hidden.is_(False),
+            )
+            .order_by(func.coalesce(counts.c.photo_count, 0).desc(), FaceIdentity.identity_name)
+        )
+        total = query.order_by(None).count()
+        rows = query.offset(offset).limit(page_size).all()
+        return {
+            "total": total,
+            "next_cursor": offset + len(rows) if offset + len(rows) < total else None,
+            "people": [{
+                "identity_id": str(identity.id), "name": identity.identity_name,
+                "description": identity.description, "tags": identity.tags or [],
+                "photo_count": count,
+                "default_face_id": identity.default_face_id,
+            } for identity, count in rows],
+        }
+
+
+@mcp.tool(structured_output=True, annotations=READ_ONLY_ANNOTATIONS)
+def investigate_memory(
+    query_text: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    locations: Optional[list[str]] = None,
+    persons: Optional[list[str]] = None,
+    text_terms: Optional[list[str]] = None,
+    semantic_photo_ids: Optional[list[str]] = None,
+    max_events: int = 8,
+) -> dict[str, Any]:
+    """融合日期、地点、人物、OCR/描述文字等模糊线索，返回可解释的候选回忆事件。"""
+    user_id = _principal("photos:read")
+    with SessionLocal() as db:
+        try:
+            return investigate_memory_clues(
+                db, str(user_id), query_text, start_date, end_date, locations,
+                persons, text_terms, semantic_photo_ids, max_events,
+            )
+        except ValueError as exc:
+            raise ToolError(str(exc)) from exc
+
+
+@mcp.tool(structured_output=True, annotations=READ_ONLY_ANNOTATIONS)
+def get_person_timeline(
+    identity_id: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    max_events: int = 20,
+) -> dict[str, Any]:
+    """按人物聚合年份、事件、地点、同行者和代表照片，生成只读人物时间线。"""
+    user_id = _principal("people:read")
+    with SessionLocal() as db:
+        try:
+            return build_person_timeline(db, str(user_id), identity_id, start_date, end_date, max_events)
+        except ValueError as exc:
+            raise ToolError(str(exc)) from exc
+
+
+mcp_http_app = mcp.streamable_http_app(
+    streamable_http_path="/",
+    json_response=True,
+    stateless_http=True,
+    transport_security=_transport_security(),
+)

--- a/package/server/main.py
+++ b/package/server/main.py
@@ -40,6 +40,7 @@ from app.core.config_manager import VERSION
 from app.dependencies import BaseResponse
 from app.service.task_manager import TaskManager
 from app.service.discovery import DiscoveryService
+from app.service.mcp_server import mcp, mcp_http_app
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -115,7 +116,10 @@ async def lifespan(app: FastAPI):
     discovery_service = DiscoveryService()
     discovery_service.start()
 
-    yield
+    # Mounted ASGI applications do not receive lifespan events from FastAPI.
+    # Run the MCP session manager inside the host lifespan explicitly.
+    async with mcp.session_manager.run():
+        yield
 
     discovery_service.stop()
     job_scheduler.stop()
@@ -271,7 +275,7 @@ app.add_middleware(
     minimum_size=1000,
     compresslevel=9,
     exclude_paths=exclude_paths,
-    exclude_exact={'/tasks/events', '/notifications/events'},
+    exclude_exact={'/tasks/events', '/notifications/events', '/mcp', '/mcp/'},
 )
 
 # 配置允许跨域的源（生产环境建议指定具体域名，不要用 "*"）
@@ -343,6 +347,10 @@ app.include_router(nav.router, prefix="/nav", tags=["Nav"])
 app.include_router(guess_city.router, prefix="/guess-city", tags=["GuessCity"])
 app.include_router(storage.router, prefix="/storage", tags=["Storage"])
 app.include_router(moment.router, prefix="/moments", tags=["Moments"])
+
+# Streamable HTTP MCP endpoint. It intentionally sits outside OpenAPI because
+# MCP has its own discovery and tool schemas.
+app.mount("/mcp", mcp_http_app, name="mcp")
 
 from fastapi.openapi.utils import get_openapi
 

--- a/package/server/pyproject.toml
+++ b/package/server/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "langchain-openai>=0.2.14",
     "langchain-community>=0.3.10",
     "langgraph>=0.2.61",
+    "mcp>=2.0,<3",
     "sse-starlette>=2.1.3",
     "psutil>=6.1.0",
     "zeroconf>=0.147.0",

--- a/package/server/tests/unit/test_agent_token_api.py
+++ b/package/server/tests/unit/test_agent_token_api.py
@@ -77,6 +77,7 @@ def test_create_token_persists_when_password_matches():
         name="my-token",
         password="correct",
         expires_at=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        scopes=["photos:read", "albums:read"],
     )
     fake_row = _token_row(name="my-token")
 
@@ -90,9 +91,22 @@ def test_create_token_persists_when_password_matches():
 
     authenticate.assert_called_once_with(db, email=user.email, password="correct")
     create_call.assert_called_once_with(
-        db=db, user_id=user.id, name="my-token", expires_at=payload.expires_at
+        db=db, user_id=user.id, name="my-token", expires_at=payload.expires_at,
+        scopes=["photos:read", "albums:read"],
     )
     assert result is fake_row
+
+
+@pytest.mark.parametrize("scopes", [[], ["photos:read", "photos:delete"]])
+def test_create_token_rejects_empty_or_unknown_scopes(scopes):
+    user = _user()
+    payload = SimpleNamespace(
+        name="limited", password="correct", expires_at=None, scopes=scopes,
+    )
+    with patch.object(tokens_api.crud_user, "authenticate", return_value=user):
+        with pytest.raises(HTTPException) as exc_info:
+            tokens_api.create_token(token_in=payload, db=object(), current_user=user)
+    assert exc_info.value.status_code == 400
 
 
 def test_delete_token_returns_404_when_crud_reports_missing():

--- a/package/server/tests/unit/test_mcp_server.py
+++ b/package/server/tests/unit/test_mcp_server.py
@@ -1,0 +1,129 @@
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from mcp import Client
+from mcp.server.auth.middleware.auth_context import auth_context_var
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.agent_token import AgentToken
+from app.db.models.album import Album
+from app.db.models.face import Face, FaceIdentity
+from app.db.models.photo import FileType, Photo
+from app.db.models.photo_metadata import PhotoMetadata
+from app.db.models.user import User
+from app.service import mcp_server
+
+
+pytestmark = [pytest.mark.smoke, pytest.mark.module_agent]
+
+
+@pytest.fixture()
+def mcp_db(monkeypatch):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    monkeypatch.setattr(mcp_server, "SessionLocal", factory)
+    try:
+        yield factory
+    finally:
+        engine.dispose()
+
+
+def _auth(user_id, scopes):
+    return auth_context_var.set(AuthenticatedUser(AccessToken(
+        token="ts_test",
+        client_id="test-client",
+        subject=str(user_id),
+        scopes=scopes,
+    )))
+
+
+@pytest.mark.asyncio
+async def test_mcp_protocol_lists_tools_and_owner_scopes_results(mcp_db):
+    owner, stranger = uuid4(), uuid4()
+    owned_photo, foreign_photo = uuid4(), uuid4()
+    person = FaceIdentity(id=uuid4(), owner_id=owner, identity_name="旅行伙伴", is_deleted=False, is_hidden=False)
+    with mcp_db() as db:
+        db.add_all([
+            User(id=owner, username="owner", hashed_password="x"),
+            User(id=stranger, username="stranger", hashed_password="x"),
+            Photo(id=owned_photo, owner_id=owner, filename="west-lake.jpg", file_path="west-lake.jpg", file_type=FileType.image, photo_time=datetime(2025, 5, 2, 10), is_deleted=False),
+            Photo(id=foreign_photo, owner_id=stranger, filename="private.jpg", file_path="private.jpg", file_type=FileType.image, photo_time=datetime(2025, 5, 2, 11), is_deleted=False),
+            PhotoMetadata(photo_id=owned_photo, city="杭州", address="西湖"),
+            PhotoMetadata(photo_id=foreign_photo, city="杭州", address="西湖"),
+            Album(id=uuid4(), owner_id=owner, name="杭州旅行", type="user", num_photos=1),
+            Album(id=uuid4(), owner_id=stranger, name="他人私密相册", type="user", num_photos=1),
+            person,
+        ])
+        db.flush()
+        db.add(Face(photo_id=owned_photo, face_identity_id=person.id, is_deleted=False))
+        db.commit()
+
+    context_token = _auth(owner, list(mcp_server.READ_SCOPES))
+    try:
+        async with Client(mcp_server.mcp) as client:
+            tools = await client.list_tools()
+            assert {tool.name for tool in tools.tools} == {
+                "search_photos", "list_albums", "list_people",
+                "investigate_memory", "get_person_timeline",
+            }
+            assert all(tool.annotations and tool.annotations.read_only_hint for tool in tools.tools)
+            assert all(tool.annotations and tool.annotations.destructive_hint is False for tool in tools.tools)
+
+            search = await client.call_tool("search_photos", {"location": "杭州"})
+            assert search.structured_content["total"] == 1
+            assert search.structured_content["photos"][0]["photo_id"] == str(owned_photo)
+
+            albums = await client.call_tool("list_albums", {})
+            assert [item["name"] for item in albums.structured_content["albums"]] == ["杭州旅行"]
+
+            people = await client.call_tool("list_people", {})
+            assert people.structured_content["people"][0]["identity_id"] == str(person.id)
+    finally:
+        auth_context_var.reset(context_token)
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_rejects_missing_scope(mcp_db):
+    owner = uuid4()
+    with mcp_db() as db:
+        db.add(User(id=owner, username="owner", hashed_password="x"))
+        db.commit()
+    context_token = _auth(owner, ["albums:read"])
+    try:
+        async with Client(mcp_server.mcp) as client:
+            result = await client.call_tool("search_photos", {})
+            assert result.is_error is True
+            assert "photos:read" in result.content[0].text
+    finally:
+        auth_context_var.reset(context_token)
+
+
+@pytest.mark.asyncio
+async def test_agent_token_verifier_rejects_expired_and_preserves_scopes(mcp_db):
+    owner = uuid4()
+    with mcp_db() as db:
+        db.add(User(id=owner, username="owner", hashed_password="x"))
+        db.add_all([
+            AgentToken(id=uuid4(), user_id=owner, name="mcp", token="ts_valid", expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=1), scopes=["photos:read"], is_deleted=False),
+            AgentToken(id=uuid4(), user_id=owner, name="expired", token="ts_expired", expires_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=1), scopes=list(mcp_server.READ_SCOPES), is_deleted=False),
+        ])
+        db.commit()
+
+    verifier = mcp_server.AgentTokenVerifier()
+    access = await verifier.verify_token("ts_valid")
+    assert access is not None
+    assert access.subject == str(owner)
+    assert access.scopes == ["photos:read"]
+    assert await verifier.verify_token("ts_expired") is None
+    assert await verifier.verify_token("jwt_not_allowed") is None

--- a/package/server/uv.lock
+++ b/package/server/uv.lock
@@ -2,9 +2,11 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
     "python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 
@@ -714,6 +716,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -738,12 +753,38 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.11"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -860,6 +901,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1151,6 +1219,44 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1343,6 +1449,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/53/e19c21e0c4eb1275c3e2c97b081103b6dfb3938172264d283a519bf728b9/opencv_python_headless-4.12.0.88-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:236c8df54a90f4d02076e6f9c1cc763d794542e886c576a6fee46ec8ff75a7a9", size = 54023419, upload-time = "2025-07-07T09:15:10.164Z" },
     { url = "https://files.pythonhosted.org/packages/bf/9c/a76fd5414de6ec9f21f763a600058a0c3e290053cea87e0275692b1375c0/opencv_python_headless-4.12.0.88-cp37-abi3-win32.whl", hash = "sha256:fde2cf5c51e4def5f2132d78e0c08f9c14783cd67356922182c6845b9af87dbd", size = 30225230, upload-time = "2025-07-07T09:15:17.045Z" },
     { url = "https://files.pythonhosted.org/packages/f2/35/0858e9e71b36948eafbc5e835874b63e515179dc3b742cbe3d76bc683439/opencv_python_headless-4.12.0.88-cp37-abi3-win_amd64.whl", hash = "sha256:86b413bdd6c6bf497832e346cd5371995de148e579b9774f8eba686dee3f5528", size = 38923559, upload-time = "2025-07-07T09:15:25.229Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1923,6 +2041,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2003,6 +2135,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2055,6 +2206,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -2181,6 +2346,102 @@ dependencies = [
     { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/0f/b7d5d4b36553731f11983e19e1813a1059ad0732c5162c01b3220c927d31/reverse_geocoder-1.5.1.tar.gz", hash = "sha256:2a2e781b5f69376d922b78fe8978f1350c84fce0ddb07e02c834ecf98b57c75c", size = 2246559, upload-time = "2016-09-15T16:46:46.277Z" }
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
 
 [[package]]
 name = "rsa"
@@ -2315,6 +2576,7 @@ dependencies = [
     { name = "langchain-community" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "mcp" },
     { name = "ollama" },
     { name = "openai" },
     { name = "opencv-python-headless" },
@@ -2359,6 +2621,7 @@ requires-dist = [
     { name = "langchain-community", specifier = ">=0.3.10" },
     { name = "langchain-openai", specifier = ">=0.2.14" },
     { name = "langgraph", specifier = ">=0.2.61" },
+    { name = "mcp", specifier = ">=2.0,<3" },
     { name = "ollama", specifier = ">=0.6.1" },
     { name = "openai", specifier = ">=2.14.0" },
     { name = "opencv-python-headless", specifier = ">=4.12.0.88" },
@@ -2554,6 +2817,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/package/website/src/api/token.ts
+++ b/package/website/src/api/token.ts
@@ -7,13 +7,17 @@ export interface AgentToken {
   token: string
   created_at: string
   expires_at: string
+  scopes: AgentTokenScope[]
   is_deleted: boolean
 }
+
+export type AgentTokenScope = 'photos:read' | 'albums:read' | 'people:read'
 
 export interface CreateTokenData {
   name: string
   expires_at: string
   password: string
+  scopes: AgentTokenScope[]
 }
 
 export function getTokens() {

--- a/package/website/src/views/settings/Tokens.vue
+++ b/package/website/src/views/settings/Tokens.vue
@@ -22,6 +22,15 @@
         <div v-show="guideExpanded" class="px-5 pb-5 pt-0">
           <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">令牌用于授权外部 AI 工具通过 API 访问你的相册数据，无需登录账号。</p>
 
+          <div class="mb-4 rounded-lg border border-primary-200/60 bg-white p-3 dark:border-gray-700 dark:bg-gray-900">
+            <p class="mb-1 text-sm font-semibold text-gray-700 dark:text-gray-300">MCP Server（推荐）</p>
+            <p class="mb-2 text-xs text-gray-500 dark:text-gray-400">在支持远程 MCP 的客户端中添加 Streamable HTTP 服务，并把令牌放入 Authorization 请求头。</p>
+            <div class="overflow-x-auto rounded-lg bg-gray-900 px-3 py-2 font-mono text-xs leading-relaxed text-green-400 dark:bg-gray-950">
+              URL: &lt;TrailSnap 地址&gt;/api/mcp/<br>
+              Authorization: Bearer <span class="text-amber-400">&lt;token&gt;</span>
+            </div>
+          </div>
+
           <div class="space-y-3">
             <!-- Step 1 -->
             <div class="flex gap-3">
@@ -106,6 +115,13 @@
             </el-tag>
           </template>
         </el-table-column>
+        <el-table-column label="MCP 权限" min-width="230">
+          <template #default="{ row }">
+            <div class="flex flex-wrap gap-1">
+              <el-tag v-for="scope in row.scopes" :key="scope" size="small" effect="plain">{{ scopeLabel(scope) }}</el-tag>
+            </div>
+          </template>
+        </el-table-column>
         <el-table-column label="过期时间" width="180">
           <template #default="{ row }">
             <span class="text-sm text-gray-600 dark:text-gray-300">{{ formatDate(row.expires_at) }}</span>
@@ -161,6 +177,10 @@
           <span>过期：{{ formatDate(token.expires_at) }}</span>
         </div>
 
+        <div class="flex flex-wrap gap-1">
+          <el-tag v-for="scope in token.scopes" :key="scope" size="small" effect="plain">{{ scopeLabel(scope) }}</el-tag>
+        </div>
+
         <div class="pt-2 border-t border-gray-100 dark:border-gray-700 flex justify-end">
           <el-popconfirm title="确定要删除这个令牌吗？删除后该令牌将失效！" @confirm="handleDelete(token.id)">
             <template #reference>
@@ -189,6 +209,14 @@
             style="width: 100%"
           />
         </el-form-item>
+        <el-form-item label="MCP 权限" prop="scopes">
+          <el-checkbox-group v-model="formData.scopes" class="flex flex-col">
+            <el-checkbox v-for="option in scopeOptions" :key="option.value" :value="option.value">
+              <span class="font-medium">{{ option.label }}</span>
+              <span class="ml-1 text-xs text-gray-500 dark:text-gray-400">{{ option.description }}</span>
+            </el-checkbox>
+          </el-checkbox-group>
+        </el-form-item>
         <el-form-item label="验证密码" prop="password">
           <el-input v-model="formData.password" type="password" show-password placeholder="请输入当前用户密码" />
         </el-form-item>
@@ -207,7 +235,7 @@
 import { ref, onMounted, reactive } from 'vue'
 import { ElMessage } from 'element-plus'
 import type { FormInstance, FormRules } from 'element-plus'
-import { getTokens, createToken, deleteToken, type AgentToken } from '@/api/token'
+import { getTokens, createToken, deleteToken, type AgentToken, type AgentTokenScope } from '@/api/token'
 import { Copy, Plus, Trash2, Info, ChevronDown, Key } from 'lucide-vue-next'
 
 const tokens = ref<AgentToken[]>([])
@@ -221,8 +249,17 @@ const formRef = ref<FormInstance>()
 const formData = reactive({
   name: '',
   expires_at: '',
-  password: ''
+  password: '',
+  scopes: ['photos:read', 'albums:read', 'people:read'] as AgentTokenScope[]
 })
+
+const scopeOptions: { value: AgentTokenScope; label: string; description: string }[] = [
+  { value: 'photos:read', label: '读取照片', description: '搜索照片与回忆线索' },
+  { value: 'albums:read', label: '读取相册', description: '查询相册列表' },
+  { value: 'people:read', label: '读取人物', description: '查询人物与时间线' }
+]
+
+const scopeLabel = (scope: AgentTokenScope) => scopeOptions.find(option => option.value === scope)?.label || scope
 
 const shortcuts = [
   {
@@ -269,6 +306,9 @@ const rules = reactive<FormRules>({
   ],
   password: [
     { required: true, message: '请输入密码验证身份', trigger: 'blur' }
+  ],
+  scopes: [
+    { type: 'array', required: true, min: 1, message: '至少选择一个权限', trigger: 'change' }
   ]
 })
 
@@ -299,6 +339,7 @@ const handleCreate = async () => {
         ElMessage.success('令牌创建成功')
         showCreateDialog.value = false
         formRef.value?.resetFields()
+        formData.scopes = ['photos:read', 'albums:read', 'people:read']
         fetchTokens()
       } catch (error: any) {
         ElMessage.error(error.message || '创建令牌失败，可能是密码错误')


### PR DESCRIPTION
## 描述

实现 TrailSnap P3 MCP Server MVP，为外部 AI Agent 提供标准 Streamable HTTP 接入，同时复用现有相册领域能力与 Agent Token 用户身份。

主要变更：

- 在 FastAPI 主服务挂载 `/mcp/`，并由主应用 lifespan 管理 MCP session manager
- 接入 MCP Python SDK 2.x，使用 SDK Bearer TokenVerifier 验证 TrailSnap Agent Token
- 新增 5 个只读工具：照片搜索、相册查询、人物查询、回忆侦探、人物时间线
- 每个工具强制按 token 用户隔离，并检查 `photos:read` / `albums:read` / `people:read`
- 为 Agent Token 增加 scopes 字段，提供 PostgreSQL 与 SQLite 迁移；旧令牌迁移为完整只读 scope，保持兼容
- 令牌管理页支持选择和展示 MCP 权限，并提供连接说明
- 增加 MCP 使用与部署文档，包括公开 Host allowlist 配置

MCP 工具均声明 read-only / non-destructive annotations，不返回照片原始文件路径。

## 变更类型

- [x] ✨ 新功能 (New Feature)
- [x] 📝 文档更新 (Documentation)
- [x] ✅ 测试增加/修改 (Tests)
- [x] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue

Closes #181

## 如何测试

- `pwsh .\tests\scripts\run-tests.ps1 -Layer unit -Level smoke`
  - Server: 2339 passed
  - AI: 328 passed
  - CLI: 13 passed
- `pnpm build`（website）
- 使用真实 PostgreSQL 执行 PostgreSQL Alembic 0038 迁移
- 使用 `zhousk` 账号创建临时 scoped Agent Token，通过真实 `http://127.0.0.1:8000/mcp/` 调用全部 5 个工具
  - 搜索识别到 39098 张可查询照片
  - 人物时间线与回忆侦探均返回 84 个候选事件
  - 无 Authorization 请求返回 401
  - 验证后已撤销临时令牌
- Playwright 验收令牌管理页 PC 与 390px 移动端布局，控制台无错误

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [x] 我已更新了相关文档
