### PR TITLE
feat(server): app 安装包缓存只保留最新版并增加下载重试

### DIFF
--- a/package/server/app/service/app_update.py
+++ b/package/server/app/service/app_update.py
@@ -11,6 +11,7 @@
 精确的直链与体积。安装包先下载到自部署 Server 的持久化缓存，App
 永远只拿到 Server 同源下载路径，不接触 GitHub 或对象存储。
 """
+import asyncio
 import logging
 import os
 import re
@@ -41,6 +42,10 @@ APK_FALLBACK_URL = (
 
 _VERSION_PATTERN = re.compile(r"^\d+(\.\d+)*$")
 APP_UPDATE_CACHE_DIR = os.path.join(DATA_DIR, "app_updates")
+
+# 弱网下载重试：总尝试 3 次，指数退避（2s / 4s / 8s）。
+APK_DOWNLOAD_ATTEMPTS = 3
+APK_RETRY_BASE_DELAY = 2.0
 
 
 def normalize_version(value: Optional[str]) -> str:
@@ -105,8 +110,43 @@ def cached_apk_path(version: str) -> Optional[str]:
     return path if os.path.isfile(path) and os.path.getsize(path) > 0 else None
 
 
+def prune_app_update_cache(keep_version: str) -> List[str]:
+    """删除缓存目录中除 ``keep_version`` 外的所有 APK 与残留 .part 文件。
+
+    只保留最新版安装包；``keep_version`` 为空（如清单损坏）时不动任何文件，
+    避免误删后没有可分发的包。
+    """
+    version = normalize_version(keep_version)
+    if not version:
+        return []
+    keep_name = f"TrailSnap-{version}.apk"
+    removed: List[str] = []
+    try:
+        names = os.listdir(APP_UPDATE_CACHE_DIR)
+    except OSError:
+        return []
+    for name in names:
+        if name == keep_name:
+            continue
+        if not (name.endswith(".apk") or name.endswith(".part")):
+            continue
+        path = os.path.join(APP_UPDATE_CACHE_DIR, name)
+        try:
+            if os.path.isfile(path):
+                os.remove(path)
+                removed.append(name)
+        except OSError as error:
+            logger.warning("Failed to prune cached APK %s: %s", name, error)
+    if removed:
+        logger.info("Pruned outdated APK cache: %s", ", ".join(removed))
+    return removed
+
+
 async def cache_release_apk(version: str, asset: Dict[str, Any]) -> Optional[str]:
-    """Download an APK atomically on the Server and return its local path."""
+    """Download an APK atomically on the Server and return its local path.
+
+    弱网下单次请求可能中断，按 ``APK_DOWNLOAD_ATTEMPTS`` 次数重试并指数退避。
+    """
     version = normalize_version(version)
     url = str(asset.get("download_url") or "")
     if not version or not url.startswith("https://"):
@@ -118,48 +158,65 @@ async def cache_release_apk(version: str, asset: Dict[str, Any]) -> Optional[str
 
     os.makedirs(APP_UPDATE_CACHE_DIR, exist_ok=True)
     target = os.path.join(APP_UPDATE_CACHE_DIR, f"TrailSnap-{version}.apk")
-    temporary = f"{target}.{uuid.uuid4().hex}.part"
     timeout = aiohttp.ClientTimeout(total=None, connect=15, sock_read=90)
-    try:
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(url, headers={"Accept": "application/octet-stream"}) as response:
-                if response.status != 200:
-                    logger.warning("APK predownload HTTP %s for v%s", response.status, version)
-                    return None
-                downloaded = 0
-                with open(temporary, "wb") as output:
-                    async for chunk in response.content.iter_chunked(256 * 1024):
-                        output.write(chunk)
-                        downloaded += len(chunk)
-        if downloaded <= 0 or (expected_size and downloaded != expected_size):
-            logger.warning("APK predownload size mismatch for v%s", version)
-            return None
-        os.replace(temporary, target)
-        logger.info("Cached Android App v%s (%s bytes)", version, downloaded)
-        return target
-    except Exception as error:
-        logger.warning("APK predownload failed for v%s: %s", version, error)
-        return None
-    finally:
+    for attempt in range(1, APK_DOWNLOAD_ATTEMPTS + 1):
+        temporary = f"{target}.{uuid.uuid4().hex}.part"
         try:
-            if os.path.exists(temporary):
-                os.remove(temporary)
-        except OSError:
-            pass
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url, headers={"Accept": "application/octet-stream"}) as response:
+                    if response.status != 200:
+                        logger.warning(
+                            "APK predownload HTTP %s for v%s (attempt %d/%d)",
+                            response.status, version, attempt, APK_DOWNLOAD_ATTEMPTS,
+                        )
+                    else:
+                        downloaded = 0
+                        with open(temporary, "wb") as output:
+                            async for chunk in response.content.iter_chunked(256 * 1024):
+                                output.write(chunk)
+                                downloaded += len(chunk)
+                        if downloaded > 0 and (not expected_size or downloaded == expected_size):
+                            os.replace(temporary, target)
+                            logger.info("Cached Android App v%s (%s bytes)", version, downloaded)
+                            return target
+                        logger.warning(
+                            "APK predownload size mismatch for v%s (attempt %d/%d)",
+                            version, attempt, APK_DOWNLOAD_ATTEMPTS,
+                        )
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            logger.warning(
+                "APK predownload failed for v%s (attempt %d/%d): %s",
+                version, attempt, APK_DOWNLOAD_ATTEMPTS, error,
+            )
+        finally:
+            try:
+                if os.path.exists(temporary):
+                    os.remove(temporary)
+            except OSError:
+                pass
+        if attempt < APK_DOWNLOAD_ATTEMPTS:
+            await asyncio.sleep(APK_RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+    return None
 
 
 async def ensure_cached_apk(version: str, repo: str = GITHUB_REPO) -> Optional[str]:
     existing = cached_apk_path(version)
-    if existing:
-        return existing
-    asset = await fetch_release_apk(version, repo=repo)
-    if asset is None:
-        asset = {
-            "download_url": APK_FALLBACK_URL.format(repo=repo, version=version),
-            "size": 0,
-            "file_name": APK_ASSET_TEMPLATE.format(version=version),
-        }
-    return await cache_release_apk(version, asset)
+    path = existing
+    if not path:
+        asset = await fetch_release_apk(version, repo=repo)
+        if asset is None:
+            asset = {
+                "download_url": APK_FALLBACK_URL.format(repo=repo, version=version),
+                "size": 0,
+                "file_name": APK_ASSET_TEMPLATE.format(version=version),
+            }
+        path = await cache_release_apk(version, asset)
+    if path:
+        # 缓存里只保留最新版，旧版本安装包及时释放磁盘。
+        prune_app_update_cache(version)
+    return path
 
 
 async def prefetch_latest_app_update(

--- a/package/server/tests/unit/test_app_update.py
+++ b/package/server/tests/unit/test_app_update.py
@@ -1,16 +1,19 @@
 """Unit tests for app/service/app_update.py（手机 App 安装包更新检查）。
 
