### PR TITLE
test(nightly): cover AI artifacts, agent stream, and worker helpers

### DIFF
--- a/package/ai/tests/test_nightly_image_classification_models_20260907.py
+++ b/package/ai/tests/test_nightly_image_classification_models_20260907.py
@@ -1,0 +1,126 @@
+"""Nightly gap coverage for image-classification model registration and batches."""
+
+import base64
+import io
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from app.services import image_classification_service as module
+from app.services.image_classification_service import ImageClassificationService
+
+pytestmark = pytest.mark.smoke
+
+
+def _png_base64():
+    image = Image.new("RGB", (8, 8), color=(12, 34, 56))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode()
+
+
+def _bare_service(category_map=None):
+    service = ImageClassificationService.__new__(ImageClassificationService)
+    service._category_model_map = category_map or {}
+    return service
+
+
+def test_service_init_registers_general_and_discovered_category_models():
+    model_manager = MagicMock()
+    model_manager.models = {}
+    ai_manager = MagicMock()
+
+    with patch.object(module, "model_manager", model_manager), \
+         patch.object(module, "ai_model_manager", ai_manager), \
+         patch.object(ImageClassificationService, "_discover_category_models", return_value={"animal": "photo-cls-animal.onnx"}):
+        service = ImageClassificationService()
+
+    registered = [call.args[0] for call in model_manager.register_model.call_args_list]
+    assert registered == ["yolo_photo_cls_general", "yolo_photo_cls_animal"]
+    assert service._category_model_map == {"animal": "photo-cls-animal.onnx"}
+    assert service.version == "v0.3.10.1"
+
+
+def test_discover_category_models_filters_general_and_non_onnx_files(tmp_path):
+    service = _bare_service()
+    for name in ("photo-cls-animal.onnx", "photo-cls-general.onnx", "notes.txt"):
+        (tmp_path / name).write_bytes(b"x")
+
+    with patch.object(module, "ai_model_manager") as manager:
+        manager.get_model_dir.return_value = tmp_path
+        result = service._discover_category_models()
+
+    assert result == {"animal": "photo-cls-animal.onnx"}
+
+
+def test_discover_category_models_returns_empty_when_model_dir_missing(tmp_path):
+    service = _bare_service()
+    with patch.object(module, "ai_model_manager") as manager:
+        manager.get_model_dir.return_value = tmp_path / "missing"
+        assert service._discover_category_models() == {}
+
+
+def test_load_category_model_handles_missing_mapping_and_missing_file(tmp_path):
+    service = _bare_service({"animal": "photo-cls-animal.onnx"})
+    with patch.object(module, "ai_model_manager") as manager:
+        manager.get_model_dir.return_value = tmp_path
+        assert service._load_category_model("document") is None
+        assert service._load_category_model("animal") is None
+
+        model_path = tmp_path / "photo-cls-animal.onnx"
+        model_path.write_bytes(b"model")
+        sentinel = object()
+        with patch.object(module, "ONNXModelWrapper", return_value=sentinel):
+            assert service._load_category_model("animal") is sentinel
+
+
+def test_release_model_removes_session_and_collects_gc():
+    service = _bare_service()
+    wrapper = MagicMock()
+    wrapper.model_name = "photo-cls-animal.onnx"
+    wrapper.session = object()
+
+    with patch("gc.collect") as collect:
+        service._release_model(wrapper)
+
+    assert not hasattr(wrapper, "session")
+    collect.assert_called_once()
+
+
+def test_classify_yolo_uses_category_model_when_available():
+    service = _bare_service({"animal": "photo-cls-animal.onnx"})
+    general = MagicMock()
+    general.names = {0: "animal", 1: "document"}
+    general.return_value = [np.array([0.9, 0.1]), np.array([0.8, 0.2])]
+    small = MagicMock()
+    small.names = {0: "cat", 1: "dog"}
+    small.return_value = [np.array([0.99, 0.01]), np.array([0.02, 0.98])]
+
+    with patch.object(service, "_register_available_category_models"), \
+         patch.object(module, "ai_model_manager") as ai_manager, \
+         patch.object(module, "model_manager") as model_manager:
+        ai_manager.is_ready.return_value = True
+        model_manager.get_model.side_effect = [general, small]
+        results = service.classify_yolo([_png_base64(), _png_base64()])
+
+    assert [item["status"] for item in results] == ["success", "success"]
+    assert [item["predictions"][0]["label"] for item in results] == ["\u732b", "\u72d7"]
+    assert [item["predictions"][0]["confidence"] for item in results] == [0.99, 0.98]
+
+
+def test_classify_yolo_falls_back_to_general_translation_without_category_model():
+    service = _bare_service({})
+    general = MagicMock()
+    general.names = {0: "animal", 1: "scenery"}
+    general.return_value = [np.array([0.9, 0.1]), np.array([0.1, 0.9])]
+
+    with patch.object(module, "ai_model_manager") as ai_manager, \
+         patch.object(module, "model_manager") as model_manager:
+        ai_manager.is_ready.return_value = True
+        model_manager.get_model.return_value = general
+        results = service.classify_yolo([_png_base64(), _png_base64()])
+
+    assert [item["predictions"][0]["label"] for item in results] == ["\u52a8\u7269", "\u98ce\u666f"]
+    assert [item["predictions"][0]["confidence"] for item in results] == [0.9, 0.9]

