### PR TITLE
feat(location): 支持分层 GPS 旅行轨迹

### DIFF
--- a/package/server/app/api/location.py
+++ b/package/server/app/api/location.py
@@ -84,6 +84,18 @@ def get_timeline_photos(
     """
     return crud.get_timeline_nodes(db, current_user.id, level, skip, limit, start_date, end_date)
 
+@router.get("/trajectory", response_model=BaseResponse[schemas.TrajectoryResponse], summary="获取旅行 GPS 轨迹")
+def get_trajectory(
+    start_date: str = Query(..., description="旅程开始日期"),
+    end_date: str = Query(..., description="旅程结束日期"),
+    max_points: int = Query(360, ge=50, le=1000, description="最多返回的轨迹点数量"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(deps.get_current_user)
+):
+    """按真实拍摄时间返回经空间去重、限量采样的 GPS 轨迹点。"""
+    data = crud.get_trajectory_points(db, current_user.id, start_date, end_date, max_points)
+    return BaseResponse.success(data=data)
+
 @router.get("/markers", response_model=List[schemas.MapMarker], summary="获取地图标记点")
 def get_map_markers(
     start_date: str = Query(None, description="开始日期"),

--- a/package/server/app/api/location.py
+++ b/package/server/app/api/location.py
@@ -25,10 +25,10 @@ def search_locations(
     """
     return crud.search_locations(db, current_user.id, q)
 
-@router.get("/years", response_model=List[int], summary="获取所有年份")
+@router.get("/years", response_model=List[int], summary="获取有位置照片的年份")
 def get_years(db: Session = Depends(get_db), current_user: User = Depends(deps.get_current_user)):
     """
-    获取所有照片的拍摄年份。
+    获取包含有效地理位置信息的照片拍摄年份。
     """
     return crud.get_location_years(db, current_user.id)
 

--- a/package/server/app/crud/location.py
+++ b/package/server/app/crud/location.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session, joinedload, contains_eager
 from uuid import UUID
 from sqlalchemy import and_, func, desc, extract, case, or_
+from math import asin, ceil, cos, radians, sin, sqrt
 from app.db.models.photo import Photo
 from app.db.models.photo_metadata import PhotoMetadata
 from app.db.models.scene import Scene
@@ -250,7 +251,9 @@ def get_timeline_nodes(db: Session, owner_id: UUID, level: str = 'city', skip: i
         func.count(Photo.id).label('photo_count'),
         func.avg(PhotoMetadata.latitude).label('lat'),
         func.avg(PhotoMetadata.longitude).label('lng'),
-        func.max(cast(Photo.id, String)).label('cover_id')
+        func.max(cast(Photo.id, String)).label('cover_id'),
+        func.min(Photo.photo_time).label('start_time'),
+        func.max(Photo.photo_time).label('end_time')
     ).join(PhotoMetadata, Photo.id == PhotoMetadata.photo_id) \
      .outerjoin(Scene, PhotoMetadata.scene_id == Scene.id) \
      .filter(Photo.owner_id == owner_id, Photo.is_deleted == False) \
@@ -277,6 +280,8 @@ def get_timeline_nodes(db: Session, owner_id: UUID, level: str = 'city', skip: i
         lng = float(row.lng)
         count = row.photo_count
         cover_id = row.cover_id
+        start_time = getattr(row, 'start_time', None)
+        end_time = getattr(row, 'end_time', None)
 
         if not nodes:
             nodes.append(TimelineNode(
@@ -287,14 +292,21 @@ def get_timeline_nodes(db: Session, owner_id: UUID, level: str = 'city', skip: i
                 lat=lat,
                 lng=lng,
                 photoCount=count,
-                coverId=cover_id
+                coverId=cover_id,
+                startTime=start_time,
+                endTime=end_time
             ))
             continue
 
         last_node = nodes[-1]
 
         if last_node.locationName == loc_name:
-            last_node.startDate = date_str
+            last_node.startDate = min(last_node.startDate, date_str)
+            last_node.endDate = max(last_node.endDate, date_str)
+            if start_time and (last_node.startTime is None or start_time < last_node.startTime):
+                last_node.startTime = start_time
+            if end_time and (last_node.endTime is None or end_time > last_node.endTime):
+                last_node.endTime = end_time
             # 更新平均经纬度
             total_lat = (last_node.lat * last_node.photoCount) + (lat * count)
             total_lng = (last_node.lng * last_node.photoCount) + (lng * count)
@@ -310,13 +322,113 @@ def get_timeline_nodes(db: Session, owner_id: UUID, level: str = 'city', skip: i
                 lat=lat,
                 lng=lng,
                 photoCount=count,
-                coverId=cover_id
+                coverId=cover_id,
+                startTime=start_time,
+                endTime=end_time
             ))
 
     total_nodes = len(nodes)
     paginated_nodes = nodes[skip:skip + limit]
 
     return TimelineResponse(nodes=paginated_nodes, total=total_nodes)
+
+
+def _haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """Return the great-circle distance between two GPS points."""
+    d_lat = radians(lat2 - lat1)
+    d_lng = radians(lng2 - lng1)
+    a = sin(d_lat / 2) ** 2 + cos(radians(lat1)) * cos(radians(lat2)) * sin(d_lng / 2) ** 2
+    return 6371.0088 * 2 * asin(min(1.0, sqrt(a)))
+
+
+def get_trajectory_points(
+    db: Session,
+    owner_id: UUID,
+    start_date: str,
+    end_date: str,
+    max_points: int = 360,
+):
+    """Return chronologically ordered GPS points with stationary bursts collapsed.
+
+    Photos within 60 metres of the previous retained point are represented by one
+    weighted point. A second contiguous bucket pass limits payload size while
+    preserving route order, first/last time and total photo counts.
+    """
+    from app.schemas.location import TrajectoryPoint, TrajectoryResponse
+
+    rows = db.query(
+        Photo.id,
+        Photo.photo_time,
+        PhotoMetadata.latitude,
+        PhotoMetadata.longitude,
+        PhotoMetadata.province,
+        PhotoMetadata.city,
+        PhotoMetadata.district,
+        Scene.name.label('scene_name'),
+    ).join(
+        PhotoMetadata, Photo.id == PhotoMetadata.photo_id
+    ).outerjoin(
+        Scene, PhotoMetadata.scene_id == Scene.id
+    ).filter(
+        Photo.owner_id == owner_id,
+        Photo.is_deleted == False,
+        Photo.photo_time.isnot(None),
+        PhotoMetadata.latitude.isnot(None),
+        PhotoMetadata.longitude.isnot(None),
+        Photo.photo_time >= start_date,
+        Photo.photo_time <= f"{end_date} 23:59:59",
+    ).order_by(Photo.photo_time.asc()).all()
+
+    collapsed = []
+    for row in rows:
+        lat = float(row.latitude)
+        lng = float(row.longitude)
+        scene_name = getattr(row, 'scene_name', None)
+        district = getattr(row, 'district', None)
+        city = getattr(row, 'city', None)
+        province = getattr(row, 'province', None)
+        location_name = scene_name or district or city or province or 'GPS 位置'
+        level = 'scene' if scene_name else 'district' if district else 'city' if city else 'province'
+
+        if collapsed and _haversine_km(collapsed[-1]['lat'], collapsed[-1]['lng'], lat, lng) <= 0.06:
+            point = collapsed[-1]
+            count = point['photoCount'] + 1
+            point['lat'] = (point['lat'] * point['photoCount'] + lat) / count
+            point['lng'] = (point['lng'] * point['photoCount'] + lng) / count
+            point['photoCount'] = count
+            point['endAt'] = row.photo_time
+            continue
+
+        collapsed.append({
+            'photoId': row.id,
+            'capturedAt': row.photo_time,
+            'endAt': row.photo_time,
+            'lat': lat,
+            'lng': lng,
+            'photoCount': 1,
+            'coverId': row.id,
+            'locationName': location_name,
+            'level': level,
+        })
+
+    sampled = len(collapsed) > max_points
+    if sampled:
+        bucket_size = ceil(len(collapsed) / max_points)
+        compacted = []
+        for offset in range(0, len(collapsed), bucket_size):
+            bucket = collapsed[offset:offset + bucket_size]
+            representative = dict(bucket[len(bucket) // 2])
+            representative['capturedAt'] = bucket[0]['capturedAt']
+            representative['endAt'] = bucket[-1]['endAt']
+            representative['photoCount'] = sum(point['photoCount'] for point in bucket)
+            compacted.append(representative)
+        collapsed = compacted
+
+    return TrajectoryResponse(
+        points=[TrajectoryPoint(**point) for point in collapsed],
+        totalPhotos=len(rows),
+        sampled=sampled,
+    )
 
 def get_location_distribution(db: Session, owner_id: UUID, level: str = 'city', start_date: str = None, end_date: str = None):
     is_scene = False

--- a/package/server/app/crud/location.py
+++ b/package/server/app/crud/location.py
@@ -1,14 +1,28 @@
 from sqlalchemy.orm import Session, joinedload, contains_eager
 from uuid import UUID
-from sqlalchemy import func, desc, extract, case
+from sqlalchemy import and_, func, desc, extract, case, or_
 from app.db.models.photo import Photo
 from app.db.models.photo_metadata import PhotoMetadata
 from app.db.models.scene import Scene
 from app.db.sql import as_date_string, date_only
 
 def get_location_years(db: Session, owner_id: UUID):
+    has_location = or_(
+        and_(PhotoMetadata.latitude.isnot(None), PhotoMetadata.longitude.isnot(None)),
+        and_(PhotoMetadata.country.isnot(None), PhotoMetadata.country != ''),
+        and_(PhotoMetadata.province.isnot(None), PhotoMetadata.province != ''),
+        and_(PhotoMetadata.city.isnot(None), PhotoMetadata.city != ''),
+        and_(PhotoMetadata.district.isnot(None), PhotoMetadata.district != ''),
+        PhotoMetadata.scene_id.isnot(None),
+    )
     years = db.query(extract('year', Photo.photo_time))\
-        .filter(Photo.photo_time.isnot(None), Photo.is_deleted == False, Photo.owner_id == owner_id)\
+        .join(PhotoMetadata, Photo.id == PhotoMetadata.photo_id)\
+        .filter(
+            Photo.photo_time.isnot(None),
+            Photo.is_deleted == False,
+            Photo.owner_id == owner_id,
+            has_location,
+        )\
         .distinct()\
         .order_by(desc(extract('year', Photo.photo_time)))\
         .all()

--- a/package/server/app/schemas/location.py
+++ b/package/server/app/schemas/location.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional, List, Union
 from uuid import UUID
 
@@ -47,7 +48,25 @@ class TimelineNode(BaseModel):
     lng: Optional[float] = None
     photoCount: int = 0
     coverId: Optional[UUID] = None
+    startTime: Optional[datetime] = None
+    endTime: Optional[datetime] = None
     
 class TimelineResponse(BaseModel):
     nodes: List[TimelineNode]
     total: int
+
+class TrajectoryPoint(BaseModel):
+    photoId: UUID
+    capturedAt: datetime
+    endAt: Optional[datetime] = None
+    lat: float
+    lng: float
+    photoCount: int = 1
+    coverId: Optional[UUID] = None
+    locationName: str
+    level: str = "city"
+
+class TrajectoryResponse(BaseModel):
+    points: List[TrajectoryPoint]
+    totalPhotos: int
+    sampled: bool = False

--- a/package/server/tests/unit/test_nightly_basic_location_session_gaps_20260817.py
+++ b/package/server/tests/unit/test_nightly_basic_location_session_gaps_20260817.py
@@ -345,10 +345,9 @@ class TestGetTimelineNodes:
         assert node.photoCount == 5
         # Weighted-average lat: (31.0*2 + 31.5*3) / 5
         assert abs(node.lat - 31.3) < 1e-6
-        # The source overwrites startDate on each merge (it tracks the
-        # latest visit, not the earliest). endDate stays at first-append.
-        assert node.startDate == "2026-01-02"
-        assert node.endDate == "2026-01-01"
+        # Merged ranges are normalized regardless of database row order.
+        assert node.startDate == "2026-01-01"
+        assert node.endDate == "2026-01-02"
 
         # coverId is NOT updated on merge -- stays at first-append.
 

--- a/package/server/tests/unit/test_nightly_crud_location_public_gaps_20260827.py
+++ b/package/server/tests/unit/test_nightly_crud_location_public_gaps_20260827.py
@@ -20,7 +20,7 @@ Why this file exists:
     that returns the full coalesce/case expression.
 """
 
-from datetime import date as _date
+from datetime import date as _date, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -271,3 +271,26 @@ def test_get_timeline_nodes_respects_skip_and_limit():
 
     assert out.total == 4
     assert [n.locationName for n in out.nodes] == ["Beijing", "Shanghai"]
+
+
+def test_get_trajectory_points_keeps_capture_order_and_collapses_nearby_photos():
+    first_id, second_id, third_id = uuid4(), uuid4(), uuid4()
+    rows = [
+        SimpleNamespace(id=first_id, photo_time=datetime(2026, 5, 1, 8), latitude=30.0000,
+                        longitude=120.0000, province="浙江", city="杭州", district="西湖区", scene_name=None),
+        SimpleNamespace(id=second_id, photo_time=datetime(2026, 5, 1, 8, 5), latitude=30.0001,
+                        longitude=120.0001, province="浙江", city="杭州", district="西湖区", scene_name=None),
+        SimpleNamespace(id=third_id, photo_time=datetime(2026, 5, 1, 10), latitude=30.0200,
+                        longitude=120.0200, province="浙江", city="杭州", district="西湖区", scene_name="西湖"),
+    ]
+    db = MagicMock()
+    db.query.return_value = _chained(all_rows=rows)
+
+    out = crud_loc.get_trajectory_points(db, uuid4(), "2026-05-01", "2026-05-01", 360)
+
+    assert out.totalPhotos == 3
+    assert len(out.points) == 2
+    assert out.points[0].photoCount == 2
+    assert out.points[0].capturedAt == datetime(2026, 5, 1, 8)
+    assert out.points[1].locationName == "西湖"
+    assert out.points[1].level == "scene"

--- a/package/server/tests/unit/test_nightly_crud_photo_location_album_gaps_20260812.py
+++ b/package/server/tests/unit/test_nightly_crud_photo_location_album_gaps_20260812.py
@@ -197,13 +197,24 @@ def test_get_location_years_skips_none_and_returns_list():
     from app.crud import location as crud_loc
     db = MagicMock()
     chain = db.query.return_value
-    chain.filter.return_value.distinct.return_value.order_by.return_value.all.return_value = [
+    chain.join.return_value.filter.return_value.distinct.return_value.order_by.return_value.all.return_value = [
         (2025,),
         (2024,),
         (None,),
     ]
     years = crud_loc.get_location_years(db, uuid4())
     assert years == [2025, 2024]
+    chain.join.assert_called_once()
+    criteria = " ".join(
+        str(condition)
+        for condition in chain.join.return_value.filter.call_args.args
+    )
+    assert "photo_metadata.latitude IS NOT NULL" in criteria
+    assert "photo_metadata.longitude IS NOT NULL" in criteria
+    assert "photo_metadata.province IS NOT NULL" in criteria
+    assert "photo_metadata.city IS NOT NULL" in criteria
+    assert "photo_metadata.district IS NOT NULL" in criteria
+    assert "photo_metadata.scene_id IS NOT NULL" in criteria
 
 
 def test_get_locations_invalid_level_returns_empty_list():

--- a/package/server/tests/unit/test_nightly_gap_rescue_20260904.py
+++ b/package/server/tests/unit/test_nightly_gap_rescue_20260904.py
@@ -246,6 +246,19 @@ def test_location_get_timeline_photos_forwards_params():
     assert result is nodes
 
 
+def test_location_get_trajectory_wraps_result():
+    db = MagicMock()
+    payload = SimpleNamespace(points=[], totalPhotos=0, sampled=False)
+    with patch.object(location_api.crud, "get_trajectory_points", return_value=payload) as trajectory:
+        result = location_api.get_trajectory(
+            start_date="2026-01-01", end_date="2026-01-02", max_points=120,
+            db=db, current_user=USER,
+        )
+    trajectory.assert_called_once_with(db, USER.id, "2026-01-01", "2026-01-02", 120)
+    assert result.code == 0
+    assert result.data is payload
+
+
 def test_location_get_map_markers_forwards_dates():
     db = MagicMock()
     with patch.object(location_api.crud, "get_map_markers", return_value=[]) as mm:

--- a/package/website/src/api/location.ts
+++ b/package/website/src/api/location.ts
@@ -1,5 +1,5 @@
 import request from '@/utils/request';
-import type { Location, Scene, SceneCreate, SceneUpdate, LocationStatistics, TimelineResponse } from '@/types/location';
+import type { Location, Scene, SceneCreate, SceneUpdate, LocationStatistics, TimelineResponse, TrajectoryResponse } from '@/types/location';
 import type { Photo } from '@/types/album';
 
 export interface OverviewStats {
@@ -95,6 +95,13 @@ export const locationService = {
       params: { skip, limit, start_date: startDate || undefined, end_date: endDate || undefined, level }
     });
     return data.data;
+  },
+
+  async getTrajectory(startDate: string, endDate: string, maxPoints: number = 360) {
+    const response = await request.get<TrajectoryResponse>('/api/locations/trajectory', {
+      params: { start_date: startDate, end_date: endDate, max_points: maxPoints }
+    });
+    return response.data;
   },
 
   async getMapMarkers(startDate?: string, endDate?: string) {

--- a/package/website/src/types/location.ts
+++ b/package/website/src/types/location.ts
@@ -54,9 +54,29 @@ export interface TimelineNode {
   lng?: number;
   photoCount: number;
   coverId?: string;
+  startTime?: string;
+  endTime?: string;
 }
 
 export interface TimelineResponse {
   nodes: TimelineNode[];
   total: number;
+}
+
+export interface TrajectoryPoint {
+  photoId: string;
+  capturedAt: string;
+  endAt?: string;
+  lat: number;
+  lng: number;
+  photoCount: number;
+  coverId?: string;
+  locationName: string;
+  level: string;
+}
+
+export interface TrajectoryResponse {
+  points: TrajectoryPoint[];
+  totalPhotos: number;
+  sampled: boolean;
 }

--- a/package/website/src/views/album/location/LocationList.vue
+++ b/package/website/src/views/album/location/LocationList.vue
@@ -1,7 +1,7 @@
 <template>
-  <div :class="['location-list flex flex-col relative py-6 px-4', (viewMode === 'map' || viewMode === 'trajectory' || viewMode === 'puzzle') ? 'h-full min-h-0' : 'container mx-auto']">
+  <div :class="['location-list flex flex-col relative py-6 px-4', (viewMode === 'map' || viewMode === 'trajectory' || viewMode === 'puzzle') ? 'h-full min-h-0' : 'container mx-auto', isImmersiveMap ? 'location-immersive' : '']">
     <!-- Header -->
-    <div class="container mx-auto flex sm:flex-row justify-between items-start sm:items-center gap-4 flex-shrink-0 z-50 transition-all duration-300 pb-2">
+    <div class="location-toolbar container mx-auto flex sm:flex-row justify-between items-start sm:items-center gap-4 flex-shrink-0 z-50 transition-all duration-300 pb-2">
       <div class="flex shrink-0 flex-col gap-3">
         <div class="flex w-full shrink-0 items-center gap-3 rounded-full border border-gray-200/50 px-3 py-1.5 shadow-sm backdrop-blur-md dark:border-gray-700/50 dark:bg-gray-900/80 md:w-auto">
           <button @click="goBack" class="rounded-full bg-white p-1.5 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:bg-gray-900 dark:hover:bg-gray-800">
@@ -379,7 +379,10 @@
       :start-date="dateRange?.[0]"
       :end-date="dateRange?.[1]"
       :parent-region="parentRegion"
+      :selected-year="selectedYear"
+      :available-years="availableYears"
       @click-location="goToLocation"
+      @select-year="selectYear"
       @change-level="(level: string, viewState?: { zoom: number; center: number[]; parentRegion?: string }) => changeLevel(level as any, viewState)"
     />
 
@@ -446,7 +449,7 @@ import { useLocationStore } from '@/stores/locationStore'
 import { locationService } from '@/api/location'
 import type { Location, LocationStatistics, Scene } from '@/types/location'
 import type { Photo } from '@/types/album'
-import { ArrowLeft, LayoutGrid, Map, Images, Plus, ChevronDown, Calendar, Check, Clock, Route, BarChart3, Shapes } from 'lucide-vue-next'
+import { ArrowLeft, LayoutGrid, Map, Images, Plus, ChevronDown, Calendar, Check, Clock, Route, BarChart3, Shapes, X } from 'lucide-vue-next'
 import { onClickOutside } from '@vueuse/core'
 import { ElMessageBox, ElMessage } from 'element-plus'
 import LocationMap from './LocationMap.vue'
@@ -479,6 +482,7 @@ const availableYears = ref<number[]>([])
 const dateRange = ref<[string, string] | null>(null)
 const isCustomRange = ref(false)
 const parentRegion = ref<string | undefined>(undefined)
+const isImmersiveMap = computed(() => viewMode.value === 'map' || viewMode.value === 'trajectory')
 
 const dateRangeStart = computed({
   get: () => dateRange.value?.[0] || '',
@@ -809,7 +813,49 @@ onMounted(() => {
 </script>
 
 <style scoped>
-/* Optional transitions */
+.location-immersive {
+  padding: 0;
+  overflow: hidden;
+  background: #07111f;
+  isolation: isolate;
+}
+
+.location-immersive .location-toolbar {
+  position: absolute;
+  inset: 0 0 auto 0;
+  width: 100%;
+  max-width: none;
+  padding: 18px 412px 12px 24px;
+  pointer-events: none;
+}
+
+.location-immersive .location-toolbar > * {
+  pointer-events: auto;
+}
+
+.location-immersive .location-toolbar > div:first-child > div,
+.location-immersive .location-toolbar > div:last-child > div {
+  border-color: rgba(var(--theme-rgb), 0.24) !important;
+  background: rgba(7, 17, 31, 0.78) !important;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(18px);
+}
+
+.location-immersive .location-toolbar button {
+  background-color: rgba(12, 28, 49, 0.88) !important;
+  border-color: rgba(var(--theme-rgb), 0.18) !important;
+}
+
+.location-immersive .location-toolbar h1,
+.location-immersive .location-toolbar button:not(.text-primary-500) {
+  color: #e5f3ff;
+}
+
+@media (max-width: 1023px) {
+  .location-immersive .location-toolbar {
+    padding: 12px 12px 0;
+  }
+}
 </style>
 
 <style>

--- a/package/website/src/views/album/location/LocationMapView.vue
+++ b/package/website/src/views/album/location/LocationMapView.vue
@@ -1,8 +1,10 @@
 <template>
-  <div class="flex flex-col md:flex-row w-full h-full relative">
+  <div class="location-map-cockpit flex flex-col md:flex-row w-full h-full relative">
     <!-- 左侧地图区域（移动端撑满，抽屉浮于其上） -->
     <!-- min-h-0 让 flex-1 在移动端 flex-col 下正确分配高度（见 LocationPuzzleView 同名注释） -->
-    <div class="flex-1 min-h-0 relative overflow-hidden shadow-sm md:h-full">
+    <div class="map-stage flex-1 min-h-0 relative overflow-hidden md:h-full">
+      <div class="map-grid" aria-hidden="true" />
+      <div class="map-radar" aria-hidden="true"><span /><span /><span /></div>
       <MapContainer
         ref="mapContainerRef"
         :level="level"
@@ -15,11 +17,43 @@
         @select-region="handleSelectRegion"
         @update-top-regions="(regions) => topRegions = regions"
       />
+
+      <div v-if="timelineYears.length" class="journey-timeline hidden md:flex" aria-label="足迹年份时间轴">
+        <button
+          class="timeline-play focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+          :title="isPlaying ? '暂停足迹巡游' : '播放足迹巡游'"
+          @click="togglePlayback"
+        >
+          <Pause v-if="isPlaying" class="h-4 w-4" />
+          <Play v-else class="h-4 w-4 fill-current" />
+        </button>
+        <div class="min-w-0 flex-1">
+          <div class="timeline-rail">
+            <button
+              v-for="item in timelineYears"
+              :key="item.year"
+              class="timeline-node focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none"
+              :class="{ active: selectedYear === item.year }"
+              :style="{ '--node-weight': String(item.weight) }"
+              :title="`${item.year} 年足迹`"
+              @click="emit('select-year', selectedYear === item.year ? null : item.year)"
+            >
+              <span class="timeline-dot" />
+              <span class="timeline-label">{{ item.year }}</span>
+            </button>
+          </div>
+          <div class="timeline-summary">
+            <span><CalendarDays class="h-3.5 w-3.5" /> {{ selectedYear ? `${selectedYear} 年足迹` : '全部旅行记忆' }}</span>
+            <span>{{ selectedYear ? '正在回看该年地图' : `${timelineYears.length} 个足迹年份` }}</span>
+            <button v-if="selectedYear" @click="emit('select-year', null)">查看全部</button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- 右侧信息面板：移动端为 fixed 底部抽屉（peek/expand），桌面端为侧栏 -->
     <div
-      class="fixed md:static inset-x-0 bottom-[calc(var(--ts-tabbar-h)+env(safe-area-inset-bottom))] md:inset-auto z-30 md:z-auto flex flex-col h-auto md:h-full md:w-80 lg:w-96 bg-white/95 dark:bg-gray-900/95 backdrop-blur-md border-t md:border-t-0 md:border-l border-gray-200 dark:border-gray-700 rounded-t-2xl md:rounded-none shadow-2xl md:shadow-sm transition-[height] duration-300 ease-out"
+      class="location-insight-panel fixed md:static inset-x-0 bottom-[calc(var(--ts-tabbar-h)+env(safe-area-inset-bottom))] md:inset-auto z-30 md:z-auto flex flex-col h-auto md:h-full md:w-80 lg:w-96 backdrop-blur-xl border-t md:border-t-0 md:border-l rounded-t-2xl md:rounded-none shadow-2xl transition-[height] duration-300 ease-out"
       :class="{ '!transition-none': isDragging }"
       :style="isMobile ? { height: sheetHeight + 'px' } : {}"
     >
@@ -38,7 +72,7 @@
       </div>
 
       <el-scrollbar class="flex-1">
-        <div class="p-4 md:p-6 space-y-8">
+        <div class="p-4 md:p-5 space-y-6">
           
           <RegionDetailsPanel
             v-if="selectedRegion"
@@ -76,7 +110,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import { locationService } from '@/api/location'
 import { albumService } from '@/api/album'
 import type { LocationStatistics, TimelineNode } from '@/types/location'
@@ -87,6 +121,7 @@ import request from '@/utils/request'
 import MapContainer from './components/MapContainer.vue'
 import GlobalOverviewPanel from './components/GlobalOverviewPanel.vue'
 import RegionDetailsPanel from './components/RegionDetailsPanel.vue'
+import { CalendarDays, Pause, Play } from 'lucide-vue-next'
 
 const ADMIN_SUFFIX_REGEX = /(省|市|自治区|特别行政区|回族自治区|壮族自治区|维吾尔自治区|县|区)$/
 
@@ -113,11 +148,14 @@ const props = defineProps<{
   startDate?: string
   endDate?: string
   parentRegion?: string
+  selectedYear?: number | null
+  availableYears?: number[]
 }>()
 
 const emit = defineEmits<{
   (e: 'click-location', name: string, level?: string): void
   (e: 'change-level', level: string, viewState: { zoom: number, center: number[], parentRegion?: string }): void
+  (e: 'select-year', year: number | null): void
 }>()
 
 const mapContainerRef = ref<InstanceType<typeof MapContainer> | null>(null)
@@ -133,6 +171,47 @@ const globalStats = ref<LocationStatistics | null>(null)
 const topRegions = ref<{name: string, count: number}[]>([])
 const recentTrips = ref<TimelineNode[]>([])
 const rawTimelineData = ref<any[]>([])
+const isPlaying = ref(false)
+let playbackTimer: ReturnType<typeof setInterval> | null = null
+
+const timelineYears = computed(() => {
+  const locationYears = new Set(props.availableYears || [])
+  const totals = new Map<number, number>()
+  rawTimelineData.value.forEach((item) => {
+    const year = Number(item.year)
+    if (!Number.isFinite(year) || !locationYears.has(year)) return
+    totals.set(year, (totals.get(year) || 0) + Number(item.count || 0))
+  })
+  locationYears.forEach(year => {
+    if (!totals.has(year)) totals.set(year, 0)
+  })
+  const max = Math.max(...totals.values(), 1)
+  return [...totals.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([year, count]) => ({ year, count, weight: 0.45 + (count / max) * 0.55 }))
+})
+
+const stopPlayback = () => {
+  isPlaying.value = false
+  if (playbackTimer) clearInterval(playbackTimer)
+  playbackTimer = null
+}
+
+const togglePlayback = () => {
+  if (isPlaying.value) {
+    stopPlayback()
+    return
+  }
+  if (!timelineYears.value.length) return
+  isPlaying.value = true
+  let index = Math.max(timelineYears.value.findIndex(item => item.year === props.selectedYear), -1)
+  const advance = () => {
+    index = (index + 1) % timelineYears.value.length
+    emit('select-year', timelineYears.value[index].year)
+  }
+  advance()
+  playbackTimer = setInterval(advance, 1800)
+}
 
 const regionPhotoCache = new Map<string, { photos: AlbumImage[], count: number, timeSpan: string, firstVisit: string, tags: { name: string, count: number }[] }>()
 const regionSubDataCache = new Map<string, { subLevel: string, exploredCount: number, totalCount: number, topSubRegions: { name: string, count: number }[], recentVisits: TimelineNode[] }>()
@@ -321,7 +400,7 @@ const clearSelection = () => {
 
 /* ----------------------- 移动端底部抽屉：peek / expand ----------------------- */
 // 桌面端为侧栏（md:static md:h-full），sheetHeight 仅移动端生效（内联高度门控 isMobile）。
-const PEEK_H = 128                                   // 收起态：露手柄 + 标题 + 首张统计卡
+const PEEK_H = 208                                   // 收起态：露手柄 + 标题 + 探索进度卡
 const expandedH = () => Math.min(                    // 展开态：~70vh，但至少留 header + 120px 地图可点
   Math.round(window.innerHeight * 0.7),
   window.innerHeight - 240
@@ -386,9 +465,172 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  stopPlayback()
   window.removeEventListener('resize', onWindowResize)
   window.removeEventListener('pointermove', onHandlePointerMove)
   window.removeEventListener('pointerup', onHandlePointerUp)
 })
 
 </script>
+
+<style scoped>
+.location-map-cockpit {
+  color: #dcecff;
+  background: #07111f;
+}
+
+.map-stage {
+  background:
+    radial-gradient(circle at 48% 44%, rgba(var(--theme-rgb), 0.12), transparent 36%),
+    linear-gradient(145deg, #08182b 0%, #07111f 58%, #050c17 100%);
+}
+
+.map-grid {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.3;
+  background-image:
+    linear-gradient(rgba(var(--theme-rgb), 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(var(--theme-rgb), 0.08) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: radial-gradient(circle at center, #000 0%, transparent 76%);
+}
+
+.map-radar {
+  position: absolute;
+  left: 42%;
+  top: 46%;
+  width: 130px;
+  height: 130px;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.map-radar span {
+  position: absolute;
+  inset: 50%;
+  border: 1px solid rgba(var(--theme-rgb), 0.65);
+  border-radius: 999px;
+  animation: radar-wave 3.6s ease-out infinite;
+  box-shadow: 0 0 18px rgba(var(--theme-rgb), 0.18);
+}
+
+.map-radar span:nth-child(2) { animation-delay: 1.2s; }
+.map-radar span:nth-child(3) { animation-delay: 2.4s; }
+
+.location-insight-panel {
+  border-color: rgba(var(--theme-rgb), 0.2);
+  background: linear-gradient(180deg, rgba(10, 25, 43, 0.96), rgba(5, 14, 26, 0.98));
+  box-shadow: -18px 0 46px rgba(0, 0, 0, 0.3), inset 1px 0 rgba(255, 255, 255, 0.025);
+}
+
+.location-insight-panel :deep(.text-gray-900),
+.location-insight-panel :deep(.text-gray-800),
+.location-insight-panel :deep(.text-gray-700) { color: #dcecff !important; }
+.location-insight-panel :deep(.text-gray-600),
+.location-insight-panel :deep(.text-gray-500),
+.location-insight-panel :deep(.text-gray-400) { color: #7891aa !important; }
+.location-insight-panel :deep(.bg-white),
+.location-insight-panel :deep(.bg-gray-50),
+.location-insight-panel :deep(.bg-gray-100) { background-color: rgba(13, 31, 51, 0.7) !important; }
+.location-insight-panel :deep(.border-gray-100),
+.location-insight-panel :deep(.border-gray-200),
+.location-insight-panel :deep(.border-gray-300) { border-color: rgba(var(--theme-rgb), 0.16) !important; }
+
+.journey-timeline {
+  position: absolute;
+  z-index: 8;
+  left: 24px;
+  right: 24px;
+  bottom: 20px;
+  align-items: center;
+  gap: 18px;
+  min-height: 96px;
+  padding: 15px 18px;
+  border: 1px solid rgba(var(--theme-rgb), 0.2);
+  border-radius: 16px;
+  background: rgba(7, 17, 31, 0.84);
+  box-shadow: 0 16px 50px rgba(0, 0, 0, 0.32), inset 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(18px);
+}
+
+.timeline-play {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(var(--theme-rgb), 0.5);
+  border-radius: 999px;
+  color: var(--theme-primary);
+  background: rgba(var(--theme-rgb), 0.12);
+  box-shadow: 0 0 24px rgba(var(--theme-rgb), 0.18);
+}
+
+.timeline-rail {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 32px;
+}
+
+.timeline-rail::before {
+  content: '';
+  position: absolute;
+  left: 1%;
+  right: 1%;
+  top: 12px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(var(--theme-rgb), 0.65), transparent);
+}
+
+.timeline-node {
+  position: relative;
+  display: flex;
+  min-width: 30px;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  color: #7690aa;
+  background: transparent;
+}
+
+.timeline-dot {
+  z-index: 1;
+  width: calc(7px + 5px * var(--node-weight));
+  height: calc(7px + 5px * var(--node-weight));
+  border: 2px solid #0b172a;
+  border-radius: 999px;
+  background: #5b7894;
+}
+
+.timeline-node:hover,
+.timeline-node.active { color: #e5f5ff; }
+.timeline-node:hover .timeline-dot,
+.timeline-node.active .timeline-dot {
+  background: var(--theme-primary);
+  box-shadow: 0 0 0 4px rgba(var(--theme-rgb), 0.14), 0 0 16px rgba(var(--theme-rgb), 0.75);
+}
+
+.timeline-label { font-size: 10px; }
+.timeline-summary {
+  display: flex;
+  gap: 14px;
+  color: #7690aa;
+  font-size: 11px;
+}
+.timeline-summary span:first-child { display: flex; align-items: center; gap: 5px; color: #b9cee2; }
+.timeline-summary button { color: var(--theme-primary); }
+
+@keyframes radar-wave {
+  0% { inset: 50%; opacity: 0.9; }
+  100% { inset: 0; opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .map-radar span { animation: none; opacity: 0.2; inset: 15%; }
+}
+</style>

--- a/package/website/src/views/album/location/LocationTrajectoryView.vue
+++ b/package/website/src/views/album/location/LocationTrajectoryView.vue
@@ -1,87 +1,161 @@
 <template>
-  <div class="relative w-full h-full flex flex-col md:flex-row bg-white dark:bg-gray-900">
-    <!-- Map Area -->
-    <div class="flex-1 relative w-full h-full md:h-auto z-10 order-1 md:order-2">
-      <div id="trajectory-map" class="w-full h-full z-10 overflow-hidden"></div>
-      
-      <!-- Loading Overlay -->
-      <div v-if="loading" class="absolute inset-0 z-50 flex items-center justify-center bg-white/50 backdrop-blur-sm">
-        <div class="w-8 h-8 border-4 border-primary-500 border-t-transparent rounded-full animate-spin"></div>
-      </div>
-    </div>
+  <div class="trajectory-cockpit relative flex h-full w-full flex-col overflow-hidden md:flex-row">
+    <section class="trajectory-map-stage relative order-1 h-full min-h-0 flex-1 md:order-2">
+      <div id="trajectory-map" class="h-full w-full overflow-hidden" />
+      <div class="map-vignette pointer-events-none absolute inset-0" aria-hidden="true" />
 
-    <!-- Timeline List Area -->
-    <div 
+      <div v-if="timelineNodes.length" class="journey-hud hidden md:block">
+        <div class="hud-kicker">{{ selectedJourney ? 'SELECTED JOURNEY' : 'ALL JOURNEYS' }}</div>
+        <div class="mt-1 text-base font-semibold text-white">{{ selectedJourney?.title || '全部足迹总览' }}</div>
+        <div class="mt-1 flex items-center gap-3 text-xs text-[#7891aa]">
+          <template v-if="selectedJourney">
+            <span>{{ selectedJourney.dateRange }}</span>
+            <span>{{ selectedJourney.nodes.length }} 个停留点</span>
+            <span>{{ selectedJourney.photoCount }} 张照片</span>
+            <span class="route-mode-badge">{{ routeModeLabel }}</span>
+          </template>
+          <template v-else>
+            <span>{{ journeyGroups.length }} 段旅程</span>
+            <span>{{ timelineNodes.length }} 个地点节点</span>
+            <span>点击左侧旅程查看 GPS 细节</span>
+          </template>
+        </div>
+      </div>
+
+      <div v-if="selectedJourney && (!isMobile || !showMobileList)" class="playback-dock">
+        <button
+          class="play-button focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+          :title="isPlaying ? '暂停旅行回放' : '播放旅行回放'"
+          @click="togglePlayback"
+        >
+          <Pause v-if="isPlaying" class="h-4 w-4" />
+          <Play v-else class="h-4 w-4 fill-current" />
+        </button>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center justify-between text-[11px] text-[#8ca4ba]">
+            <span>{{ playbackLabel }}</span>
+            <span>{{ playbackIndex }}/{{ selectedJourney.nodes.length }}</span>
+          </div>
+          <div class="playback-track mt-2">
+            <div :style="{ width: `${playbackProgress}%` }" />
+          </div>
+        </div>
+        <button class="speed-button focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none" @click="cycleSpeed">{{ playbackSpeed }}×</button>
+      </div>
+
+      <div v-if="loading || detailLoading" class="loading-chip">
+        <LoaderCircle class="h-4 w-4 animate-spin text-primary-500" />
+        {{ detailLoading ? '正在加载 GPS 精细轨迹' : '正在整理旅行足迹' }}
+      </div>
+    </section>
+
+    <aside
       :class="[
-        'bg-white dark:bg-gray-900 border-t md:border-t-0 md:border-r border-gray-200 dark:border-gray-800 transition-all duration-300 z-20 flex flex-col',
-        isMobile ? 'absolute bottom-0 left-0 right-0 max-h-[50vh] rounded-t-2xl shadow-[0_-4px_20px_rgba(0,0,0,0.1)]' : 'w-80 h-full order-2 md:order-1'
+        'journey-panel z-20 flex flex-col border-t transition-all duration-300 md:order-1 md:h-full md:w-[352px] md:border-r md:border-t-0',
+        isMobile ? 'journey-panel-mobile absolute inset-x-0 max-h-[62vh] rounded-t-2xl' : ''
       ]"
     >
-      <div v-if="isMobile" class="w-full flex justify-center py-2 cursor-pointer" @click="toggleMobileList">
-        <div class="w-12 h-1.5 bg-gray-300 dark:bg-gray-600 rounded-full"></div>
-      </div>
+      <button
+        v-if="isMobile"
+        class="flex w-full justify-center py-3 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none"
+        aria-label="展开或收起旅程列表"
+        @click="toggleMobileList"
+      >
+        <span class="h-1 w-11 rounded-full bg-[#587087]" />
+      </button>
 
-      <div v-show="!isMobile || showMobileList" class="flex-1 overflow-y-auto custom-scrollbar p-4 md:pt-24" @scroll="handleScroll">
-        <div v-if="!timelineNodes.length && !loading && !loadingMore" class="flex flex-col items-center justify-center py-10 text-gray-500">
-          <Map class="w-10 h-10 mb-2 text-gray-300 dark:text-gray-600" />
+      <div v-show="!isMobile || showMobileList" class="custom-scrollbar flex-1 overflow-y-auto px-4 pb-5 pt-1 md:px-5 md:pt-24">
+        <header class="mb-5">
+          <div class="panel-kicker">JOURNEY ARCHIVE</div>
+          <div class="mt-1 flex items-end justify-between">
+            <div>
+              <h2 class="text-lg font-bold text-white">旅行轨迹</h2>
+              <p class="mt-1 text-xs text-[#7891aa]">按连续旅行时间自动整理</p>
+            </div>
+            <div class="text-right">
+              <div class="text-lg font-semibold text-primary-500">{{ journeyGroups.length }}</div>
+              <div class="text-[10px] text-[#617b93]">段旅程</div>
+            </div>
+          </div>
+        </header>
+
+        <div v-if="!journeyGroups.length && !loading" class="flex flex-col items-center justify-center py-16 text-[#7891aa]">
+          <Map class="mb-3 h-10 w-10 opacity-50" />
           <p class="text-sm">暂无轨迹数据</p>
         </div>
-        
-        <div v-else class="space-y-4">
-          <div v-for="(node, index) in timelineNodes" :key="index" class="relative pl-8 py-2">
-            <!-- Timeline vertical line -->
-            <div v-if="index !== timelineNodes.length - 1" class="absolute left-[11px] top-1/2 w-0.5 h-full bg-gray-200 dark:bg-gray-700"></div>
-            
-            <!-- Dot -->
-            <div class="absolute left-0 top-1/2 -translate-y-1/2 w-[24px] h-[24px] rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center border-2 border-white dark:border-gray-900 z-10 cursor-pointer" @click="panToNode(node)">
-              <div class="w-2 h-2 rounded-full bg-primary-500"></div>
-            </div>
-            
-            <div class="cursor-pointer group flex items-center justify-between w-full" @click="panToNode(node)">
-              <div class="flex-1 pr-4">
-                <div class="text-sm font-bold text-gray-900 dark:text-white mb-1" v-if="node.startDate === node.endDate">{{ formatDate(node.startDate).full }}</div>
-                <div class="text-sm font-bold text-gray-900 dark:text-white mb-1" v-else>{{ formatDate(node.startDate).short }} - {{ formatDate(node.endDate).short }}</div>
-                <div class="text-xs text-primary-600 dark:text-primary-400 font-medium">{{ node.locationName }}</div>
-              </div>
-              
-              <!-- Photos preview -->
-              <div v-if="node.coverId" class="flex-shrink-0">
-                <div 
-                  class="w-16 h-16 rounded-md overflow-hidden bg-gray-100 dark:bg-gray-800 relative cursor-pointer group/more"
-                  @click="goToLocationDetail(node)"
-                >
-                  <img :src="getThumbnailUrl(node.coverId)" class="w-full h-full object-cover transition-transform duration-300 group-hover/more:scale-105" loading="lazy" />
-                  <div 
-                    v-if="node.photoCount > 1"
-                    class="absolute inset-0 bg-black/40 opacity-0 group-hover/more:opacity-100 transition-opacity flex items-center justify-center"
-                  >
-                    <span class="text-white font-medium text-xs">+{{ node.photoCount - 1 }}</span>
+
+        <div v-else class="space-y-3">
+          <button
+            class="overview-card focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+            :class="{ active: !selectedJourneyKey }"
+            @click="selectOverview"
+          >
+            <span class="overview-icon"><Map class="h-4 w-4" /></span>
+            <span class="min-w-0 flex-1">
+              <span class="block text-sm font-semibold text-[#e4f2ff]">全部足迹总览</span>
+              <span class="mt-1 block text-[11px] text-[#7891aa]">汇聚所有地点与历史轨迹</span>
+            </span>
+            <ChevronRight class="h-4 w-4 text-primary-500" />
+          </button>
+
+          <article
+            v-for="journey in journeyGroups"
+            :key="journey.key"
+            class="journey-card"
+            :class="{ active: journey.key === selectedJourneyKey }"
+          >
+            <button
+              class="w-full rounded-xl p-3 text-left focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+              @click="selectJourney(journey.key)"
+            >
+              <div class="flex items-start gap-3">
+                <img v-if="journey.coverId" :src="getThumbnailUrl(journey.coverId)" class="h-14 w-14 shrink-0 rounded-xl object-cover" loading="lazy" />
+                <div v-else class="grid h-14 w-14 shrink-0 place-items-center rounded-xl bg-[#132b42] text-primary-500"><Route class="h-5 w-5" /></div>
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-start justify-between gap-2">
+                    <h3 class="truncate text-sm font-semibold text-[#e4f2ff]">{{ journey.title }}</h3>
+                    <span class="journey-count">{{ journey.photoCount }}</span>
+                  </div>
+                  <div class="mt-1 text-[11px] text-[#7891aa]">{{ journey.dateRange }}</div>
+                  <div class="mt-2 flex items-center gap-1 overflow-hidden text-[11px] text-[#9fb5c8]">
+                    <template v-for="(location, index) in journey.locations.slice(0, 3)" :key="location">
+                      <ChevronRight v-if="index" class="h-3 w-3 shrink-0 text-primary-500" />
+                      <span class="truncate">{{ location }}</span>
+                    </template>
                   </div>
                 </div>
               </div>
+            </button>
+
+            <div v-if="journey.key === selectedJourneyKey" class="journey-stops">
+              <button
+                v-for="(node, index) in journey.nodes"
+                :key="`${node.startDate}-${node.locationName}`"
+                class="stop-row focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none"
+                :class="{ current: isPlaying && index === playbackIndex - 1 }"
+                @click="panToNode(node)"
+              >
+                <span class="stop-index">{{ index + 1 }}</span>
+                <span class="min-w-0 flex-1">
+                  <span class="block truncate text-xs text-[#c7d9e9]">{{ node.locationName }}</span>
+                  <span class="block text-[10px] text-[#617b93]">{{ formatNodeDate(node) }}</span>
+                </span>
+                <span class="text-[10px] text-[#7891aa]">{{ node.photoCount }} 张</span>
+              </button>
             </div>
-          </div>
-          
-          <!-- Loading More Indicator -->
-          <div v-if="loadingMore" class="flex justify-center items-center py-4">
-            <div class="animate-spin rounded-full h-6 w-6 border-4 border-primary-500 border-t-transparent"></div>
-          </div>
-          <div v-if="!hasMore && timelineNodes.length > 0" class="text-center text-gray-400 py-4 text-xs">
-            没有更多数据了
-          </div>
+          </article>
         </div>
       </div>
-    </div>
+    </aside>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted, computed, nextTick } from 'vue'
-import { Map, Plane } from 'lucide-vue-next'
+import { ChevronRight, LoaderCircle, Map, Pause, Play, Route } from 'lucide-vue-next'
 import { useRouter } from 'vue-router'
 import { locationService } from '@/api/location'
-import type { TimelineNode } from '@/types/location'
-import type { Photo } from '@/types/album'
+import type { TimelineNode, TrajectoryPoint } from '@/types/location'
 import { getTiandituTileTemplate, loadMapScript } from '@/utils/mapLoader'
 import { thumbnailUrl } from '@/utils/mediaUrl'
 import { ElMessage } from 'element-plus'
@@ -97,14 +171,7 @@ const props = defineProps<{
   viewMode: string
 }>()
 
-const emit = defineEmits<{
-  (e: 'click-photo', photo: Photo, contextPhotos: Photo[]): void
-}>()
-
 const loading = ref(false)
-const loadingMore = ref(false)
-const hasMore = ref(true)
-const skip = ref(0)
 const limit = 100
 
 const router = useRouter()
@@ -113,10 +180,25 @@ const timelineNodes = ref<TimelineNode[]>([])
 const map = ref<any>(null)
 const currentApiKey = ref('')
 const isMobile = computed(() => window.innerWidth <= 768)
-const showMobileList = ref(true)
+const showMobileList = ref(!isMobile.value)
+const selectedJourneyKey = ref('')
+const detailPoints = ref<TrajectoryPoint[]>([])
+const detailLoading = ref(false)
+const isPlaying = ref(false)
+const playbackIndex = ref(0)
+const playbackSpeed = ref(1)
+let playbackTimer: ReturnType<typeof setInterval> | null = null
+let detailRequestId = 0
 
-let animationId: number | null = null
-let currentArrow: any = null
+interface JourneyGroup {
+  key: string
+  title: string
+  dateRange: string
+  nodes: TimelineNode[]
+  locations: string[]
+  photoCount: number
+  coverId?: string
+}
 
 const toggleMobileList = () => {
   showMobileList.value = !showMobileList.value
@@ -133,9 +215,223 @@ const formatDate = (dateStr: string) => {
   }
 }
 
+const formatNodeDate = (node: TimelineNode) => {
+  if (node.startDate === node.endDate) return formatDate(node.startDate).full
+  return `${formatDate(node.startDate).full} — ${formatDate(node.endDate).short}`
+}
+
+const nodeStartTime = (node: TimelineNode) => new Date(node.startTime || `${node.startDate}T00:00:00`).getTime()
+const nodeEndTime = (node: TimelineNode) => new Date(node.endTime || `${node.endDate}T23:59:59`).getTime()
+
+const journeyGroups = computed<JourneyGroup[]>(() => {
+  const nodes = [...timelineNodes.value]
+    .filter(node => node.lat != null && node.lng != null)
+    .sort((a, b) => nodeStartTime(a) - nodeStartTime(b))
+
+  const groups: TimelineNode[][] = []
+  const maxGap = 7 * 24 * 60 * 60 * 1000
+  const maxJourneySpan = 21 * 24 * 60 * 60 * 1000
+  nodes.forEach((node) => {
+    const current = groups.at(-1)
+    if (!current) {
+      groups.push([node])
+      return
+    }
+    const previous = current.at(-1)!
+    const gap = nodeStartTime(node) - nodeEndTime(previous)
+    const journeySpan = nodeEndTime(node) - nodeStartTime(current[0])
+    // 地点时间段可能横跨数月；限制整段旅程的跨度，避免常驻城市把相邻旅行串成长链。
+    if (gap > maxGap || journeySpan > maxJourneySpan) groups.push([node])
+    else current.push(node)
+  })
+
+  return groups.reverse().map((group, index) => {
+    const first = group[0]
+    const last = group.at(-1)!
+    const locations = [...new Set(group.map(node => node.locationName))]
+    const title = locations.length === 1
+      ? locations[0]
+      : `${locations[0]} → ${locations.at(-1)}`
+    const start = formatDate(first.startDate)
+    const end = formatDate(last.endDate)
+    const dateRange = first.startDate === last.endDate
+      ? start.full
+      : `${start.full} — ${end.full}`
+    return {
+      key: `${first.startDate}-${last.endDate}-${index}`,
+      title,
+      dateRange,
+      nodes: group,
+      locations,
+      photoCount: group.reduce((sum, node) => sum + node.photoCount, 0),
+      coverId: last.coverId || first.coverId,
+    }
+  })
+})
+
+const selectedJourney = computed(() =>
+  journeyGroups.value.find(journey => journey.key === selectedJourneyKey.value)
+)
+
+const overviewNodes = computed(() => [...timelineNodes.value].sort((a, b) => nodeStartTime(a) - nodeStartTime(b)))
+
+const gpsRouteNodes = computed<TimelineNode[]>(() => detailPoints.value.map(point => ({
+  type: 'gps',
+  startDate: point.capturedAt.slice(0, 10),
+  endDate: (point.endAt || point.capturedAt).slice(0, 10),
+  startTime: point.capturedAt,
+  endTime: point.endAt || point.capturedAt,
+  locationName: point.locationName,
+  level: point.level,
+  lat: point.lat,
+  lng: point.lng,
+  photoCount: point.photoCount,
+  coverId: point.coverId,
+})))
+
+const haversineKm = (a: TimelineNode, b: TimelineNode) => {
+  const toRad = (value: number) => value * Math.PI / 180
+  const lat1 = toRad(a.lat || 0)
+  const lat2 = toRad(b.lat || 0)
+  const dLat = lat2 - lat1
+  const dLng = toRad((b.lng || 0) - (a.lng || 0))
+  const value = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2
+  return 6371.0088 * 2 * Math.asin(Math.sqrt(value))
+}
+
+const gpsExtentKm = computed(() => {
+  if (gpsRouteNodes.value.length < 2) return 0
+  const minLat = Math.min(...gpsRouteNodes.value.map(node => node.lat!))
+  const maxLat = Math.max(...gpsRouteNodes.value.map(node => node.lat!))
+  const minLng = Math.min(...gpsRouteNodes.value.map(node => node.lng!))
+  const maxLng = Math.max(...gpsRouteNodes.value.map(node => node.lng!))
+  return haversineKm(
+    { lat: minLat, lng: minLng } as TimelineNode,
+    { lat: maxLat, lng: maxLng } as TimelineNode,
+  )
+})
+
+const isLocalJourney = computed(() => Boolean(selectedJourney.value) && (
+  selectedJourney.value!.locations.length === 1 || gpsExtentKm.value <= 80
+))
+
+const routeModeLabel = computed(() => {
+  if (detailLoading.value) return '正在加载 GPS'
+  if (!detailPoints.value.length) return '行政区轨迹'
+  return isLocalJourney.value ? 'GPS 精细轨迹' : '跨区域混合轨迹'
+})
+
+const visibleJourneyNodes = computed(() => {
+  const nodes = selectedJourney.value?.nodes || []
+  return isPlaying.value ? nodes.slice(0, playbackIndex.value) : nodes
+})
+
+const playbackProgress = computed(() => {
+  const total = selectedJourney.value?.nodes.length || 0
+  return total ? Math.round((playbackIndex.value / total) * 100) : 0
+})
+
+const playbackLabel = computed(() => {
+  if (!selectedJourney.value) return '暂无旅程'
+  if (!isPlaying.value) return '完整路线'
+  const current = selectedJourney.value.nodes[Math.max(0, playbackIndex.value - 1)]
+  return current ? `${formatDate(current.startDate).short} · ${current.locationName}` : '准备出发'
+})
+
+const stopPlayback = (showFullRoute = true) => {
+  isPlaying.value = false
+  if (playbackTimer) clearInterval(playbackTimer)
+  playbackTimer = null
+  playbackIndex.value = showFullRoute ? (selectedJourney.value?.nodes.length || 0) : 0
+}
+
+const startPlaybackTimer = () => {
+  if (playbackTimer) clearInterval(playbackTimer)
+  const interval = Math.max(450, 1500 / playbackSpeed.value)
+  playbackTimer = setInterval(() => {
+    const total = selectedJourney.value?.nodes.length || 0
+    if (playbackIndex.value >= total) {
+      stopPlayback(true)
+      drawTrajectory()
+      return
+    }
+    playbackIndex.value += 1
+    drawTrajectory()
+    const current = selectedJourney.value?.nodes[playbackIndex.value - 1]
+    if (current?.lat != null && current.lng != null) {
+      map.value?.panTo(new T.LngLat(current.lng, current.lat))
+    }
+  }, interval)
+}
+
+const togglePlayback = () => {
+  if (!selectedJourney.value) return
+  if (isPlaying.value) {
+    stopPlayback(true)
+    drawTrajectory()
+    return
+  }
+  playbackIndex.value = 1
+  isPlaying.value = true
+  drawTrajectory()
+  startPlaybackTimer()
+}
+
+const cycleSpeed = () => {
+  playbackSpeed.value = playbackSpeed.value === 1 ? 1.5 : playbackSpeed.value === 1.5 ? 2 : 1
+  if (isPlaying.value) startPlaybackTimer()
+}
+
+const selectJourney = (key: string) => {
+  stopPlayback(false)
+  selectedJourneyKey.value = key
+  detailPoints.value = []
+  if (isMobile.value) showMobileList.value = false
+  nextTick(() => {
+    playbackIndex.value = selectedJourney.value?.nodes.length || 0
+    drawTrajectory(true)
+    void fetchJourneyDetail()
+  })
+}
+
+const selectOverview = () => {
+  detailRequestId += 1
+  detailLoading.value = false
+  detailPoints.value = []
+  selectedJourneyKey.value = ''
+  stopPlayback(false)
+  if (isMobile.value) showMobileList.value = false
+  nextTick(() => drawTrajectory(true))
+}
+
+const fetchJourneyDetail = async () => {
+  const journey = selectedJourney.value
+  if (!journey) return
+  const requestId = ++detailRequestId
+  detailLoading.value = true
+  try {
+    const response = await locationService.getTrajectory(journey.nodes[0].startDate, journey.nodes.at(-1)!.endDate)
+    if (requestId !== detailRequestId) return
+    detailPoints.value = response.points
+    nextTick(() => drawTrajectory(true))
+  } catch (error) {
+    if (requestId === detailRequestId) console.warn('Failed to load GPS trajectory detail', error)
+  } finally {
+    if (requestId === detailRequestId) detailLoading.value = false
+  }
+}
+
 const getThumbnailUrl = (photoId: string) => {
   // return `https://picsum.photos/seed/${photoId}/400/600`
   return thumbnailUrl(photoId)
+}
+
+const waitForOverlayApi = async () => {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (typeof T?.Label === 'function' && typeof T?.Polyline === 'function') return
+    await new Promise(resolve => window.setTimeout(resolve, 100))
+  }
+  throw new Error('天地图覆盖物组件加载超时')
 }
 
 // Map initialization
@@ -161,79 +457,83 @@ const initMap = () => {
 }
 
 // Data fetching
-const fetchTimelineData = async (isLoadMore = false) => {
-  if (loading.value || loadingMore.value || (!hasMore.value && isLoadMore)) return
-
-  if (isLoadMore) {
-    loadingMore.value = true
-  } else {
-    loading.value = true
-    skip.value = 0
-    hasMore.value = true
-  }
-  timelineNodes.value = []
+const fetchTimelineData = async () => {
+  if (loading.value) return
+  loading.value = true
   try {
-    while (hasMore.value) {
-      const res = await locationService.getTimelineNodes(skip.value, limit, props.startDate, props.endDate, props.level)
+    const incoming: TimelineNode[] = []
+    let offset = 0
+    let hasMore = true
+    while (hasMore) {
+      const res = await locationService.getTimelineNodes(offset, limit, props.startDate, props.endDate, props.level)
       const newNodes = res.nodes
-      if (newNodes.length < limit) {
-        hasMore.value = false
-      }
-      timelineNodes.value.push(...newNodes)
-      skip.value += limit
+      incoming.push(...newNodes)
+      hasMore = newNodes.length === limit
+      offset += limit
     }
+    // 新数据完整到达后再一次性替换，筛选时不会先清空地图。
+    timelineNodes.value = incoming
+    selectedJourneyKey.value = ''
+    detailPoints.value = []
+    playbackIndex.value = 0
     nextTick(() => {
-       drawTrajectory()
+      drawTrajectory(true)
     })
   } catch (e) {
     console.error('Failed to fetch timeline nodes', e)
   } finally {
     loading.value = false
-    loadingMore.value = false
-  }
-}
-
-const handleScroll = (e: Event) => {
-  const target = e.target as HTMLElement
-  if (target.scrollHeight - target.scrollTop <= target.clientHeight + 200) {
-    fetchTimelineData(true)
   }
 }
 
 // Draw markers and lines on the map
-const drawTrajectory = () => {
+const drawTrajectory = (fitViewport = false) => {
   if (!map.value) return
   map.value.clearOverLays()
 
   const points: any[] = []
-  
-  timelineNodes.value.forEach((node, index) => {
+  const summaryNodes = selectedJourney.value ? visibleJourneyNodes.value : overviewNodes.value
+  const detailedRoute = selectedJourney.value && !isPlaying.value ? gpsRouteNodes.value : []
+  const routeNodes = detailedRoute.length > 1 ? detailedRoute : summaryNodes
+  const representativeGpsNodes = (() => {
+    if (!isLocalJourney.value || detailedRoute.length <= 18) return detailedRoute
+    const result: TimelineNode[] = []
+    const lastIndex = detailedRoute.length - 1
+    for (let index = 0; index < 18; index += 1) {
+      result.push(detailedRoute[Math.round(index * lastIndex / 17)])
+    }
+    return [...new Set(result)]
+  })()
+  // 区域内旅行显示有限数量的 GPS 照片节点；跨区域旅行保留行政区停留点。
+  const markerNodes = isLocalJourney.value && representativeGpsNodes.length
+    ? representativeGpsNodes
+    : summaryNodes
+
+  markerNodes.forEach((node, index) => {
      const lat = (node as any).lat;
      const lng = (node as any).lng;
      if (!lat || !lng) return;
 
      const point = new T.LngLat(lng, lat);
-     points.push(point);
-
      const photoCount = (node as any).photoCount || 1;
-     // Adjust marker size based on photo count (min 30, max 60)
-     const size = Math.min(60, Math.max(30, 20 + Math.sqrt(photoCount) * 5));
+     const size = isLocalJourney.value
+       ? Math.min(42, Math.max(28, 24 + Math.sqrt(photoCount) * 2.2))
+       : Math.min(52, Math.max(34, 27 + Math.sqrt(photoCount) * 2.8));
      const coverId = (node as any).coverId;
      const coverUrl = coverId ? getThumbnailUrl(coverId) : '';
      
      const dateLabel = node.startDate === node.endDate ? formatDate(node.startDate).short : formatDate(node.startDate).short + '-' + formatDate(node.endDate).short;
 
+     const accent = currentTheme.value.primary
      const html = `
-       <div class="trajectory-marker group relative cursor-pointer" style="width: ${size}px; height: ${size}px; z-index: ${index};">
-         <div class="w-full h-full rounded-full border-[3px] border-white shadow-lg overflow-hidden bg-gray-200 transition-transform duration-300 group-hover:scale-110 group-hover:border-primary-500 group-hover:z-50 group-hover:shadow-xl">
-           <img src="${coverUrl}" class="w-full h-full object-cover" onerror="this.style.display='none'" />
+       <div style="position:relative;width:${size}px;height:${size}px;cursor:pointer;filter:drop-shadow(0 8px 14px rgba(0,0,0,.38));">
+         <div style="width:100%;height:100%;overflow:hidden;border:2px solid ${accent};border-radius:999px;background:#10243a;box-shadow:0 0 0 4px rgba(7,17,31,.72),0 0 22px ${accent}55;">
+           <img src="${coverUrl}" style="width:100%;height:100%;object-fit:cover;" onerror="this.style.display='none'" />
          </div>
-         <div class="absolute -bottom-6 left-1/2 -translate-x-1/2 whitespace-nowrap bg-white/90 backdrop-blur-sm px-2 py-0.5 rounded shadow-sm text-xs font-bold text-gray-800 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
-           ${dateLabel} · ${node.locationName}
-         </div>
-         ${photoCount > 1 ? `<div style="position: absolute; top: -6px; right: -6px; background-color: #ef4444; color: white; font-size: 11px; font-weight: 600; padding: 0 5px; height: 18px; line-height: 16px; border-radius: 9px; border: 2px solid white; box-shadow: 0 2px 4px rgba(0,0,0,0.1); min-width: 18px; text-align: center;">${photoCount}</div>` : ''}
-       </div>
-     `;
+         <div style="position:absolute;left:-5px;top:-6px;display:grid;width:20px;height:20px;place-items:center;border:2px solid #07111f;border-radius:999px;background:${accent};color:white;font:700 10px/1 sans-serif;">${index + 1}</div>
+         <div style="position:absolute;right:-7px;bottom:-5px;min-width:22px;height:18px;padding:0 5px;border:1px solid ${accent}88;border-radius:9px;background:rgba(7,17,31,.92);color:#dcecff;font:600 10px/16px sans-serif;text-align:center;">${photoCount}</div>
+         <div style="position:absolute;left:50%;bottom:-29px;transform:translateX(-50%);padding:3px 7px;border:1px solid ${accent}55;border-radius:7px;background:rgba(7,17,31,.9);color:#dcecff;font:600 10px/1.2 sans-serif;white-space:nowrap;">${dateLabel} · ${node.locationName}</div>
+       </div>`;
 
      const label = new T.Label({
        text: html,
@@ -250,19 +550,23 @@ const drawTrajectory = () => {
      map.value.addOverLay(label)
   })
 
-  // Draw lines and directional arrows
+  routeNodes.forEach((node) => {
+    if (node.lat == null || node.lng == null) return
+    points.push(new T.LngLat(node.lng, node.lat))
+  })
+
+  // 一次只绘制选中旅程，避免跨年份节点被强行连接成蜘蛛网。
   if (points.length > 1) {
      const line = new T.Polyline(points, {
-       color: currentTheme.value.primary, // 跟随主题色
-       weight: 3,
-       opacity: 0.8,
-       lineStyle: "dashed"
+       color: currentTheme.value.primary,
+       weight: 4,
+       opacity: 0.9,
+       lineStyle: "solid"
      });
      map.value.addOverLay(line)
-     // Fit view to points
-     map.value.setViewport(points)
+     if (fitViewport) map.value.setViewport(points)
   } else if (points.length === 1) {
-     map.value.panTo(points[0], 10)
+     if (fitViewport) map.value.centerAndZoom(points[0], 10)
   }
 }
 
@@ -291,7 +595,10 @@ const goToLocationDetail = (node: TimelineNode) => {
 
 watch([() => props.startDate, () => props.endDate, () => props.level], () => {
   if (props.viewMode === 'trajectory' && props.level !== 'photo-map') {
-      fetchTimelineData()
+      stopPlayback(false)
+      detailRequestId += 1
+      detailPoints.value = []
+      void fetchTimelineData()
       nextTick(() => {
         initMap()
       })
@@ -308,10 +615,11 @@ watch(() => currentTheme.value.primary, () => {
 onMounted(async () => {
   try {
     currentApiKey.value = await loadMapScript()
+    // 天地图主脚本就绪后，Label 等覆盖物组件仍可能异步注册。
+    await waitForOverlayApi()
     if (props.viewMode === 'trajectory' && props.level !== 'photo-map') {
-      nextTick(() => {
-        initMap()
-      })
+      await nextTick()
+      initMap()
       await fetchTimelineData()
     }
   } catch (e: any) {
@@ -320,14 +628,207 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  if (animationId) {
-    cancelAnimationFrame(animationId)
-  }
+  stopPlayback(false)
 })
 
 </script>
 
 <style scoped>
+.trajectory-cockpit { color: #dcecff; background: #07111f; }
+.trajectory-map-stage { isolation: isolate; background: #07111f; }
+#trajectory-map { background: #0a1727; }
+#trajectory-map :deep(.tdt-tile-pane img) {
+  filter: invert(0.88) hue-rotate(175deg) saturate(0.65) brightness(0.66) contrast(1.14);
+}
+.map-vignette {
+  z-index: 3;
+  background:
+    radial-gradient(circle at 58% 46%, transparent 28%, rgba(4, 11, 20, 0.14) 64%, rgba(4, 11, 20, 0.58) 100%),
+    linear-gradient(90deg, rgba(7, 17, 31, 0.46), transparent 18%);
+  box-shadow: inset 0 0 90px rgba(0, 0, 0, 0.25);
+}
+.journey-panel {
+  z-index: 1000;
+  border-color: rgba(var(--theme-rgb), 0.18);
+  background: linear-gradient(180deg, rgba(8, 21, 37, 0.98), rgba(5, 14, 26, 0.99));
+  box-shadow: 16px 0 48px rgba(0, 0, 0, 0.24), inset -1px 0 rgba(255, 255, 255, 0.025);
+}
+.panel-kicker,
+.hud-kicker {
+  color: var(--theme-primary);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+.journey-card {
+  overflow: hidden;
+  border: 1px solid rgba(var(--theme-rgb), 0.12);
+  border-radius: 15px;
+  background: rgba(13, 31, 51, 0.64);
+  transition: border-color 180ms ease, background-color 180ms ease, box-shadow 180ms ease;
+}
+.overview-card {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 11px;
+  padding: 12px;
+  border: 1px solid rgba(var(--theme-rgb), 0.14);
+  border-radius: 15px;
+  background: rgba(13, 31, 51, 0.58);
+  text-align: left;
+  transition: border-color 180ms ease, background-color 180ms ease, box-shadow 180ms ease;
+}
+.overview-card:hover,
+.overview-card.active {
+  border-color: rgba(var(--theme-rgb), 0.5);
+  background: linear-gradient(135deg, rgba(var(--theme-rgb), 0.16), rgba(13, 31, 51, 0.82));
+  box-shadow: 0 0 24px rgba(var(--theme-rgb), 0.08);
+}
+.overview-icon {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(var(--theme-rgb), 0.34);
+  border-radius: 11px;
+  color: var(--theme-primary);
+  background: rgba(var(--theme-rgb), 0.1);
+}
+.journey-card:hover { border-color: rgba(var(--theme-rgb), 0.34); }
+.journey-card.active {
+  border-color: rgba(var(--theme-rgb), 0.58);
+  background: linear-gradient(135deg, rgba(var(--theme-rgb), 0.14), rgba(13, 31, 51, 0.82));
+  box-shadow: 0 0 26px rgba(var(--theme-rgb), 0.08), inset 0 1px rgba(255, 255, 255, 0.035);
+}
+.journey-count {
+  min-width: 24px;
+  padding: 2px 6px;
+  border: 1px solid rgba(var(--theme-rgb), 0.3);
+  border-radius: 999px;
+  color: var(--theme-primary);
+  background: rgba(var(--theme-rgb), 0.1);
+  font-size: 10px;
+  text-align: center;
+}
+.journey-stops {
+  margin: 0 12px 12px 30px;
+  padding-left: 12px;
+  border-left: 1px solid rgba(var(--theme-rgb), 0.24);
+}
+.stop-row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 5px;
+  border-radius: 8px;
+  text-align: left;
+  transition: background-color 160ms ease;
+}
+.stop-row:hover,
+.stop-row.current { background: rgba(var(--theme-rgb), 0.09); }
+.stop-index {
+  display: grid;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(var(--theme-rgb), 0.34);
+  border-radius: 999px;
+  color: var(--theme-primary);
+  font-size: 9px;
+}
+.journey-hud {
+  position: absolute;
+  z-index: 1000;
+  left: 24px;
+  top: 84px;
+  min-width: 280px;
+  padding: 14px 16px;
+  border: 1px solid rgba(var(--theme-rgb), 0.2);
+  border-radius: 14px;
+  background: rgba(7, 17, 31, 0.82);
+  box-shadow: 0 14px 42px rgba(0, 0, 0, 0.3), inset 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(16px);
+}
+.route-mode-badge {
+  padding: 2px 7px;
+  border: 1px solid rgba(var(--theme-rgb), 0.28);
+  border-radius: 999px;
+  color: var(--theme-primary);
+  background: rgba(var(--theme-rgb), 0.09);
+}
+.playback-dock {
+  position: absolute;
+  z-index: 1000;
+  left: 24px;
+  right: 24px;
+  bottom: 22px;
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  max-width: 620px;
+  min-height: 66px;
+  padding: 12px 14px;
+  border: 1px solid rgba(var(--theme-rgb), 0.24);
+  border-radius: 15px;
+  background: rgba(7, 17, 31, 0.86);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.34), inset 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(18px);
+}
+.play-button {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(var(--theme-rgb), 0.5);
+  border-radius: 999px;
+  color: var(--theme-primary);
+  background: rgba(var(--theme-rgb), 0.12);
+  box-shadow: 0 0 20px rgba(var(--theme-rgb), 0.16);
+}
+.playback-track {
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #1b3248;
+}
+.playback-track div {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--theme-primary);
+  box-shadow: 0 0 12px rgba(var(--theme-rgb), 0.7);
+  transition: width 300ms ease;
+}
+.speed-button {
+  min-width: 38px;
+  padding: 5px 7px;
+  border: 1px solid rgba(var(--theme-rgb), 0.2);
+  border-radius: 8px;
+  color: #a9bed1;
+  background: rgba(var(--theme-rgb), 0.08);
+  font-size: 11px;
+}
+.loading-chip {
+  position: absolute;
+  z-index: 1001;
+  left: 50%;
+  top: 88px;
+  display: flex;
+  transform: translateX(-50%);
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid rgba(var(--theme-rgb), 0.2);
+  border-radius: 999px;
+  color: #a9bed1;
+  background: rgba(7, 17, 31, 0.86);
+  font-size: 11px;
+  backdrop-filter: blur(14px);
+}
 .custom-scrollbar::-webkit-scrollbar {
   width: 4px;
 }
@@ -335,18 +836,20 @@ onUnmounted(() => {
   background: transparent;
 }
 .custom-scrollbar::-webkit-scrollbar-thumb {
-  background-color: rgba(156, 163, 175, 0.5);
+  background-color: rgba(var(--theme-rgb), 0.28);
   border-radius: 20px;
 }
-.dark .custom-scrollbar::-webkit-scrollbar-thumb {
-  background-color: rgba(75, 85, 99, 0.5);
-}
 
-.no-scrollbar::-webkit-scrollbar {
-  display: none;
-}
-.no-scrollbar {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+@media (max-width: 767px) {
+  .journey-panel-mobile {
+    bottom: 0;
+    box-shadow: 0 -18px 48px rgba(0, 0, 0, 0.36);
+  }
+  .playback-dock {
+    left: 12px;
+    right: 12px;
+    bottom: 48px;
+  }
+  .loading-chip { top: 70px; }
 }
 </style>

--- a/package/website/src/views/album/location/components/GlobalOverviewPanel.vue
+++ b/package/website/src/views/album/location/components/GlobalOverviewPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="space-y-8 animate-fade-in">
+  <div class="overview-cockpit space-y-6 animate-fade-in">
     <!-- 骨架屏加载状态 -->
     <div v-if="!globalStats" class="space-y-8">
       <div>
@@ -13,36 +13,47 @@
 
     <div v-else class="space-y-6">
       <div>
-        <h2 class="text-xl font-bold text-gray-800 dark:text-white mb-4">足迹概览</h2>
+        <div class="mb-4 flex items-center justify-between">
+          <div>
+            <div class="cockpit-kicker">TRAVEL INTELLIGENCE</div>
+            <h2 class="text-xl font-bold text-white">足迹概览</h2>
+          </div>
+          <div class="live-indicator"><span /> 数据已同步</div>
+        </div>
         
         <!-- 足迹里程碑 -->
-        <div class="mb-4 bg-gradient-to-r from-primary-50 to-primary-100 dark:from-primary-900/20 dark:to-primary-900/10 p-4 rounded-xl border border-primary-100 dark:border-primary-800/30">
-          <div class="flex justify-between items-end mb-2">
-            <div>
-              <div class="text-sm font-bold text-gray-800 dark:text-gray-200">全国探索进度</div>
-              <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">已点亮 {{ globalStats.province_count }} / 34 个省级行政区</div>
-            </div>
-            <div class="text-lg font-black text-primary-600 dark:text-primary-400">
-              {{ Math.round((globalStats.province_count / 34) * 100) }}%
+        <div class="exploration-card">
+          <div class="progress-orbit" :style="{ '--progress': `${explorationPercentage * 3.6}deg` }">
+            <div class="progress-orbit__inner">
+              <strong>{{ explorationPercentage }}%</strong>
+              <span>已探索</span>
             </div>
           </div>
-          <div class="h-2 w-full bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden shadow-inner">
-            <div class="h-full rounded-full transition-all duration-1000" :style="{ width: `${(globalStats.province_count / 34) * 100}%`, backgroundColor: currentTheme.primary }"></div>
+          <div class="min-w-0 flex-1">
+            <div class="text-base font-semibold text-white">探索中国</div>
+            <div class="mt-1 text-xs text-[#7891aa]">已点亮 {{ globalStats.province_count }} / 34 个省级行政区</div>
+            <div class="progress-track mt-4">
+              <div :style="{ width: `${explorationPercentage}%`, backgroundColor: currentTheme.primary }" />
+            </div>
           </div>
         </div>
 
-        <div class="grid grid-cols-2 gap-3">
-          <div class="bg-primary-50 dark:bg-primary-900/20 p-3 rounded-xl border border-primary-100 dark:border-primary-800/30">
-            <div class="text-xs text-primary-600 dark:text-primary-400 mb-1">点亮省份</div>
-            <div class="text-2xl font-bold text-primary-700 dark:text-primary-300">
+        <div class="mt-3 grid grid-cols-3 gap-2">
+          <div class="metric-card">
+            <div class="metric-label">点亮省份</div>
+            <div class="metric-value">
               {{ globalStats.province_count || 0 }}
             </div>
           </div>
-          <div class="bg-primary-50 dark:bg-primary-900/20 p-3 rounded-xl border border-primary-100 dark:border-primary-800/30">
-            <div class="text-xs text-primary-600 dark:text-primary-400 mb-1">点亮城市</div>
-            <div class="text-2xl font-bold text-primary-700 dark:text-primary-300">
+          <div class="metric-card">
+            <div class="metric-label">点亮城市</div>
+            <div class="metric-value">
               {{ globalStats.city_count || 0 }}
             </div>
+          </div>
+          <div class="metric-card">
+            <div class="metric-label">点亮区县</div>
+            <div class="metric-value metric-value--small">{{ globalStats.district_count || 0 }}</div>
           </div>
         </div>
       </div>
@@ -50,11 +61,11 @@
 
     <!-- Top 5 排行榜 -->
     <div>
-      <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-1.5">
+      <h3 class="section-heading">
         <Trophy class="w-4 h-4 text-yellow-500" /> 热门打卡地
       </h3>
       <div v-if="topRegions.length > 0" class="space-y-3">
-        <div v-for="(item, index) in topRegions" :key="item.name" class="flex items-center gap-3 cursor-pointer group" @click="emit('select-region', item.name, item.count)">
+        <div v-for="(item, index) in topRegions" :key="item.name" class="ranking-row flex items-center gap-3 cursor-pointer group rounded-xl p-2 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" role="button" tabindex="0" @click="emit('select-region', item.name, item.count)" @keydown.enter="emit('select-region', item.name, item.count)">
           <div class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold" 
                :class="index === 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500' : 
                        index === 1 ? 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400' : 
@@ -64,10 +75,10 @@
           </div>
           <div class="flex-1">
             <div class="flex justify-between text-sm mb-1">
-              <span class="text-gray-700 dark:text-gray-200 group-hover:text-primary-500 transition-colors">{{ item.name }}</span>
-              <span class="text-gray-500 dark:text-gray-400">{{ item.count }} 张</span>
+              <span class="text-[#c8d9e9] group-hover:text-primary-500 transition-colors">{{ item.name }}</span>
+              <span class="text-[#7189a0]">{{ item.count }} 张</span>
             </div>
-            <div class="h-1.5 w-full bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+            <div class="h-1 w-full bg-[#152a40] rounded-full overflow-hidden">
               <div class="h-full rounded-full transition-all duration-1000" 
                    :style="{ 
                      width: `${(item.count / topRegions[0].count) * 100}%`,
@@ -86,29 +97,29 @@
     <!-- 时间轴趋势图 -->
     <div v-if="globalStats && (globalStats.province_count > 0 || globalStats.city_count > 0)">
       <div class="flex items-center justify-between mb-3">
-        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
-          <TrendingUp class="w-4 h-4 text-green-500" /> 足迹趋势
+        <h3 class="section-heading">
+          <TrendingUp class="w-4 h-4 text-primary-500" /> 足迹趋势
         </h3>
-        <div class="flex bg-gray-100 dark:bg-gray-800 p-0.5 rounded-lg">
-          <button @click="trendDimension = 'year'; renderTrendChart()" :class="trendDimension === 'year' ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-800 dark:text-white' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'" class="px-2 py-1 text-xs rounded-md transition-all font-medium">年</button>
-          <button @click="trendDimension = 'month'; renderTrendChart()" :class="trendDimension === 'month' ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-800 dark:text-white' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700'" class="px-2 py-1 text-xs rounded-md transition-all font-medium">月</button>
+        <div class="dimension-toggle">
+          <button @click="trendDimension = 'year'; renderTrendChart()" :class="{ active: trendDimension === 'year' }" class="focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none">年</button>
+          <button @click="trendDimension = 'month'; renderTrendChart()" :class="{ active: trendDimension === 'month' }" class="focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none">月</button>
         </div>
       </div>
-      <div class="bg-white dark:bg-gray-800/50 rounded-xl p-2 border border-gray-100 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-shadow">
+      <div class="chart-card">
         <div ref="trendChartContainer" class="h-40 w-full"></div>
       </div>
     </div>
 
     <!-- 最近去过的地方 -->
     <div class="pt-2">
-      <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-1.5">
+      <h3 class="section-heading mb-3">
         <MapPin class="w-4 h-4 text-primary-500" /> 最近去过
       </h3>
       <div v-if="recentTrips.length > 0" class="space-y-2">
-        <div v-for="(trip, index) in recentTrips" :key="index" class="flex items-center justify-between bg-white dark:bg-gray-800/50 p-3 rounded-xl border border-gray-100 dark:border-gray-700/50 hover:border-primary-200 dark:hover:border-primary-800/50 cursor-pointer transition-colors" @click="emit('click-location', trip.locationName, trip.level)">
+        <div v-for="(trip, index) in recentTrips" :key="index" class="recent-trip flex items-center justify-between p-3 rounded-xl cursor-pointer focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" role="button" tabindex="0" @click="emit('click-location', trip.locationName, trip.level)" @keydown.enter="emit('click-location', trip.locationName, trip.level)">
           <div class="flex flex-col">
-            <span class="text-sm font-medium text-gray-800 dark:text-white">{{ trip.locationName }}</span>
-            <span class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ trip.startDate }}</span>
+            <span class="text-sm font-medium text-[#dcecff]">{{ trip.locationName }}</span>
+            <span class="text-xs text-[#7189a0] mt-0.5">{{ trip.startDate }}</span>
           </div>
           <div class="flex items-center gap-1.5 text-xs text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20 px-2 py-1 rounded-md">
             <Images class="w-3 h-3" />
@@ -125,7 +136,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { computed, ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { echarts } from '@/utils/echarts'
 import { useTheme } from '@/composables/useTheme'
 import { MapPin, Trophy, TrendingUp, Images } from 'lucide-vue-next'
@@ -150,6 +161,7 @@ const trendChartContainer = ref<HTMLElement | null>(null)
 let trendChart: echarts.ECharts | null = null
 const trendDimension = ref<'year' | 'month'>('year')
 let resizeTimer: ReturnType<typeof setTimeout> | null = null
+const explorationPercentage = computed(() => Math.min(Math.round(((props.globalStats?.province_count || 0) / 34) * 100), 100))
 
 const renderTrendChart = () => {
   if (!trendChartContainer.value || props.rawTimelineData.length === 0) return
@@ -180,12 +192,12 @@ const renderTrendChart = () => {
       data: keys,
       axisLine: { show: false },
       axisTick: { show: false },
-      axisLabel: { color: isDark.value ? '#94a3b8' : '#64748b', fontSize: 10 }
+      axisLabel: { color: '#7189a0', fontSize: 10 }
     },
     yAxis: {
       type: 'value',
-      splitLine: { lineStyle: { type: 'dashed', color: isDark.value ? '#334155' : '#e2e8f0' } },
-      axisLabel: { color: isDark.value ? '#94a3b8' : '#64748b', fontSize: 10 }
+      splitLine: { lineStyle: { type: 'dashed', color: 'rgba(113, 137, 160, 0.18)' } },
+      axisLabel: { color: '#7189a0', fontSize: 10 }
     },
     series: [{
       name: '照片数量',
@@ -241,6 +253,82 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.overview-cockpit { color: #c8d9e9; }
+.cockpit-kicker {
+  margin-bottom: 3px;
+  color: var(--theme-primary);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+.live-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #7189a0;
+  font-size: 10px;
+}
+.live-indicator span {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--theme-primary);
+  box-shadow: 0 0 10px rgba(var(--theme-rgb), 0.8);
+}
+.exploration-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 15px;
+  border: 1px solid rgba(var(--theme-rgb), 0.24);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(var(--theme-rgb), 0.11), rgba(15, 35, 57, 0.52));
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.035);
+}
+.progress-orbit {
+  display: grid;
+  width: 78px;
+  height: 78px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 999px;
+  background: conic-gradient(var(--theme-primary) var(--progress), rgba(var(--theme-rgb), 0.12) 0);
+  box-shadow: 0 0 28px rgba(var(--theme-rgb), 0.18);
+}
+.progress-orbit__inner {
+  display: flex;
+  width: 64px;
+  height: 64px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(var(--theme-rgb), 0.15);
+  border-radius: 999px;
+  background: #0a192b;
+}
+.progress-orbit__inner strong { color: #fff; font-size: 20px; line-height: 1; }
+.progress-orbit__inner span { margin-top: 4px; color: #7189a0; font-size: 9px; }
+.progress-track { height: 4px; overflow: hidden; border-radius: 999px; background: #172c42; }
+.progress-track div { height: 100%; border-radius: inherit; box-shadow: 0 0 10px rgba(var(--theme-rgb), 0.6); }
+.metric-card {
+  min-width: 0;
+  padding: 11px;
+  border: 1px solid rgba(var(--theme-rgb), 0.16);
+  border-radius: 12px;
+  background: rgba(15, 35, 57, 0.62);
+}
+.metric-label { overflow: hidden; color: #7189a0; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.metric-value { margin-top: 4px; color: #f0f8ff; font-size: 22px; font-weight: 700; }
+.metric-value--small { font-size: 17px; line-height: 28px; }
+.section-heading { display: flex; align-items: center; gap: 6px; color: #a9bed1; font-size: 13px; font-weight: 600; }
+.ranking-row { transition: background-color 180ms ease; }
+.ranking-row:hover { background: rgba(var(--theme-rgb), 0.07); }
+.dimension-toggle { display: flex; padding: 2px; border: 1px solid rgba(var(--theme-rgb), 0.14); border-radius: 8px; background: #0b1a2c; }
+.dimension-toggle button { padding: 3px 8px; border-radius: 6px; color: #7189a0; font-size: 10px; }
+.dimension-toggle button.active { color: #e8f6ff; background: rgba(var(--theme-rgb), 0.18); }
+.chart-card { padding: 8px; border: 1px solid rgba(var(--theme-rgb), 0.15); border-radius: 14px; background: rgba(13, 31, 51, 0.62); }
+.recent-trip { border: 1px solid rgba(var(--theme-rgb), 0.13); background: rgba(13, 31, 51, 0.58); transition: border-color 180ms ease, background-color 180ms ease; }
+.recent-trip:hover { border-color: rgba(var(--theme-rgb), 0.4); background: rgba(var(--theme-rgb), 0.08); }
 .animate-fade-in {
   animation: fadeIn 0.3s ease-in-out;
 }

--- a/package/website/src/views/album/location/components/MapContainer.vue
+++ b/package/website/src/views/album/location/components/MapContainer.vue
@@ -1,30 +1,30 @@
 <template>
-  <div class="w-full h-full relative">
+  <div class="immersive-map w-full h-full relative">
     <div ref="mapContainer" class="w-full h-full"></div>
     
     <!-- 面包屑导航 -->
-    <div v-if="parentRegion" class="absolute top-6 left-6 z-10 flex items-center gap-2 bg-white/90 dark:bg-gray-800/90 backdrop-blur-md px-3 py-2 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 animate-fade-in">
-      <button @click="emit('change-level', level === 'city' ? 'province' : 'city', { zoom: 1.2, center: [] })" class="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500 hover:text-primary-500 dark:text-gray-400 transition-colors" title="返回上一级">
+    <div v-if="parentRegion" class="map-glass absolute top-20 left-6 z-10 flex items-center gap-2 backdrop-blur-md px-3 py-2 rounded-xl animate-fade-in">
+      <button @click="emit('change-level', level === 'city' ? 'province' : 'city', { zoom: 1.2, center: [] })" class="p-1 rounded text-[#7891aa] hover:text-primary-500 transition-colors focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" title="返回上一级">
         <ArrowLeft class="w-4 h-4" />
       </button>
-      <div class="w-px h-4 bg-gray-300 dark:bg-gray-600"></div>
-      <button @click="emit('change-level', level === 'city' ? 'province' : 'city', { zoom: 1.2, center: [] })" class="text-sm font-medium text-gray-500 hover:text-primary-500 dark:text-gray-400 dark:hover:text-primary-400 transition-colors flex items-center gap-1">
+      <div class="w-px h-4 bg-[#29425a]"></div>
+      <button @click="emit('change-level', level === 'city' ? 'province' : 'city', { zoom: 1.2, center: [] })" class="text-sm font-medium text-[#7891aa] hover:text-primary-500 transition-colors flex items-center gap-1 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none">
         <MapPin class="w-4 h-4" />
         全国
       </button>
       <ChevronRight class="w-4 h-4 text-gray-400" />
-      <span class="text-sm font-bold text-gray-800 dark:text-white pr-2">{{ parentRegion }}</span>
+      <span class="text-sm font-bold text-white pr-2">{{ parentRegion }}</span>
     </div>
     
     <!-- Map Controls Overlay -->
-    <div class="absolute bottom-6 right-6 flex flex-col gap-2 z-10">
-       <button @click="handleZoom('in')" class="p-2 bg-white/90 dark:bg-gray-800/90 backdrop-blur border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300 transition-colors" title="放大">
+    <div class="absolute bottom-32 right-6 flex flex-col gap-2 z-10">
+       <button @click="handleZoom('in')" class="map-control focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" title="放大">
          <ZoomIn class="w-5 h-5" />
        </button>
-       <button @click="handleZoom('out')" class="p-2 bg-white/90 dark:bg-gray-800/90 backdrop-blur border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300 transition-colors" title="缩小">
+       <button @click="handleZoom('out')" class="map-control focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" title="缩小">
          <ZoomOut class="w-5 h-5" />
        </button>
-       <button @click="resetMap" class="p-2 bg-white/90 dark:bg-gray-800/90 backdrop-blur border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300 transition-colors" title="重置视角">
+       <button @click="resetMap" class="map-control focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:outline-none" title="重置视角">
          <RotateCcw class="w-5 h-5" />
        </button>
     </div>
@@ -81,6 +81,7 @@ const isDark = isDarkMode
 
 let cachedMapData: { data: any[], max: number, geoJson: any, mapName: string, viewState?: { zoom: number, center: number[] } } | null = null
 let resizeTimer: ReturnType<typeof setTimeout> | null = null
+let distributionRequestId = 0
 const MOBILE_ROAM_ZOOM_DAMPING = 0.35
 
 // 双击下钻检测：记录上一次单击的区块名与时间，用于区分「单击选中」与「双击进入下一级」
@@ -137,7 +138,7 @@ const initMap = async (viewState?: { zoom: number, center: number[] }) => {
   myMap.showLoading({
     text: '',
     color: currentTheme.value.primary,
-    maskColor: isDark.value ? 'rgba(30, 41, 59, 0.8)' : 'rgba(255, 255, 255, 0.8)',
+    maskColor: 'rgba(7, 17, 31, 0.84)',
     spinnerRadius: 14,
     lineWidth: 3
   })
@@ -240,13 +241,13 @@ const initMap = async (viewState?: { zoom: number, center: number[] }) => {
 const renderMap = (data: any[], max: number, geoJson: any, mapName: string, viewState?: { zoom: number, center: number[] }) => {
   if (!myMap) return
 
-  const isDarkMode = isDark.value
+  const isDarkMode = true
   const isMobile = window.innerWidth < 768
 
   const nameMap = buildNameMap(geoJson)
 
   const rgbStr = currentTheme.value.rgb
-  const bgRgb = isDarkMode ? [30, 41, 59] : [244, 244, 245]
+  const bgRgb = [11, 28, 48]
   
   const mixColor = (ratio: number) => {
     const [r1, g1, b1] = rgbStr.split(',').map(Number)
@@ -257,9 +258,7 @@ const renderMap = (data: any[], max: number, geoJson: any, mapName: string, view
     return `rgb(${r}, ${g}, ${b})`
   }
 
-  const inRangeColors = isDarkMode
-    ? [mixColor(0.3), mixColor(0.6), mixColor(1)]
-    : [mixColor(0.2), mixColor(0.6), mixColor(1)]
+  const inRangeColors = [mixColor(0.24), mixColor(0.55), mixColor(0.92)]
 
   const option = {
     backgroundColor: 'transparent',
@@ -311,9 +310,11 @@ const renderMap = (data: any[], max: number, geoJson: any, mapName: string, view
         },
         labelLayout: { hideOverlap: true },
         itemStyle: {
-          areaColor: isDarkMode ? '#1e293b' : '#e2e8f0',
-          borderColor: isDarkMode ? '#334155' : '#ffffff',
-          borderWidth: isDarkMode ? 0.5 : 1
+          areaColor: '#0d2238',
+          borderColor: `rgba(${rgbStr}, 0.34)`,
+          borderWidth: 0.9,
+          shadowColor: `rgba(${rgbStr}, 0.16)`,
+          shadowBlur: 8
         },
         emphasis: {
           itemStyle: {
@@ -364,6 +365,63 @@ const renderMap = (data: any[], max: number, geoJson: any, mapName: string, view
   myMap.setOption(option)
 }
 
+// 时间筛选只更新地图数据，不销毁 ECharts 实例或重新加载 GeoJSON。
+// 这样地图会一直留在画面中，并保留用户当前的缩放和拖拽位置。
+const refreshDistribution = async () => {
+  if (!myMap || !cachedMapData) {
+    await initMap()
+    return
+  }
+
+  const requestId = ++distributionRequestId
+  const { geoJson, mapName } = cachedMapData
+
+  try {
+    let distribution = await locationService.getDistribution(
+      props.level as 'city' | 'province' | 'district' | 'scene' | undefined,
+      props.startDate,
+      props.endDate
+    )
+    // 自动巡游或快速点击年份时，只应用最后一次请求，避免旧响应覆盖新年份。
+    if (requestId !== distributionRequestId || !myMap) return
+
+    if (props.parentRegion && geoJson.features) {
+      const validNames = new Set(Object.keys(buildNameMap(geoJson)))
+      distribution = distribution.filter(item =>
+        validNames.has(item.name) || [...validNames].some(name => name.includes(item.name))
+      )
+    }
+
+    const nameMap = buildNameMap(geoJson)
+    const data = distribution.map(item => ({
+      name: nameMap[item.name] || item.name,
+      value: item.count,
+    }))
+    const topRegions = [...data]
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 5)
+      .map(item => ({ name: item.name, count: item.value }))
+    emit('update-top-regions', topRegions)
+
+    const values = data.map(item => item.value).sort((a, b) => a - b)
+    const p90 = values[Math.floor(values.length * 0.9)] || 10
+    const maxVal = Math.max(...values, 10)
+    const visualMax = maxVal > p90 * 2 ? p90 * 1.5 : maxVal
+    cachedMapData = { ...cachedMapData, data, max: visualMax, geoJson, mapName }
+
+    myMap.setOption({
+      visualMap: { max: visualMax },
+      series: [{
+        data,
+        animationDurationUpdate: 480,
+        animationEasingUpdate: 'cubicOut',
+      }],
+    })
+  } catch (error) {
+    console.error('Map distribution refresh failed', error)
+  }
+}
+
 watch(() => props.viewMode, (newMode) => {
   if (newMode === 'map') {
     nextTick(() => { initMap() })
@@ -378,7 +436,7 @@ watch([() => props.level, () => props.parentRegion], ([newLevel, newParentRegion
 
 watch([() => props.startDate, () => props.endDate], () => {
   if (props.viewMode === 'map' && props.level !== 'photo-map' && props.level !== 'scene') {
-    nextTick(() => { initMap() })
+    nextTick(() => { void refreshDistribution() })
   }
 })
 
@@ -424,6 +482,27 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.immersive-map { z-index: 3; }
+.map-glass {
+  border: 1px solid rgba(var(--theme-rgb), 0.22);
+  background: rgba(7, 17, 31, 0.82);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.28), inset 0 1px rgba(255, 255, 255, 0.04);
+}
+.map-control {
+  padding: 8px;
+  border: 1px solid rgba(var(--theme-rgb), 0.2);
+  border-radius: 10px;
+  color: #a9bed1;
+  background: rgba(7, 17, 31, 0.84);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(14px);
+  transition: color 180ms ease, border-color 180ms ease, background-color 180ms ease;
+}
+.map-control:hover {
+  color: var(--theme-primary);
+  border-color: rgba(var(--theme-rgb), 0.48);
+  background: rgba(var(--theme-rgb), 0.1);
+}
 .animate-fade-in { animation: fadeIn 0.3s ease-in-out; }
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(5px); }


### PR DESCRIPTION
## 描述

升级位置相册的地图总览与旅行轨迹体验：默认保留全部地点汇聚总览，选中某次旅行后再根据空间尺度切换为景区级 GPS 轨迹或跨区域混合轨迹；同一天内的地点严格按照片实际拍摄时间排列。

同时补齐定位年份筛选与无空白切换体验，并提供暗色、响应式的沉浸式地图界面。

## 变更类型

- [ ] 🐛 修复错误 (Bug Fix)
- [x] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [x] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [x] ⚡️ 性能优化 (Performance)
- [x] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue

Closes #187

## 如何测试

- `pnpm build`（`package/website`）
- `uv run python -m pytest tests/unit/test_nightly_crud_location_public_gaps_20260827.py tests/unit/test_nightly_basic_location_session_gaps_20260817.py tests/unit/test_nightly_gap_rescue_20260904.py -q`（68 passed）
- 使用已部署的真实数据验证桌面端与移动端：全局总览、42 次旅行、跨区域混合轨迹，以及景区级 GPS 轨迹

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [ ] 我已更新了相关文档