-覆盖三条主线：
+覆盖主线：
 - ``normalize_version``：兼容 ``v0.12.1`` 并拒绝非法版本串。
 - ``fetch_release_apk``：从 GitHub Release 资产里挑 APK（正式包优先于 debug 包），
   以及 HTTP 失败 / 无 APK 资产时返回 None。
 - ``check_app_update``：无更新、有更新且拿到资产、有更新但 GitHub 不可达
   （回退 CI 命名约定且 size=0）、非法版本、不支持的平台。
+- ``prune_app_update_cache``：只保留最新版，清理旧 APK 与 .part 残留。
+- ``cache_release_apk``：弱网重试（传输中断 / HTTP 错误 / 大小不符），重试耗尽后失败。
 """
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 pytestmark = [pytest.mark.smoke, pytest.mark.module_system]
@@ -124,6 +127,213 @@ def test_fetch_release_apk_returns_none_on_http_error():
 def test_fetch_release_apk_rejects_invalid_version():
     from app.service.app_update import fetch_release_apk
     assert _run(fetch_release_apk("not-a-version")) is None
+
+
+# ---------------------------- prune_app_update_cache ---------------------------
+
+
+def test_prune_app_update_cache_keeps_only_latest(tmp_path):
+    from app.service import app_update
+
+    cache_dir = tmp_path / "app_updates"
+    cache_dir.mkdir()
+    (cache_dir / "TrailSnap-1.0.0.apk").write_bytes(b"old")
+    (cache_dir / "TrailSnap-1.0.1.apk").write_bytes(b"old")
+    (cache_dir / "TrailSnap-1.1.0.apk.abc.part").write_bytes(b"partial")
+    (cache_dir / "TrailSnap-1.2.0.apk").write_bytes(b"current")
+    (cache_dir / "unrelated.txt").write_text("keep me")
+    with patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(cache_dir)):
+        removed = app_update.prune_app_update_cache("1.2.0")
+
+    assert sorted(removed) == ["TrailSnap-1.0.0.apk", "TrailSnap-1.0.1.apk", "TrailSnap-1.1.0.apk.abc.part"]
+    remaining = sorted(p.name for p in cache_dir.iterdir())
+    assert remaining == ["TrailSnap-1.2.0.apk", "unrelated.txt"]
+
+
+def test_prune_app_update_cache_keeps_current_version(tmp_path):
+    from app.service import app_update
+
+    cache_dir = tmp_path / "app_updates"
+    cache_dir.mkdir()
+    (cache_dir / "TrailSnap-1.2.0.apk").write_bytes(b"current")
+    (cache_dir / "TrailSnap-1.0.0.apk").write_bytes(b"old")
+    with patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(cache_dir)):
+        removed = app_update.prune_app_update_cache("v1.2.0")
+
+    assert removed == ["TrailSnap-1.0.0.apk"]
+    assert [p.name for p in cache_dir.iterdir()] == ["TrailSnap-1.2.0.apk"]
+
+
+def test_prune_app_update_cache_noop_on_invalid_version(tmp_path):
+    from app.service import app_update
+
+    cache_dir = tmp_path / "app_updates"
+    cache_dir.mkdir()
+    (cache_dir / "TrailSnap-1.0.0.apk").write_bytes(b"old")
+    with patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(cache_dir)):
+        assert app_update.prune_app_update_cache("not-a-version") == []
+
+    assert [p.name for p in cache_dir.iterdir()] == ["TrailSnap-1.0.0.apk"]
+
+
+def test_prune_app_update_cache_noop_on_missing_dir(tmp_path):
+    from app.service import app_update
+
+    with patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(tmp_path / "missing")):
+        assert app_update.prune_app_update_cache("1.2.0") == []
+
+
+# ---------------------------- cache_release_apk retry ---------------------------
+
+
+class _FlakyContent:
+    """迭代器：第一次抛异常模拟传输中断，第二次返回完整数据。"""
+
+    def __init__(self, chunks, fail_first):
+        self.chunks = list(chunks)
+        self.fail_first = fail_first
+
+    async def iter_chunked(self, _size):
+        if self.fail_first:
+            self.fail_first = False
+            raise aiohttp.ClientError("connection reset")
+        for chunk in self.chunks:
+            yield chunk
+
+
+class _FlakyResponse:
+    def __init__(self, status, content):
+        self.status = status
+        self.content = content
+
+
+class _RespCtx:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, *_a):
+        return None
+
+
+class _Session:
+    def __init__(self, queue, *_a, **_k):
+        self.queue = queue
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return None
+
+    def get(self, *_a, **_k):
+        return _RespCtx(self.queue.pop(0))
+
+
+def _flaky_session_factory(responses):
+    queue = list(responses)
+    return lambda *a, **k: _Session(queue)
+
+
+def test_cache_release_apk_retries_and_succeeds(tmp_path):
+    from app.service import app_update
+
+    asset = {"download_url": "https://dl/apk", "size": 5, "file_name": "TrailSnap-1.2.0.apk"}
+    responses = [
+        _FlakyResponse(200, _FlakyContent([b"ab", b"cd", b"e"], fail_first=True)),
+        _FlakyResponse(200, _FlakyContent([b"ab", b"cd", b"e"], fail_first=False)),
+    ]
+    with (
+        patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(tmp_path)),
+        patch.object(app_update.aiohttp, "ClientSession", _flaky_session_factory(responses)),
+        patch.object(app_update.asyncio, "sleep", new_callable=AsyncMock) as sleep_mock,
+    ):
+        path = _run(app_update.cache_release_apk("1.2.0", asset))
+
+    assert path == str(tmp_path / "TrailSnap-1.2.0.apk")
+    assert (tmp_path / "TrailSnap-1.2.0.apk").read_bytes() == b"abcde"
+    assert not [p for p in tmp_path.iterdir() if p.name.endswith(".part")]
+    sleep_mock.assert_awaited_once()
+
+
+def test_cache_release_apk_retries_on_http_error(tmp_path):
+    from app.service import app_update
+
+    asset = {"download_url": "https://dl/apk", "size": 0, "file_name": "TrailSnap-1.2.0.apk"}
+    responses = [
+        _FlakyResponse(503, None),
+        _FlakyResponse(503, None),
+        _FlakyResponse(200, _FlakyContent([b"ok"], fail_first=False)),
+    ]
+    with (
+        patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(tmp_path)),
+        patch.object(app_update.aiohttp, "ClientSession", _flaky_session_factory(responses)),
+        patch.object(app_update.asyncio, "sleep", new_callable=AsyncMock),
+    ):
+        path = _run(app_update.cache_release_apk("1.2.0", asset))
+
+    assert path == str(tmp_path / "TrailSnap-1.2.0.apk")
+    assert (tmp_path / "TrailSnap-1.2.0.apk").read_bytes() == b"ok"
+
+
+def test_cache_release_apk_exhausts_retries(tmp_path):
+    from app.service import app_update
+
+    asset = {"download_url": "https://dl/apk", "size": 0, "file_name": "TrailSnap-1.2.0.apk"}
+    responses = [_FlakyResponse(503, None)] * app_update.APK_DOWNLOAD_ATTEMPTS
+    with (
+        patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(tmp_path)),
+        patch.object(app_update.aiohttp, "ClientSession", _flaky_session_factory(responses)),
+        patch.object(app_update.asyncio, "sleep", new_callable=AsyncMock) as sleep_mock,
+    ):
+        path = _run(app_update.cache_release_apk("1.2.0", asset))
+
+    assert path is None
+    assert list(tmp_path.iterdir()) == []
+    assert sleep_mock.await_count == app_update.APK_DOWNLOAD_ATTEMPTS - 1
+
+
+def test_cache_release_apk_size_mismatch_retries(tmp_path):
+    from app.service import app_update
+
+    asset = {"download_url": "https://dl/apk", "size": 10, "file_name": "TrailSnap-1.2.0.apk"}
+    responses = [
+        _FlakyResponse(200, _FlakyContent([b"short"], fail_first=False)),
+        _FlakyResponse(200, _FlakyContent([b"0123456789"], fail_first=False)),
+    ]
+    with (
+        patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(tmp_path)),
+        patch.object(app_update.aiohttp, "ClientSession", _flaky_session_factory(responses)),
+        patch.object(app_update.asyncio, "sleep", new_callable=AsyncMock),
+    ):
+        path = _run(app_update.cache_release_apk("1.2.0", asset))
+
+    assert path == str(tmp_path / "TrailSnap-1.2.0.apk")
+    assert (tmp_path / "TrailSnap-1.2.0.apk").read_bytes() == b"0123456789"
+
+
+def test_ensure_cached_apk_prunes_older_versions(tmp_path):
+    from app.service import app_update
+
+    cache_dir = tmp_path / "app_updates"
+    cache_dir.mkdir()
+    (cache_dir / "TrailSnap-1.0.0.apk").write_bytes(b"old")
+    (cache_dir / "TrailSnap-1.2.0.apk").write_bytes(b"current")
+
+    def _cached(version):
+        path = cache_dir / f"TrailSnap-{version}.apk"
+        return str(path) if path.is_file() else None
+
+    with (
+        patch.object(app_update, "APP_UPDATE_CACHE_DIR", str(cache_dir)),
+        patch.object(app_update, "cached_apk_path", side_effect=_cached),
+    ):
+        path = _run(app_update.ensure_cached_apk("1.2.0"))
+
+    assert path == str(cache_dir / "TrailSnap-1.2.0.apk")
+    assert [p.name for p in cache_dir.iterdir()] == ["TrailSnap-1.2.0.apk"]
 
 
 # ---------------------------- check_app_update ---------------------------


### PR DESCRIPTION
## Summary

Closes #198

针对 App 自动更新缓存机制的两项优化：

1. **缓存清理**：新增 `prune_app_update_cache(keep_version)`，在 `ensure_cached_apk` 确认/下载成功后自动清理缓存目录中除最新版外的所有 APK 与 `.part` 残留文件。版本串非法时（如清单损坏）跳过清理，避免误删后没有可分发的包。
2. **下载重试**：`cache_release_apk` 最多尝试 3 次（指数退避 2s/4s/8s），覆盖三类弱网失败场景——传输中断（`aiohttp.ClientError`）、HTTP 非 200、下载大小与 Release 资产不符。每次尝试使用独立临时文件，失败后清理；`asyncio.CancelledError` 直接上抛不吞掉。

## 测试

- 新增 9 个单元测试：清理逻辑 4 个（只保留最新版 / 保留当前版 / 非法版本不动 / 目录缺失不动）、重试逻辑 5 个（中断后重试成功 / HTTP 错误重试成功 / 重试耗尽返回 None / 大小不符重试成功 / ensure_cached_apk 触发清理）。
- 本地 `pytest tests/unit/test_app_update.py tests/unit/test_system_api.py` 共 41 个测试全部通过。

- [x] 单元测试覆盖新增逻辑
- [ ] e2e 不涉及（API 契约无变化）

I have read and agree to the CLA