--- a/package/server/tests/unit/test_agent_service_stream_filter.py
+++ b/package/server/tests/unit/test_agent_service_stream_filter.py
@@ -1,0 +1,47 @@
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+import pytest
+
+from app.service.agent.service import ThinkTagStreamFilter, _messages_to_text
+
+pytestmark = [pytest.mark.smoke]
+
+
+def test_think_stream_filter_splits_cross_chunk_tags():
+    stream_filter = ThinkTagStreamFilter()
+
+    visible, reasoning = stream_filter.feed("Hello <th")
+    assert visible == "Hello "
+    assert reasoning == ""
+
+    visible, reasoning = stream_filter.feed("ink>hidden</think>")
+    assert visible == ""
+    assert reasoning == "hidden"
+
+    visible, reasoning = stream_filter.feed("World")
+    assert visible == "World"
+    assert reasoning == ""
+
+
+def test_think_stream_filter_flush_drops_unclosed_reasoning():
+    stream_filter = ThinkTagStreamFilter()
+    stream_filter.feed("Visible <think>unfinished")
+
+    assert stream_filter.flush() == ("", "")
+    assert stream_filter.buffer == ""
+
+
+def test_messages_to_text_uses_readable_roles_and_ignores_system():
+    messages = [
+        SystemMessage(content="system prompt"),
+        HumanMessage(content="查找九月的照片"),
+        AIMessage(content="找到 3 张照片"),
+        AIMessage(content=[{"type": "text", "text": "结构化回复"}]),
+    ]
+
+    text = _messages_to_text(messages)
+
+    assert "用户：查找九月的照片" in text
+    assert "助手：找到 3 张照片" in text
+    assert "结构化回复" in text
+    assert "system prompt" not in text

--- a/package/server/tests/unit/test_agent_tools_registry.py
+++ b/package/server/tests/unit/test_agent_tools_registry.py
@@ -1,0 +1,20 @@
+import pytest
+
+from app.service.agent.tools import get_agent_tools
+
+pytestmark = [pytest.mark.smoke]
+
+
+def test_agent_tool_registry_contains_core_tools():
+    tools = get_agent_tools("unit-user", "unit-session")
+    names = {tool.name for tool in tools}
+
+    assert len(tools) == 23
+    assert len(names) == len(tools)
+    assert {
+        "search_photos_tool",
+        "search_photos_v2",
+        "get_trip_tickets",
+        "create_artifact_draft",
+        "propose_album_organization",
+    }.issubset(names)

--- a/package/server/tests/unit/test_ai_artifact_crud.py
+++ b/package/server/tests/unit/test_ai_artifact_crud.py
@@ -1,0 +1,99 @@
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.crud import ai_artifact
+from app.db.base import Base
+from app.db.models.ai_artifact import AIArtifact
+from app.db.models.user import User
+from app.schemas.ai_artifact import AIArtifactUpdate
+
+pytestmark = [pytest.mark.smoke]
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _user(db, name: str):
+    user = User(id=uuid4(), username=name, hashed_password="x")
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _artifact(user_id, title: str, updated_at: datetime):
+    return AIArtifact(
+        user_id=user_id,
+        artifact_type="travel_story",
+        title=title,
+        content_json={"summary": "旅行摘要"},
+        html_content=None,
+        html_config={"style_name": "editorial"},
+        source_photo_ids=[],
+        source_ticket_ids=[],
+        status="draft",
+        version=1,
+        updated_at=updated_at,
+    )
+
+
+def test_get_owned_is_user_scoped(db):
+    owner, stranger = _user(db, "artifact-owner"), _user(db, "artifact-stranger")
+    artifact = _artifact(owner.id, "西安秋日", datetime(2026, 9, 5, 8, 0, 0))
+    db.add(artifact)
+    db.commit()
+
+    assert ai_artifact.get_owned(db, artifact.id, owner.id).id == artifact.id
+    assert ai_artifact.get_owned(db, artifact.id, stranger.id) is None
+    assert ai_artifact.get_owned(db, str(artifact.id), owner.id).id == artifact.id
+
+
+def test_list_owned_orders_recent_and_paginates(db):
+    owner = _user(db, "artifact-list-owner")
+    stranger = _user(db, "artifact-list-stranger")
+    old = _artifact(owner.id, "old", datetime(2026, 9, 1, 8, 0, 0))
+    middle = _artifact(owner.id, "middle", datetime(2026, 9, 3, 8, 0, 0))
+    newest = _artifact(owner.id, "newest", datetime(2026, 9, 5, 8, 0, 0))
+    foreign = _artifact(stranger.id, "foreign", datetime(2026, 9, 6, 8, 0, 0))
+    db.add_all([old, middle, newest, foreign])
+    db.commit()
+
+    assert [item.title for item in ai_artifact.list_owned(db, owner.id)] == ["newest", "middle", "old"]
+    assert [item.title for item in ai_artifact.list_owned(db, owner.id, skip=1, limit=1)] == ["middle"]
+    assert [item.title for item in ai_artifact.list_owned(db, stranger.id)] == ["foreign"]
+
+
+def test_update_only_changes_supplied_fields_and_bumps_version(db):
+    owner = _user(db, "artifact-update-owner")
+    artifact = _artifact(owner.id, "原标题", datetime(2026, 9, 5, 8, 0, 0))
+    db.add(artifact)
+    db.commit()
+
+    updated = ai_artifact.update(
+        db,
+        artifact,
+        AIArtifactUpdate(title="新标题", html_config={"style_name": "cinematic", "server_api_access": True}),
+    )
+
+    assert updated.title == "新标题"
+    assert updated.html_config == {"style_name": "cinematic", "server_api_access": True}
+    assert updated.content_json == {"summary": "旅行摘要"}
+    assert updated.status == "draft"
+    assert updated.version == 2
+
+    published = ai_artifact.update(db, artifact, AIArtifactUpdate(status="published"))
+    assert published.title == "新标题"
+    assert published.status == "published"
+    assert published.version == 3

