### PR TITLE
docs(official-site): robots.txt 增加 llms.txt 提示引导 AI Agent

### DIFF
--- a/package/official-site/.vitepress/ai-docs.ts
+++ b/package/official-site/.vitepress/ai-docs.ts
@@ -312,6 +312,8 @@ const robots = [
   'Disallow: /en/docs/dev/prompt/',
   '',
   `Sitemap: ${siteUrl}/sitemap.xml`,
+  `# AI agents: read ${siteUrl}/llms.txt for a site-wide directory of AI-friendly documentation`,
+  `# Full documentation text: ${siteUrl}/llms-full.txt`,
   '',
 ].join('\n')
 


### PR DESCRIPTION
## 描述
在官网构建生成的 robots.txt 中追加两行注释，声明 llms.txt（AI Agent 友好的全站文档目录）与 llms-full.txt（全量文档文本）入口。

robots.txt 没有「第三方文档入口」的标准指令，业界惯例是通过注释行提供线索，AI Agent 读取 robots.txt 时会识别这类注释。抓取规则本身（Allow / Disallow / Sitemap）不变。

Closes #189

## 变更类型
- [x] 📝 文档更新 (Documentation)

## 相关 Issue
Closes #189

## 如何测试
本地执行 `pnpm docs:build`，检查 `.vitepress/dist/robots.txt` 产物，确认新增两行注释且原有规则未变：
```
Sitemap: https://trailsnap.cn/sitemap.xml
# AI agents: read https://trailsnap.cn/llms.txt for a site-wide directory of AI-friendly documentation
# Full documentation text: https://trailsnap.cn/llms-full.txt
```

## 检查清单
- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [ ] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [x] 我已更新了相关文档

I have read and agree to the CLA