--- a/package/server/tests/unit/test_day_caption_helpers.py
+++ b/package/server/tests/unit/test_day_caption_helpers.py
@@ -1,0 +1,42 @@
+from datetime import date, datetime, timezone
+
+import pytest
+
+from app.service.moment.day_caption_service import (
+    _ThinkStripper,
+    _resolve_tz,
+    _strip_think_blocks,
+    day_bounds_utc,
+)
+
+pytestmark = [pytest.mark.smoke]
+
+
+def test_strip_think_blocks_removes_complete_blocks_only():
+    text = "前文<think>内部\n思考</think>后文<think>未闭合"
+
+    assert _strip_think_blocks(text) == "前文后文<think>未闭合"
+
+
+def test_resolve_tz_prefers_named_zone_and_falls_back_to_utc():
+    assert _resolve_tz("") is timezone.utc
+    assert _resolve_tz("not/a/zone") is timezone.utc
+    assert str(_resolve_tz("Asia/Shanghai")) == "Asia/Shanghai"
+
+
+def test_day_bounds_utc_returns_naive_wall_clock_range():
+    start, end = day_bounds_utc(date(2026, 9, 7), "Asia/Shanghai")
+
+    assert start == datetime(2026, 9, 7, 0, 0, 0)
+    assert end == datetime(2026, 9, 8, 0, 0, 0)
+    assert start.tzinfo is None
+    assert end.tzinfo is None
+
+
+def test_think_stripper_handles_chunked_open_and_close_tags():
+    stripper = _ThinkStripper()
+
+    assert stripper.feed("可见<th") == "可见"
+    assert stripper.feed("ink>隐藏</think>") == ""
+    assert stripper.feed("正文") == "正文"
+    assert stripper.flush() == ""

--- a/package/server/tests/unit/test_logger_json_rotation.py
+++ b/package/server/tests/unit/test_logger_json_rotation.py
@@ -1,0 +1,71 @@
+import json
+import logging
+import os
+import time
+from datetime import datetime
+
+import pytest
+
+from app.core.logger import DailySizeRotatingFileHandler, JSONFormatter
+
+pytestmark = [pytest.mark.smoke]
+
+
+def _record(message="hello %s", *args):
+    return logging.LogRecord(
+        name="app",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=args,
+        exc_info=None,
+        func="test",
+    )
+
+
+def test_json_formatter_outputs_operation_context():
+    record = _record("hello %s", "world")
+    setattr(record, "operation", "unit-test")
+    setattr(record, "params", {"key": "value"})
+    setattr(record, "result", "ok")
+
+    payload = json.loads(JSONFormatter().format(record))
+
+    assert payload["level"] == "INFO"
+    assert payload["message"] == "hello world"
+    assert payload["operation"] == "unit-test"
+    assert payload["params"] == {"key": "value"}
+    assert payload["result"] == "ok"
+    assert "timestamp" in payload
+
+
+def test_daily_rotating_handler_uses_dated_filename_and_cleans_old_logs(tmp_path):
+    handler = DailySizeRotatingFileHandler(
+        filename="unit-app",
+        log_dir=str(tmp_path),
+        maxBytes=128,
+        backupCount=2,
+    )
+    try:
+        expected_name = f"unit-app-{datetime.now().date():%Y-%m-%d}.log"
+        assert (tmp_path / expected_name).exists()
+
+        old_files = [
+            tmp_path / "unit-app-2000-01-01.log",
+            tmp_path / "unit-app-2000-01-02.log",
+            tmp_path / "unit-app-2000-01-03.log",
+        ]
+        for index, path in enumerate(old_files):
+            path.write_text("old", encoding="utf-8")
+            stamp = time.mktime((2000, 1, index + 1, 0, 0, 0, 0, 0, -1))
+            os.utime(path, (stamp, stamp))
+
+        handler._cleanup_logs()
+
+        assert not old_files[0].exists()
+        assert not old_files[1].exists()
+        assert old_files[2].exists()
+        assert (tmp_path / expected_name).exists()
+    finally:
+        handler.close()

--- a/package/server/tests/unit/test_nightly_agent_crud_edges_20260907.py
+++ b/package/server/tests/unit/test_nightly_agent_crud_edges_20260907.py
@@ -1,0 +1,59 @@
+"""Nightly gap coverage for agent session summary and message bookkeeping."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.crud import agent as agent_crud
+
+SESSION_ID = '12345678-1234-5678-1234-567812345678'
+
+pytestmark = pytest.mark.smoke
+
+
+def _db_with_first(first):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = first
+    return db
+
+
+def test_context_summary_returns_none_when_session_is_missing():
+    assert agent_crud.get_context_summary(_db_with_first(None), SESSION_ID) is None
+
+
+def test_update_context_summary_does_not_create_missing_session():
+    db = _db_with_first(None)
+
+    assert agent_crud.update_context_summary(db, SESSION_ID, "summary") is None
+    db.add.assert_not_called()
+    db.commit.assert_not_called()
+
+
+def test_update_context_summary_refreshes_existing_session():
+    session = SimpleNamespace(context_summary="old", summary_update_time=None)
+    db = _db_with_first(session)
+
+    result = agent_crud.update_context_summary(db, SESSION_ID, "new summary")
+
+    assert result is session
+    assert session.context_summary == "new summary"
+    assert session.summary_update_time is not None
+    db.add.assert_called_once_with(session)
+    db.commit.assert_called_once()
+
+
+def test_create_message_touches_session_summary_time():
+    session = SimpleNamespace(summary_update_time=None)
+    db = _db_with_first(session)
+    payload = MagicMock()
+    payload.session_id = SESSION_ID
+    payload.model_dump.return_value = {"session_id": SESSION_ID, "role": "user", "content": "hi"}
+
+    created = agent_crud.create_message(db, payload)
+
+    assert created is not None
+    assert session.summary_update_time is not None
+    db.add.assert_any_call(created)
+    db.add.assert_called_with(session)
+    db.commit.assert_called_once()

--- a/package/server/tests/unit/test_nightly_album_folder_counts_20260907.py
+++ b/package/server/tests/unit/test_nightly_album_folder_counts_20260907.py
@@ -1,0 +1,68 @@
+"""Nightly gap coverage for album folder filtering and bulk recount logic."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+
+from app.crud import album as album_crud
+
+pytestmark = pytest.mark.smoke
+
+
+def test_folder_condition_ignores_empty_and_non_string_values():
+    assert album_crud._build_folder_condition(None) is None
+    assert album_crud._build_folder_condition([]) is None
+    assert album_crud._build_folder_condition([None, 123, "   ", "/"]) is None
+
+
+def test_folder_condition_normalizes_paths_and_escapes_sql_wildcards():
+    condition = album_crud._build_folder_condition(
+        ["Photos\\Trips 2026", "Photos/Trips 2026", "Photos/100%_old"]
+    )
+    assert condition is not None
+
+    sqlite = create_engine("sqlite://")
+    sql = str(condition.compile(sqlite, compile_kwargs={"literal_binds": True}))
+    assert "replace" in sql.lower()
+    assert "like" in sql.lower()
+    # LIKE wildcards supplied by users must be escaped.
+    assert "100\\%\\_old" in sql
+
+
+def test_update_album_photo_counts_deduplicates_and_recounts_once():
+    db = object.__new__(object)
+    albums = [
+        SimpleNamespace(id="album-1", num_photos=0),
+        SimpleNamespace(id="album-2", num_photos=0),
+    ]
+    query = SimpleNamespace(all=lambda: albums)
+    db = SimpleNamespace(
+        query=lambda *_args, **_kwargs: SimpleNamespace(
+            filter=lambda *_args, **_kwargs: query
+        ),
+        add=lambda item: None,
+        commit=lambda: None,
+    )
+
+    with patch.object(album_crud, "_build_album_query", side_effect=lambda _db, album: SimpleNamespace(count=lambda: 3)) as build_query:
+        count = album_crud.update_album_photo_counts(db, ["album-2", "album-1", "album-2"])
+
+    assert count == 2
+    assert build_query.call_count == 2
+    assert all(album.num_photos == 3 for album in albums)
+
+
+def test_update_album_photo_counts_returns_zero_for_empty_or_unknown_ids():
+    db = SimpleNamespace(
+        query=lambda *_args, **_kwargs: SimpleNamespace(
+            filter=lambda *_args, **_kwargs: SimpleNamespace(all=lambda: [])
+        ),
+        add=lambda item: None,
+        commit=lambda: None,
+    )
+
+    assert album_crud.update_album_photo_counts(db, []) == 0
+    assert album_crud.update_album_photo_counts(db, None) == 0
+    assert album_crud.update_album_photo_counts(db, ["missing"]) == 0

--- a/package/server/tests/unit/test_nightly_app_update_cache_20260907.py
+++ b/package/server/tests/unit/test_nightly_app_update_cache_20260907.py
@@ -1,0 +1,62 @@
+"""Nightly gap coverage for App APK cache validation and fallback lookup."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from app.service import app_update
+
+pytestmark = pytest.mark.smoke
+
+
+def _async_return(value):
+    async def callback(*_args, **_kwargs):
+        return value
+    return callback
+
+
+def test_cache_release_apk_rejects_invalid_version_or_url():
+    async def run(version, asset):
+        return await app_update.cache_release_apk(version, asset)
+
+    assert asyncio.run(run("", {"download_url": "https://example.com/a.apk"})) is None
+    assert asyncio.run(run("1.2.3", {"download_url": "http://example.com/a.apk"})) is None
+    assert asyncio.run(run("1.2.3", {})) is None
+
+
+def test_cache_release_apk_reuses_matching_cached_file():
+    cached = r"C:\TrailSnap\app_updates\TrailSnap-1.2.3.apk"
+    asset = {"download_url": "https://example.com/TrailSnap-1.2.3.apk", "size": 123}
+
+    with patch.object(app_update, "cached_apk_path", return_value=cached), \
+         patch.object(app_update.os.path, "getsize", return_value=123):
+        result = asyncio.run(app_update.cache_release_apk("1.2.3", asset))
+
+    assert result == cached
+
+
+def test_ensure_cached_apk_uses_existing_cache_without_release_lookup():
+    cached = "/cache/TrailSnap-1.2.3.apk"
+    with patch.object(app_update, "cached_apk_path", return_value=cached), \
+         patch.object(app_update, "fetch_release_apk", side_effect=AssertionError("must not fetch")):
+        assert asyncio.run(app_update.ensure_cached_apk("1.2.3")) == cached
+
+
+def test_ensure_cached_apk_falls_back_to_ci_asset_when_release_lookup_fails():
+    expected = "/cache/TrailSnap-1.2.3.apk"
+    captured = {}
+
+    async def fake_cache(version, asset):
+        captured["version"] = version
+        captured["asset"] = asset
+        return expected
+
+    with patch.object(app_update, "cached_apk_path", return_value=None), \
+         patch.object(app_update, "fetch_release_apk", side_effect=_async_return(None)), \
+         patch.object(app_update, "cache_release_apk", side_effect=fake_cache):
+        result = asyncio.run(app_update.ensure_cached_apk("1.2.3", repo="LC044/TrailSnap"))
+
+    assert result == expected
+    assert captured["version"] == "1.2.3"
+    assert captured["asset"]["download_url"].startswith("https://github.com/LC044/TrailSnap/releases/download/v1.2.3/")

--- a/package/server/tests/unit/test_nightly_db_session_sqlite_20260907.py
+++ b/package/server/tests/unit/test_nightly_db_session_sqlite_20260907.py
@@ -9,8 +9,6 @@ pytestmark = pytest.mark.smoke
 
 
 def test_sqlite_engine_enables_wal_and_large_pool(monkeypatch, tmp_path):
-    from app.db import session as session_module
-
     original_ts = os.environ.get("TS_DB_URL")
     original_db = os.environ.get("DB_URL")
     database = tmp_path / "trailsnap.sqlite"
@@ -18,6 +16,7 @@ def test_sqlite_engine_enables_wal_and_large_pool(monkeypatch, tmp_path):
     monkeypatch.delenv("DB_URL", raising=False)
 
     try:
+        session_module = importlib.import_module("app.db.session")
         reloaded = importlib.reload(session_module)
         assert reloaded.IS_SQLITE is True
         assert reloaded.engine.url.database == database.as_posix()
@@ -29,12 +28,13 @@ def test_sqlite_engine_enables_wal_and_large_pool(monkeypatch, tmp_path):
             assert connection.exec_driver_sql("PRAGMA journal_mode").scalar() == "wal"
             assert connection.exec_driver_sql("PRAGMA busy_timeout").scalar() == 30000
     finally:
-        if original_ts is None:
+        if not original_ts:
             os.environ.pop("TS_DB_URL", None)
         else:
             os.environ["TS_DB_URL"] = original_ts
-        if original_db is None:
+        if not original_db:
             os.environ.pop("DB_URL", None)
         else:
             os.environ["DB_URL"] = original_db
-        importlib.reload(session_module)
+        if original_ts or original_db:
+            importlib.reload(session_module)

--- a/package/server/tests/unit/test_nightly_db_session_sqlite_20260907.py
+++ b/package/server/tests/unit/test_nightly_db_session_sqlite_20260907.py
@@ -1,0 +1,40 @@
+"""Nightly gap coverage for the desktop SQLite engine configuration."""
+
+import importlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def test_sqlite_engine_enables_wal_and_large_pool(monkeypatch, tmp_path):
+    from app.db import session as session_module
+
+    original_ts = os.environ.get("TS_DB_URL")
+    original_db = os.environ.get("DB_URL")
+    database = tmp_path / "trailsnap.sqlite"
+    monkeypatch.setenv("TS_DB_URL", f"sqlite:///{database.as_posix()}")
+    monkeypatch.delenv("DB_URL", raising=False)
+
+    try:
+        reloaded = importlib.reload(session_module)
+        assert reloaded.IS_SQLITE is True
+        assert reloaded.engine.url.database == database.as_posix()
+        assert reloaded.engine.pool.size() == 20
+        assert reloaded.engine.pool._max_overflow == 40
+
+        with reloaded.engine.connect() as connection:
+            assert connection.exec_driver_sql("PRAGMA foreign_keys").scalar() == 1
+            assert connection.exec_driver_sql("PRAGMA journal_mode").scalar() == "wal"
+            assert connection.exec_driver_sql("PRAGMA busy_timeout").scalar() == 30000
+    finally:
+        if original_ts is None:
+            os.environ.pop("TS_DB_URL", None)
+        else:
+            os.environ["TS_DB_URL"] = original_ts
+        if original_db is None:
+            os.environ.pop("DB_URL", None)
+        else:
+            os.environ["DB_URL"] = original_db
+        importlib.reload(session_module)

--- a/package/server/tests/unit/test_nightly_system_map_proxy_20260907.py
+++ b/package/server/tests/unit/test_nightly_system_map_proxy_20260907.py
@@ -1,0 +1,49 @@
+"""Nightly gap coverage for the Tianditu reverse proxy guard and failure path."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import aiohttp
+import pytest
+from fastapi import HTTPException, Request
+
+from app.api import system as system_api
+
+pytestmark = pytest.mark.smoke
+
+
+def _request(headers=None):
+    return Request({
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("localhost", 8000),
+        "path": "/api/system/map-proxy/api.tianditu.gov.cn/icon.png",
+        "query_string": b"tk=test",
+        "headers": headers or [(b"host", b"localhost:8000")],
+    })
+
+
+def test_public_origin_falls_back_to_request_scheme_and_host():
+    assert system_api._public_request_origin(_request()) == "http://localhost:8000"
+
+
+def test_map_proxy_rejects_hosts_outside_tianditu_allowlist():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(system_api.proxy_tianditu_resource("evil.example.com", "icon.png", _request()))
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Unsupported map host"
+
+
+def test_map_proxy_maps_upstream_client_error_to_502():
+    request = _request([
+        (b"host", b"photos.example.com"),
+        (b"x-forwarded-proto", b"https,http"),
+    ])
+    with patch.object(system_api.aiohttp, "ClientSession", MagicMock(side_effect=aiohttp.ClientError("network down"))):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(system_api.proxy_tianditu_resource("api.tianditu.gov.cn", "icon.png", request))
+
+    assert exc.value.status_code == 502
+    assert exc.value.detail == "Map service is unavailable"

--- a/package/server/tests/unit/test_task_worker_chunk_size.py
+++ b/package/server/tests/unit/test_task_worker_chunk_size.py
@@ -1,0 +1,29 @@
+import pytest
+
+from app.db.models.task import TaskType
+from app.service import task_worker
+
+pytestmark = [pytest.mark.smoke]
+
+
+def test_high_concurrency_chunk_sizes(monkeypatch):
+    monkeypatch.setattr(task_worker, "resolve_concurrency_level", lambda _level: "high")
+
+    assert task_worker.get_chunk_size(TaskType.VISUAL_DESCRIPTION) == 1
+    assert task_worker.get_chunk_size(TaskType.OCR) == 2
+    assert task_worker.get_chunk_size(TaskType.RECOGNIZE_TICKET) == 2
+    assert task_worker.get_chunk_size(TaskType.RECOGNIZE_FACE) == 4
+    assert task_worker.get_chunk_size(TaskType.PROCESS_BASIC) == 16
+    assert task_worker.get_chunk_size(TaskType.EXTRACT_METADATA) == 16
+    assert task_worker.get_chunk_size(TaskType.CLASSIFY_IMAGE) == 8
+    assert task_worker.get_chunk_size(TaskType.IMAGE_EMBEDDING) == 8
+
+
+def test_low_concurrency_chunk_sizes(monkeypatch):
+    monkeypatch.setattr(task_worker, "resolve_concurrency_level", lambda _level: "low")
+
+    assert task_worker.get_chunk_size(TaskType.PROCESS_BASIC) == 16
+    assert task_worker.get_chunk_size(TaskType.OCR) == 1
+    assert task_worker.get_chunk_size(TaskType.RECOGNIZE_FACE) == 2
+    assert task_worker.get_chunk_size(TaskType.CLUSTER_FACES) == 1
+    assert task_worker.get_chunk_size(TaskType.IMAGE_EMBEDDING) == 8

--- a/package/website/tests/e2e/specs/recycle-bin/recycle-bin-bulk-cleanup.spec.ts
+++ b/package/website/tests/e2e/specs/recycle-bin/recycle-bin-bulk-cleanup.spec.ts
@@ -201,7 +201,8 @@ test.describe('P1 - 回收站清理优化 @recycle-bin', () => {
     const moreBtn = page.getByRole('button', { name: /加载更多/ });
     await expect(moreBtn).toBeVisible({ timeout: 10_000 });
 
-    await moreBtn.click();
+    // Virtualized list re-renders can detach this button between pointer actionability checks.
+    await moreBtn.dispatchEvent('click');
     // 第二页返回 5 条(<200) => hasMore=false => 按钮消失
     await expect(moreBtn).toBeHidden({ timeout: 10_000 });
     await expect(page.getByText(/已加载 205/)).toBeVisible();

--- a/package/website/tests/e2e/specs/views-coverage/agent-action-history-coverage.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/agent-action-history-coverage.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type Route } from '@playwright/test'
+
+import { ensureAuthSession } from '../../helpers/auth'
+
+const proposedPlan = {
+  id: '11111111-1111-4111-8111-111111111111',
+  plan_type: 'organize_album',
+  title: '整理武汉旅行照片',
+  summary: '把武汉美食和夜景照片放进同一个相册。',
+  status: 'proposed',
+  attempt_count: 1,
+  error_message: null,
+  preview: {
+    mode: 'create',
+    album_name: '武汉旅行',
+    photo_count: 3,
+    tags: ['美食', '夜景'],
+    sample_photos: [],
+    notice: '不会修改原文件',
+    artifact_id: null,
+  },
+  result: {},
+  created_at: '2026-09-07T08:00:00Z',
+  updated_at: '2026-09-07T08:00:00Z',
+}
+
+const executedPlan = {
+  ...proposedPlan,
+  id: '22222222-2222-4222-8222-222222222222',
+  title: '整理西安旅行照片',
+  summary: '把城墙和博物馆照片放进西安相册。',
+  status: 'executed',
+  preview: { ...proposedPlan.preview, mode: 'update', photo_count: 5, tags: [] },
+  result: {
+    album_url: '/album/1',
+    artifact_url: '/agent/artifacts/33333333-3333-4333-8333-333333333333',
+  },
+  created_at: '2026-09-06T08:00:00Z',
+}
+
+function respond(route: Route, data: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ code: 0, message: 'success', data }),
+  })
+}
+
+test.describe('P1 - ActionHistory / AgentActionPlanCard @views-coverage', () => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    if (!(await ensureAuthSession(request, page, testInfo))) return
+
+    await page.route('**/api/agent/proactive**', route => respond(route, { messages: [], unread: 0 }))
+  })
+
+  test('ActionHistory 渲染计划卡并按状态过滤', async ({ page }) => {
+    const requests: string[] = []
+    await page.route('**/api/agent/actions**', async route => {
+      const url = new URL(route.request().url())
+      if (url.pathname.endsWith('/actions')) {
+        requests.push(url.searchParams.get('status') ?? 'all')
+        return respond(route, url.searchParams.get('status') === 'executed' ? [executedPlan] : [proposedPlan, executedPlan])
+      }
+      return respond(route, url.pathname.endsWith(executedPlan.id) ? executedPlan : proposedPlan)
+    })
+
+    await page.goto('/agent/actions')
+    await expect(page.getByRole('heading', { name: '操作记录' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: '整理武汉旅行照片' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: '整理西安旅行照片' })).toBeVisible()
+    await expect(page.getByText('等待确认').first()).toBeVisible()
+    await expect(page.getByText('已执行').first()).toBeVisible()
+
+    await page.getByRole('button', { name: '已执行' }).click()
+    await expect(page.getByRole('heading', { name: '整理西安旅行照片' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: '整理武汉旅行照片' })).toHaveCount(0)
+    expect(requests).toEqual(['all', 'executed'])
+  })
+
+  test('ActionHistory 空列表渲染安全空态', async ({ page }) => {
+    await page.route('**/api/agent/actions**', async route => {
+      const url = new URL(route.request().url())
+      if (url.pathname.endsWith('/actions')) return respond(route, [])
+      return respond(route, proposedPlan)
+    })
+
+    await page.goto('/agent/actions')
+    await expect(page.getByText('暂无符合条件的 Agent 操作')).toBeVisible()
+    await expect(page.getByRole('button', { name: '刷新' })).toBeVisible()
+  })
+
+  test('AgentActionPlanCard 刷新后展示执行态操作', async ({ page }) => {
+    await page.route('**/api/agent/actions**', async route => {
+      const url = new URL(route.request().url())
+      if (url.pathname.endsWith('/actions')) return respond(route, [proposedPlan])
+      return respond(route, executedPlan)
+    })
+
+    await page.goto('/agent/actions')
+    await expect(page.getByRole('heading', { name: '整理西安旅行照片' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '打开相册' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '撤销操作' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '查看旅行日志' })).toBeVisible()
+    await expect(page.getByText('修改已撤销')).toHaveCount(0)
+  })
+
+  test('AgentActionPlanCard 确认执行后更新为已执行', async ({ page }) => {
+    await page.route('**/api/agent/actions**', async route => {
+      const url = new URL(route.request().url())
+      if (url.pathname.endsWith('/execute')) return respond(route, executedPlan)
+      if (url.pathname.endsWith('/actions')) return respond(route, [proposedPlan])
+      return respond(route, proposedPlan)
+    })
+
+    await page.goto('/agent/actions')
+    await page.getByRole('button', { name: '确认执行' }).click()
+    await page.locator('.el-message-box').getByRole('button', { name: '确认执行' }).click()
+
+    await expect(page.getByText('相册整理完成，可随时撤销')).toBeVisible()
+    await expect(page.getByRole('button', { name: '打开相册' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '撤销操作' })).toBeVisible()
+  })
+})

--- a/package/website/tests/e2e/specs/views-coverage/agent-artifact-coverage.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/agent-artifact-coverage.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test, type Route } from '@playwright/test'
+
+import { ensureAuthSession } from '../../helpers/auth'
+
+const artifactId = '33333333-3333-4333-8333-333333333333'
+
+const artifact = {
+  id: artifactId,
+  user_id: '22222222-2222-4222-8222-222222222222',
+  artifact_type: 'travel_story',
+  title: '西安秋日旅行日志',
+  content_json: {
+    summary: '三天两夜的西安旅行。',
+    sections: [
+      {
+        heading: '城墙黄昏',
+        body: '傍晚沿着城墙走过一段安静的旅程。',
+        photo_ids: ['11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222'],
+      },
+    ],
+  },
+  html_content: '<!doctype html><html><head><title>西安秋日</title></head><body><main><h1>HTML artifact works</h1></main></body></html>',
+  html_config: { style_name: 'editorial', custom_style: '夏日公路电影', server_api_access: false },
+  source_photo_ids: [],
+  source_ticket_ids: [],
+  status: 'draft',
+  version: 2,
+  created_by_session_id: null,
+  created_at: '2026-09-05T08:00:00Z',
+  updated_at: '2026-09-05T09:00:00Z',
+}
+
+function respond(route: Route, data: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ code: 0, message: 'success', data }),
+  })
+}
+
+test.describe('P1 - Agent ArtifactDetail / HtmlArtifactPreview @views-coverage', () => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
+    if (!(await ensureAuthSession(request, page, testInfo))) return
+
+    await page.route('**/api/agent/proactive**', route => respond(route, { messages: [], unread: 0 }))
+    await page.route('**/api/agent/artifacts/**', route => respond(route, artifact))
+  })
+
+  test('结构化草稿渲染并打开个性化页面设计器', async ({ page }) => {
+    await page.goto(`/agent/artifacts/${artifactId}`)
+
+    await expect(page.getByRole('heading', { name: '西安秋日旅行日志' })).toBeVisible()
+    await expect(page.getByText('三天两夜的西安旅行。')).toBeVisible()
+    await expect(page.getByRole('heading', { name: '城墙黄昏' })).toBeVisible()
+    await expect(page.getByAltText('旅行照片')).toHaveCount(2)
+
+    await page.getByRole('button', { name: '重新设计' }).click()
+    await expect(page.getByRole('heading', { name: '让 Agent 设计这篇旅行日志' })).toBeVisible()
+    await expect(page.getByRole('combobox')).toHaveValue('editorial')
+    await expect(page.getByText('允许页面只读访问 Server API')).toBeVisible()
+    await expect(page.getByRole('button', { name: '在 Agent 中生成' })).toBeVisible()
+  })
+
+  test('个性页面在沙箱 iframe 中渲染且源码可编辑', async ({ page }) => {
+    await page.goto(`/agent/artifacts/${artifactId}?view=html`)
+
+    const frame = page.frameLocator('iframe[title="西安秋日旅行日志 个性化页面"]')
+    await expect(frame.getByRole('heading', { name: 'HTML artifact works' })).toBeVisible()
+    await expect(page.locator('iframe[title="西安秋日旅行日志 个性化页面"]')).toHaveAttribute('sandbox', 'allow-scripts')
+
+    await page.getByRole('button', { name: 'HTML 源码' }).click()
+    await expect(page.locator('textarea')).toHaveValue(/HTML artifact works/)
+  })
+
+  test('没有 HTML 内容时提供空态且不显示源码入口', async ({ page }) => {
+    await page.route('**/api/agent/artifacts/**', route => respond(route, { ...artifact, html_content: null }))
+
+    await page.goto(`/agent/artifacts/${artifactId}`)
+    await expect(page.getByRole('button', { name: '生成个性页面' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'HTML 源码' })).toHaveCount(0)
+
+    await page.getByRole('button', { name: '个性页面', exact: true }).click()
+    await expect(page.getByText('还没有个性化 HTML 页面')).toBeVisible()
+  })
+
+  test('作品加载失败时提示错误且不渲染编辑工具', async ({ page }) => {
+    await page.route('**/api/agent/artifacts/**', route => route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 1, message: 'server error' }),
+    }))
+
+    await page.goto(`/agent/artifacts/${artifactId}`)
+    await expect(page.getByText('旅行日志加载失败')).toBeVisible()
+    await expect(page.getByRole('button', { name: '编辑内容' })).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary
Closes #192

### Commit 1 — bc65bf83
- Add 3 backend unit tests for `crud/ai_artifact.py` owner scoping, list ordering/pagination, partial updates, and version increments.
- Add 4 frontend E2E tests for `ArtifactDetail.vue` and `HtmlArtifactPreview.vue`, covering structured drafts, designer, sandboxed HTML preview/source, empty state, and load failure.
- Stabilize the recycle-bin “load more” test by dispatching the click event after virtualized-list re-renders detached the button during pointer actionability checks.

### Commit 2 — 6f889cdd
- Add 12 backend unit tests across 5 coverage-gap modules:
  - `service/agent/service.py` — `<think>` stream splitting, flush behavior, and message-to-text conversion.
  - `service/agent/tools.py` — tool registry size, uniqueness, and core tool names.
  - `service/moment/day_caption_service.py` — think-block stripping, timezone resolution, naive day bounds, and chunked stream stripping.
  - `core/logger.py` — JSON log formatting and dated rotating-file cleanup.
  - `service/task_worker.py` — chunk sizes for high/low concurrency and task-type priorities.

## Test plan
- [x] `uv run python -m pytest tests/unit/test_agent_service_stream_filter.py tests/unit/test_agent_tools_registry.py tests/unit/test_day_caption_helpers.py tests/unit/test_logger_json_rotation.py tests/unit/test_task_worker_chunk_size.py -v` — 12 passed
- [x] `pwsh .\tests\scripts\run-tests.ps1 -Layer e2e -Level full` — 342 passed / 4 skipped / 0 failed
- [x] Backend unit coverage — 2413 passed / 3 skipped; total 79%
- [x] AI unit coverage — 328 passed; total 77%
- [x] Frontend view-gap scan — only 2 known false positives (`ActionHistory`, `AgentActionPlanCard`)

I have read and agree to the CLA.

Nightly watch run 2026-09-07

### Commit 3 — 3131c337
- Add 16 backend unit tests across 5 coverage-gap modules:
  - `crud/album.py` — folder conditions, SQL wildcard escaping, and bulk photo-count recount.
  - `api/system.py` — Tianditu proxy host guard, public-origin fallback, and upstream 502 mapping.
  - `crud/agent.py` — context-summary miss/update and message session bookkeeping.
  - `service/app_update.py` — APK cache validation, reuse, and CI asset fallback.
  - `db/session.py` — desktop SQLite WAL, busy timeout, and enlarged pool settings.
- Add 7 AI unit tests for `image_classification_service.py` model registration, discovery, loading/release, category batch inference, and general-model fallback.
- Add 4 frontend E2E tests for `ActionHistory.vue` and `AgentActionPlanCard.vue`, closing the last two frontend view gaps.

### Commit 3 local verification
- [x] New backend tests — 16 passed
- [x] New AI tests — 7 passed
- [x] New frontend E2E — 4 passed
- [x] Final full E2E — 343 passed / 4 skipped / 0 failed
- [x] Frontend view-gap scan — no untested views remain

Nightly watch run 2026-09-07 (round 3)


### Follow-up — 209fa1d6
- Make the SQLite session test independent of pre-existing `DB_URL` / `TS_DB_URL` environment values.
- CI after this commit: all workflows pass (unit, integration, E2E, Docker builds, desktop installers, Android APK, and AI extensions).
