### PR TITLE
feat(ai): 改进大模型配置与对话选择

### DIFF
--- a/package/server/app/api/agent.py
+++ b/package/server/app/api/agent.py
@@ -20,6 +20,7 @@ class ChatRequest(BaseModel):
     stream: bool = False
     connection_id: str | None = None
     model_name: str | None = None
+    reasoning_effort: str | None = None
 
 class ChatResponse(BaseModel):
     response: str
@@ -57,7 +58,8 @@ def chat_endpoint(
                     user_input=request.message,
                     db=db,
                     connection_id=request.connection_id,
-                    model_name=request.model_name
+                    model_name=request.model_name,
+                    reasoning_effort=request.reasoning_effort
                 ),
                 media_type="text/event-stream"
             )
@@ -68,7 +70,8 @@ def chat_endpoint(
                 user_input=request.message,
                 db=db,
                 connection_id=request.connection_id,
-                model_name=request.model_name
+                model_name=request.model_name,
+                reasoning_effort=request.reasoning_effort
             )
             return ChatResponse(response=reply, session_id=session_id)
     except ValueError as ve:

--- a/package/server/app/api/settings.py
+++ b/package/server/app/api/settings.py
@@ -81,36 +81,27 @@ def get_available_models(
         if not conn.enable:
             continue
         
+        # The chat UI must expose only models explicitly saved by the user.
+        # Provider discovery belongs to the connection editor and is never
+        # performed while opening a conversation.
         models = conn.model_names
-        # If no models specified and we have an api_base, try to fetch them dynamically
-        if not models and conn.api_base:
-            try:
-                base_url = conn.api_base.rstrip('/')
-                headers = {}
-                if conn.api_key:
-                    headers['Authorization'] = f"Bearer {conn.api_key}"
-                
-                resp = requests.get(f"{base_url}/models", headers=headers, timeout=5)
-                if resp.status_code == 200:
-                    data = resp.json()
-                    if 'data' in data:
-                        models = [m.get('id') for m in data['data'] if m.get('id')]
-            except Exception as e:
-                logging.error(f"Failed to fetch models from {conn.api_base}: {e}")
-                
+        model_configs = [model.model_dump() for model in getattr(conn, 'models', [])]
         connections.append({
             "id": conn.id,
             "provider": getattr(conn, "provider", "OpenAI"),
             "api_base": conn.api_base,
-            "models": models
+            "models": models,
+            "model_configs": model_configs
         })
         
     return {
         "connections": connections,
         "analysis_connection_id": ai_config.analysis_connection_id,
         "analysis_model_name": ai_config.analysis_model_name,
+        "analysis_reasoning_effort": getattr(ai_config, "analysis_reasoning_effort", "none"),
         "chat_connection_id": getattr(ai_config, "chat_connection_id", ""),
-        "chat_model_name": getattr(ai_config, "chat_model_name", "")
+        "chat_model_name": getattr(ai_config, "chat_model_name", ""),
+        "chat_reasoning_effort": getattr(ai_config, "chat_reasoning_effort", "none")
     }
 
 class VerifyConnectionRequest(BaseModel):
@@ -577,6 +568,11 @@ def update_settings(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
+    for connection in payload.get("ai", {}).get("connections", []):
+        models = connection.get("models") or []
+        model_names = connection.get("model_names") or []
+        if not models and not model_names:
+            raise HTTPException(status_code=400, detail="每个大模型连接必须至少添加一个模型")
     # Use config_manager to update settings and cache
     new_config = config_manager.update_user_config(current_user.id, payload, db)
 

--- a/package/server/app/core/config_manager.py
+++ b/package/server/app/core/config_manager.py
@@ -153,20 +153,33 @@ DEFAULT_MOMENT_DAY_CAPTION_PROMPT = """你是一位帮用户写朋友圈文案�
 3. 输出末尾不要有空行、不要有 emoji（除非素材里明显有需要呼应 emoji 的元素，
    且最多 1 个；一般情况下不出现 emoji）。"""
 
+class LLMModelConfig(BaseModel):
+    model_name: str = Field(description="Model name sent to the upstream API")
+    display_name: str = Field(default="", description="Optional model name shown in the UI")
+    context_window: int = Field(default=128000, ge=1024, description="Model context window in tokens")
+    reasoning_levels: List[str] = Field(
+        default_factory=lambda: ["none", "low", "medium", "high"],
+        description="Reasoning efforts supported by this model",
+    )
+
+
 class LLMConnection(BaseModel):
     id: str = Field(default="", description="Connection ID")
     provider: str = Field(default="OpenAI", description="API Provider (e.g. OpenAI, Ollama, Google)")
     api_base: str = Field(default="", description="LLM API base URL")
     api_key: str = Field(default="", description="LLM API key")
     model_names: List[str] = Field(default_factory=list, description="Available model names")
+    models: List[LLMModelConfig] = Field(default_factory=list, description="Model capabilities and display metadata")
     enable: bool = Field(default=True, description="Whether this connection is enabled")
 
 class AISettings(BaseModel):
     connections: List[LLMConnection] = Field(default_factory=list, description="LLM Connections")
     analysis_connection_id: str = Field(default="builtin", description="Default connection ID for analysis")
     analysis_model_name: str = Field(default="MiniCPM-V-4_6-Q4_K_M", description="Default model name for analysis")
+    analysis_reasoning_effort: str = Field(default="none", description="Default reasoning effort for analysis")
     chat_connection_id: str = Field(default="builtin", description="Default connection ID for agent chat")
     chat_model_name: str = Field(default="MiniCPM-V-4_6-Q4_K_M", description="Default model name for agent chat")
+    chat_reasoning_effort: str = Field(default="none", description="Default reasoning effort for agent chat")
     ai_api_url: str = Field(default=os.getenv("TS_AI_API_URL") or os.getenv("AI_API_URL", "http://localhost:8001"), description="AI Service API URL")
     face_recognition_threshold: float = Field(default=0.7, description="Face recognition confidence threshold")
     face_cluster_threshold: float = Field(default=0.4, description="Face cluster distance threshold")
@@ -374,6 +387,25 @@ class ConfigManager:
         
         builtin_exists = False
         for conn in connections:
+            # Upgrade legacy string-only model lists without invalidating an
+            # existing user configuration. Keep model_names for older clients.
+            configured_models = conn.get('models') or []
+            configured_names = conn.get('model_names') or []
+            if not configured_models and configured_names:
+                conn['models'] = [
+                    {
+                        'model_name': name,
+                        'display_name': name,
+                        'context_window': 128000,
+                        'reasoning_levels': ['none', 'low', 'medium', 'high'],
+                    }
+                    for name in configured_names
+                ]
+            elif configured_models:
+                conn['model_names'] = [
+                    item.get('model_name') for item in configured_models
+                    if item.get('model_name')
+                ]
             if conn.get('id') == 'builtin':
                 builtin_exists = True
                 conn['api_base'] = builtin_api_base
@@ -386,6 +418,12 @@ class ConfigManager:
                 'api_base': builtin_api_base,
                 'api_key': 'empty',
                 'model_names': ['MiniCPM-V-4_6-Q4_K_M'],
+                'models': [{
+                    'model_name': 'MiniCPM-V-4_6-Q4_K_M',
+                    'display_name': 'MiniCPM-V-4_6-Q4_K_M',
+                    'context_window': 32768,
+                    'reasoning_levels': ['none'],
+                }],
                 'enable': True
             })
         ai_settings['connections'] = connections

--- a/package/server/app/service/agent/service.py
+++ b/package/server/app/service/agent/service.py
@@ -42,20 +42,50 @@ def get_session_history(db: Session, session_id: str) -> List[BaseMessage]:
 # 滑动窗口大小：传给模型的历史最多保留最近 N 条消息（不按 token 预算，仅按条数）
 MAX_HISTORY_MESSAGES = 20
 
-def trim_history_messages(messages: List[BaseMessage]) -> List[BaseMessage]:
+
+def _estimate_message_tokens(messages: List[BaseMessage]) -> int:
+    """Conservative tokenizer-independent estimate for OpenAI-compatible APIs."""
+    total = 0
+    for message in messages:
+        content = message.content if isinstance(message.content, str) else json.dumps(message.content, ensure_ascii=False)
+        total += max(1, len(content) // 3) + 8
+    return total
+
+
+def _model_context_window(ai_settings, connection_id: str = None, model_name: str = None) -> int:
+    c_id = connection_id or getattr(ai_settings, "chat_connection_id", None) or ai_settings.analysis_connection_id
+    m_name = model_name or getattr(ai_settings, "chat_model_name", None) or ai_settings.analysis_model_name
+    connection = next((c for c in ai_settings.connections if c.id == c_id), None)
+    if connection:
+        model = next((m for m in getattr(connection, "models", []) if m.model_name == m_name), None)
+        if model:
+            return model.context_window
+    return 128000
+
+def trim_history_messages(messages: List[BaseMessage], context_window: int | None = None) -> List[BaseMessage]:
     """
-    基于消息条数的滑动窗口裁剪：保留 system 提示，并只保留最近的 MAX_HISTORY_MESSAGES 条对话。
-    使用 token_counter=len 表示"按消息条数计数"，因此这是纯滑动窗口，不涉及 token 预算估算。
+    按模型上下文窗口裁剪历史并预留输出空间；旧配置没有窗口信息时，
+    回退为基于消息条数的滑动窗口。
     裁剪只影响传给模型的上下文，不影响数据库中的完整历史记录。
     """
     if not messages:
         return messages
     try:
+        if context_window:
+            # Reserve room for system/tool payloads and the completion. The
+            # configured model window therefore has a real effect on how much
+            # conversation history is submitted.
+            input_budget = max(1024, int(context_window * 0.75))
+            token_counter = _estimate_message_tokens
+            max_tokens = input_budget
+        else:
+            token_counter = len
+            max_tokens = MAX_HISTORY_MESSAGES
         trimmed = trim_messages(
             messages,
-            max_tokens=MAX_HISTORY_MESSAGES,
+            max_tokens=max_tokens,
             strategy="last",
-            token_counter=len,  # 按消息条数计数 => 滑动窗口
+            token_counter=token_counter,
             include_system=True,
             allow_partial=False,
             start_on="human",
@@ -125,7 +155,8 @@ def _get_summary_llm(user_id: str, db: Session):
 
 
 def compress_history_if_needed(
-    messages: List[BaseMessage], user_id: str, session_id: str, db: Session
+    messages: List[BaseMessage], user_id: str, session_id: str, db: Session,
+    context_window: int | None = None,
 ) -> List[BaseMessage]:
     """
     上下文压缩：当历史对话过长时，把较早的对话压成摘要，只保留最近若干条原文。
@@ -141,14 +172,18 @@ def compress_history_if_needed(
     system_msgs = [m for m in messages if isinstance(m, SystemMessage)]
     convo = [m for m in messages if not isinstance(m, SystemMessage)]
 
-    # 未达触发阈值，走原有滑动窗口
-    if len(convo) <= COMPRESSION_TRIGGER:
+    # Prefer the configured token window. The message-count threshold remains
+    # as a compatibility fallback for connections without model metadata.
+    if context_window:
+        if _estimate_message_tokens(messages) <= max(1024, int(context_window * 0.75)):
+            return messages
+    elif len(convo) <= COMPRESSION_TRIGGER:
         return trim_history_messages(messages)
 
     try:
         llm = _get_summary_llm(user_id, db)
         if llm is None:
-            return trim_history_messages(messages)
+            return trim_history_messages(messages, context_window)
 
         recent = convo[-KEEP_RECENT_MESSAGES:]
         to_compress = convo[:-KEEP_RECENT_MESSAGES]
@@ -161,7 +196,7 @@ def compress_history_if_needed(
 
         conversation_text = _messages_to_text(to_compress)
         if not conversation_text.strip():
-            return trim_history_messages(messages)
+            return trim_history_messages(messages, context_window)
 
         resp = llm.invoke([HumanMessage(content=_SUMMARY_PROMPT.format(
             prev_summary_section=prev_summary_section,
@@ -169,7 +204,7 @@ def compress_history_if_needed(
         ))])
         summary_text = (resp.content or "").strip()
         if not summary_text:
-            return trim_history_messages(messages)
+            return trim_history_messages(messages, context_window)
 
         # 持久化摘要，供后续轮次复用
         try:
@@ -181,7 +216,7 @@ def compress_history_if_needed(
         return system_msgs + [summary_msg] + recent
     except Exception as e:
         logger.warning(f"上下文压缩失败，回退到滑动窗口：{e}")
-        return trim_history_messages(messages)
+        return trim_history_messages(messages, context_window)
 
 class FixedChatOpenAI(ChatOpenAI):
     def _convert_chunk_to_generation_chunk(self, chunk: dict,
@@ -253,7 +288,7 @@ class ThinkTagStreamFilter:
         self.buffer = ""
         return result
 
-def get_agent_executor(user_id: str, session_id: str, db: Session, connection_id: str = None, model_name: str = None, user_input: str = None):
+def get_agent_executor(user_id: str, session_id: str, db: Session, connection_id: str = None, model_name: str = None, reasoning_effort: str = None, user_input: str = None):
     """
     完全适配 langgraph==1.1.3 的 Agent 初始化
     """
@@ -261,8 +296,9 @@ def get_agent_executor(user_id: str, session_id: str, db: Session, connection_id
 
     ai_settings = user_config.ai
 
-    c_id = connection_id or ai_settings.analysis_connection_id
-    m_name = model_name or ai_settings.analysis_model_name
+    c_id = connection_id or getattr(ai_settings, "chat_connection_id", None) or ai_settings.analysis_connection_id
+    m_name = model_name or getattr(ai_settings, "chat_model_name", None) or ai_settings.analysis_model_name
+    effort = reasoning_effort or getattr(ai_settings, "chat_reasoning_effort", None) or "none"
 
     if not c_id or not m_name:
         raise ValueError("未配置智能分析模型，请在「系统设置 -> AI相关配置」中配置连接和模型。")
@@ -278,8 +314,15 @@ def get_agent_executor(user_id: str, session_id: str, db: Session, connection_id
     if not connection.api_key:
         raise ValueError(f"选中的 AI 连接未配置 API Key: {c_id}，请在「系统设置 -> AI相关配置」中检查配置")
 
-    # 初始化 LLM
-    llm = FixedChatOpenAI(
+    model_config = next((m for m in getattr(connection, "models", []) if m.model_name == m_name), None)
+    if getattr(connection, "models", []) and model_config is None:
+        raise ValueError(f"模型 {m_name} 不在连接 {c_id} 的可用模型列表中")
+    if model_config and model_config.reasoning_levels and effort not in model_config.reasoning_levels:
+        raise ValueError(f"模型 {m_name} 不支持思考等级 {effort}")
+
+    # 初始化 LLM。“不思考”通过省略 reasoning_effort 表达，兼容不认识
+    # 该 OpenAI 扩展参数的普通 Chat Completions 服务。
+    llm_options = dict(
         model=m_name,
         api_key=connection.api_key,
         base_url=connection.api_base if connection.api_base else None,
@@ -287,14 +330,10 @@ def get_agent_executor(user_id: str, session_id: str, db: Session, connection_id
         temperature=0.7,
         streaming=True,
         max_completion_tokens=8192,
-        # reasoning_effort='high',
-
-        # use_responses_api=False,
-        # reasoning={
-        #     "effort": "low",
-        #     "summary": "detailed",
-        # }
     )
+    if effort != "none":
+        llm_options["reasoning_effort"] = effort
+    llm = FixedChatOpenAI(**llm_options)
 
     # 加载工具列表
     tools = get_agent_tools(user_id, session_id=session_id)
@@ -341,11 +380,11 @@ def get_agent_executor(user_id: str, session_id: str, db: Session, connection_id
 
     return agent, system_prompt
 
-def chat_with_agent(user_id: str, session_id: str, user_input: str, db: Session, connection_id: str = None, model_name: str = None) -> str:
+def chat_with_agent(user_id: str, session_id: str, user_input: str, db: Session, connection_id: str = None, model_name: str = None, reasoning_effort: str = None) -> str:
     """
     与 Agent 对话，维护上下文历史
     """
-    agent, system_prompt = get_agent_executor(user_id, session_id, db, connection_id, model_name, user_input=user_input)
+    agent, system_prompt = get_agent_executor(user_id, session_id, db, connection_id, model_name, reasoning_effort, user_input=user_input)
     messages = get_session_history(db, session_id)
     
     # 将 system_prompt 作为第一条消息传入，如果它不在历史中
@@ -362,7 +401,9 @@ def chat_with_agent(user_id: str, session_id: str, user_input: str, db: Session,
     ))
 
     # 上下文压缩：历史过长时压成摘要 + 近期原文，否则退化为滑动窗口
-    messages = compress_history_if_needed(messages, user_id, session_id, db)
+    ai_settings = config_manager.get_user_config(user_id, db).ai
+    context_window = _model_context_window(ai_settings, connection_id, model_name)
+    messages = compress_history_if_needed(messages, user_id, session_id, db, context_window)
     
     try:
         response = agent.invoke({"messages": messages})
@@ -449,7 +490,7 @@ def generate_session_title_task(user_id: str, session_id: str, user_input: str):
         logger.error(f"Failed to generate title: {e}")
         return None
 
-async def stream_chat_with_agent(user_id: str, session_id: str, user_input: str, db: Session, connection_id: str = None, model_name: str = None):
+async def stream_chat_with_agent(user_id: str, session_id: str, user_input: str, db: Session, connection_id: str = None, model_name: str = None, reasoning_effort: str = None):
     """
     与 Agent 对话，并使用 SSE 流式返回大模型的回复
     """
@@ -466,7 +507,7 @@ async def stream_chat_with_agent(user_id: str, session_id: str, user_input: str,
     
     try:
         # 在独立的线程中执行可能会阻塞的同步代码，以避免阻塞主事件循环
-        agent, system_prompt = await asyncio.to_thread(get_agent_executor, user_id, session_id, db, connection_id, model_name, user_input)
+        agent, system_prompt = await asyncio.to_thread(get_agent_executor, user_id, session_id, db, connection_id, model_name, reasoning_effort, user_input)
         messages = await asyncio.to_thread(get_session_history, db, session_id)
 
         if not messages or not isinstance(messages[0], SystemMessage):
@@ -491,7 +532,9 @@ async def stream_chat_with_agent(user_id: str, session_id: str, user_input: str,
 
         # 上下文压缩：历史过长时压成摘要 + 近期原文（在首轮判断之后执行，避免影响标题生成逻辑）
         # 压缩内部可能调用 LLM 生成摘要，放到线程池执行，避免阻塞事件循环
-        messages = await asyncio.to_thread(compress_history_if_needed, messages, user_id, session_id, db)
+        ai_settings = config_manager.get_user_config(user_id, db).ai
+        context_window = _model_context_window(ai_settings, connection_id, model_name)
+        messages = await asyncio.to_thread(compress_history_if_needed, messages, user_id, session_id, db, context_window)
 
         # 使用 langgraph astream 模式
         async for chunk, metadata in agent.astream({"messages": messages}, stream_mode="messages"):

--- a/package/server/app/service/tasks/visual_description.py
+++ b/package/server/app/service/tasks/visual_description.py
@@ -243,9 +243,9 @@ class VisualDescriptionStrategy(BaseTaskStrategy):
             max_retries=0,
             max_completion_tokens=4096,
             extra_body={
-                "chat_template_kwargs": {"enable_thinking": False},
+                "chat_template_kwargs": {"enable_thinking": getattr(settings, "analysis_reasoning_effort", "none") != "none"},
             },
-            reasoning_effort="none",
+            reasoning_effort=getattr(settings, "analysis_reasoning_effort", "none"),
         )
         return client
 

--- a/package/server/tests/unit/test_config_manager.py
+++ b/package/server/tests/unit/test_config_manager.py
@@ -308,6 +308,48 @@ def test_merge_user_settings_strips_legacy_ai_settings():
     assert cfg.ai.analysis_model_name == "M"
 
 
+def test_merge_user_settings_upgrades_model_names_to_capability_configs():
+    cfg = config_manager.merge_user_settings({
+        "ai": {
+            "connections": [{
+                "id": "remote",
+                "provider": "OpenAI",
+                "api_base": "https://example.test/v1",
+                "api_key": "secret",
+                "model_names": ["model-a"],
+                "enable": True,
+            }]
+        }
+    })
+    remote = next(c for c in cfg.ai.connections if c.id == "remote")
+    assert remote.models[0].model_name == "model-a"
+    assert remote.models[0].context_window == 128000
+    assert remote.models[0].reasoning_levels == ["none", "low", "medium", "high"]
+
+
+def test_merge_user_settings_keeps_structured_models_and_legacy_names_in_sync():
+    cfg = config_manager.merge_user_settings({
+        "ai": {
+            "connections": [{
+                "id": "remote",
+                "models": [{
+                    "model_name": "reasoner",
+                    "display_name": "Reasoner",
+                    "context_window": 512000,
+                    "reasoning_levels": ["low", "high", "max"],
+                }],
+            }],
+            "analysis_reasoning_effort": "high",
+            "chat_reasoning_effort": "max",
+        }
+    })
+    remote = next(c for c in cfg.ai.connections if c.id == "remote")
+    assert remote.model_names == ["reasoner"]
+    assert remote.models[0].context_window == 512000
+    assert cfg.ai.analysis_reasoning_effort == "high"
+    assert cfg.ai.chat_reasoning_effort == "max"
+
+
 def test_get_default_config_returns_serializable_dict():
     """``get_default_config`` is used by the settings export endpoint; the
     dict form must round-trip through ``AppSettings`` cleanly."""

--- a/package/server/tests/unit/test_nightly_api_settings_directories_gaps_20260821.py
+++ b/package/server/tests/unit/test_nightly_api_settings_directories_gaps_20260821.py
@@ -96,7 +96,7 @@ def test_get_available_models_filters_disabled_connections():
     assert result["analysis_model_name"] == "gpt-4"
 
 
-def test_get_available_models_fetches_models_dynamically_when_empty():
+def test_get_available_models_does_not_discover_models_during_chat_loading():
     db = MagicMock()
     user = _user()
     enabled = SimpleNamespace(
@@ -116,28 +116,15 @@ def test_get_available_models_fetches_models_dynamically_when_empty():
     )
     cfg = SimpleNamespace(ai=ai)
 
-    fake_response = MagicMock()
-    fake_response.status_code = 200
-    fake_response.json.return_value = {
-        "data": [
-            {"id": "upstream-model"},
-            {"id": ""},
-            {"id": "another-model"},
-        ]
-    }
-
     with patch.object(settings_api.config_manager, "get_user_config", return_value=cfg), \
-         patch.object(settings_api.requests, "get", return_value=fake_response) as get_call:
+         patch.object(settings_api.requests, "get") as get_call:
         result = settings_api.get_available_models(db=db, current_user=user)
 
-    get_call.assert_called_once()
-    args, kwargs = get_call.call_args
-    assert args[0] == "https://api.example.com/v1/models"
-    assert kwargs["headers"]["Authorization"] == "Bearer key-123"
-    assert result["connections"][0]["models"] == ["upstream-model", "another-model"]
+    get_call.assert_not_called()
+    assert result["connections"][0]["models"] == []
 
 
-def test_get_available_models_swallows_upstream_errors():
+def test_get_available_models_does_not_contact_broken_upstream():
     db = MagicMock()
     user = _user()
     enabled = SimpleNamespace(

--- a/package/server/tests/unit/test_nightly_photo_settings_gaps_20260811.py
+++ b/package/server/tests/unit/test_nightly_photo_settings_gaps_20260811.py
@@ -25,15 +25,14 @@ def test_on_this_day_forwards_date_and_owner():
         result = photo_api.get_on_this_day_photos(month=8, day=11, year=2025, db=db, current_user=user)
     get_photos.assert_called_once_with(db, user_id=user.id, month=8, day=11, year=2025, limit=10); assert result == expected
 
-def test_available_models_fetches_remote_models():
+def test_available_models_only_returns_explicitly_saved_models():
     db = MagicMock(); user = SimpleNamespace(id="owner-4")
     conn = SimpleNamespace(id="remote", enable=True, model_names=[], api_base="https://ai.example/", api_key="secret", provider="OpenAI")
     config = SimpleNamespace(ai=SimpleNamespace(connections=[conn], analysis_connection_id="remote", analysis_model_name="vision", chat_connection_id="", chat_model_name=""))
-    response = SimpleNamespace(status_code=200, json=lambda: {"data": [{"id": "model-a"}, {"name": "ignored"}]})
-    with patch.object(settings_api.config_manager, "get_user_config", return_value=config), patch.object(settings_api.requests, "get", return_value=response) as get:
+    with patch.object(settings_api.config_manager, "get_user_config", return_value=config), patch.object(settings_api.requests, "get") as get:
         result = settings_api.get_available_models(db=db, current_user=user)
-    get.assert_called_once_with("https://ai.example/models", headers={"Authorization": "Bearer secret"}, timeout=5)
-    assert result["connections"][0]["models"] == ["model-a"]
+    get.assert_not_called()
+    assert result["connections"][0]["models"] == []
 
 def test_verify_ai_service_rejects_invalid_url():
     result = settings_api.verify_ai_service(settings_api.VerifyAIServiceRequest(api_url="localhost:8001"), current_user=SimpleNamespace(id="owner-5"))

--- a/package/server/tests/unit/test_nightly_router_gaps_20260810_round2.py
+++ b/package/server/tests/unit/test_nightly_router_gaps_20260810_round2.py
@@ -142,13 +142,14 @@ def test_available_models_returns_enabled_static_connections_only():
             "provider": "OpenAI",
             "api_base": "http://models.test/v1",
             "models": ["model-a"],
+            "model_configs": [],
         }
     ]
     assert result["chat_connection_id"] == ""
     request.assert_not_called()
 
 
-def test_available_models_fetches_dynamic_ids_with_auth_header():
+def test_available_models_does_not_fetch_unconfigured_models():
     connection = SimpleNamespace(
         id="dynamic",
         enable=True,
@@ -156,28 +157,21 @@ def test_available_models_fetches_dynamic_ids_with_auth_header():
         api_key="secret",
         model_names=[],
     )
-    response = MagicMock(status_code=200)
-    response.json.return_value = {"data": [{"id": "model-a"}, {}, {"id": "model-b"}]}
-
     with patch.object(
         settings_api.config_manager,
         "get_user_config",
         return_value=_settings_config([connection]),
-    ), patch.object(settings_api.requests, "get", return_value=response) as request:
+    ), patch.object(settings_api.requests, "get") as request:
         result = settings_api.get_available_models(
             db=MagicMock(), current_user=_user()
         )
 
-    request.assert_called_once_with(
-        "http://models.test/v1/models",
-        headers={"Authorization": "Bearer secret"},
-        timeout=5,
-    )
-    assert result["connections"][0]["models"] == ["model-a", "model-b"]
+    request.assert_not_called()
+    assert result["connections"][0]["models"] == []
     assert result["connections"][0]["provider"] == "OpenAI"
 
 
-def test_available_models_tolerates_provider_failure():
+def test_available_models_never_contacts_provider():
     connection = SimpleNamespace(
         id="offline",
         enable=True,

--- a/package/server/tests/unit/test_settings_api.py
+++ b/package/server/tests/unit/test_settings_api.py
@@ -107,6 +107,17 @@ def test_update_settings_returns_new_config():
     assert result["config"]["storage"]["photo_storage_path"] == "F:/photos"
 
 
+def test_update_settings_rejects_connection_without_models():
+    with pytest.raises(HTTPException) as exc:
+        settings_api.update_settings(
+            payload={"ai": {"connections": [{"id": "empty", "models": [], "model_names": []}]}},
+            db=MagicMock(),
+            current_user=_user(),
+        )
+    assert exc.value.status_code == 400
+    assert "至少添加一个模型" in exc.value.detail
+
+
 def test_export_settings_matches_get_settings():
     db = MagicMock()
     user = _user()

--- a/package/website/src/api/agent.ts
+++ b/package/website/src/api/agent.ts
@@ -7,6 +7,7 @@ export interface ChatRequest {
   stream?: boolean;
   connection_id?: string;
   model_name?: string;
+  reasoning_effort?: string;
 }
 
 export interface ChatResponse {

--- a/package/website/src/views/Settings.vue
+++ b/package/website/src/views/Settings.vue
@@ -135,7 +135,7 @@ const baseGroups: Array<{ label: string; items: MenuItem[] }> = [
     { key: 'basic', label: '系统设置', description: '安全、地图、扫描与任务选项', icon: SettingsIcon },
     { key: 'tasks', label: '任务管理', description: '查看和控制后台处理任务', icon: List },
     { key: 'ai-extensions', label: 'AI 扩展包', description: '安装桌面 AI 运行能力', icon: BrainCircuit, desktopOnly: true },
-    { key: 'ai-models', label: 'AI 模型管理', description: '下载和切换本地模型', icon: Database },
+    { key: 'ai-models', label: 'AI 模型管理', description: '管理大模型连接与本地模型', icon: Database },
     { key: 'performance', label: '性能测试', description: '检测存储与服务性能', icon: Activity },
   ] },
   { label: '支持', items: [

--- a/package/website/src/views/agent/AgentChat.vue
+++ b/package/website/src/views/agent/AgentChat.vue
@@ -23,9 +23,6 @@
           :is-fullscreen="isFullscreen"
           :is-selection-mode="isSelectionMode"
           :selected-count="selectedMessages.length"
-          :available-models="availableModels"
-          v-model="selectedModelValue"
-          :is-models-loading="isModelsLoading"
           @toggle-sidebar="isSidebarOpen = !isSidebarOpen"
           @toggle-fullscreen="isFullscreen = !isFullscreen"
           @close="handleClose"
@@ -72,6 +69,10 @@
         <!-- Input Area -->
         <AgentInput
           v-model="inputMessage"
+          v-model:selected-model="selectedModelValue"
+          v-model:reasoning="selectedReasoningValue"
+          :available-models="availableModels"
+          :is-models-loading="isModelsLoading"
           :is-generating="isGenerating"
           :is-selection-mode="isSelectionMode"
           @send="sendMessage"
@@ -130,23 +131,28 @@ const isFullscreen = ref(false);
 const isSidebarOpen = ref(false);
 
 // Models & Connections state
-const availableModels = ref<Array<{ conn_id: string, model: string, label: string }>>([]);
+type AvailableModel = { conn_id: string; model: string; label: string; context_window: number; reasoning_levels: string[] };
+const availableModels = ref<AvailableModel[]>([]);
 const selectedModelValue = ref('');
+const selectedReasoningValue = ref('none');
 const isModelsLoading = ref(false);
 
 const loadModels = async () => {
   isModelsLoading.value = true;
   try {
     const res = await settingsApi.getModels();
-    const list: Array<{ conn_id: string, model: string, label: string }> = [];
+    const list: AvailableModel[] = [];
     if (res && res.connections) {
       res.connections.forEach((conn: any) => {
         if (conn.models && conn.models.length > 0) {
           conn.models.forEach((m: string) => {
+            const config = conn.model_configs?.find((item: any) => item.model_name === m);
             list.push({
               conn_id: conn.id,
               model: m,
-              label: `${m} (${conn.api_base || conn.id})`
+              label: `${config?.display_name || m} (${conn.api_base || conn.id})`,
+              context_window: config?.context_window || 128000,
+              reasoning_levels: config?.reasoning_levels?.length ? config.reasoning_levels : ['none', 'low', 'medium', 'high']
             });
           });
         }
@@ -160,6 +166,7 @@ const loadModels = async () => {
     } else if (list.length > 0) {
       selectedModelValue.value = `${list[0].conn_id}|${list[0].model}`;
     }
+    selectedReasoningValue.value = res.chat_reasoning_effort || 'none';
   } catch (e) {
     console.error('Failed to load models', e);
   } finally {
@@ -712,7 +719,8 @@ const sendMessage = async () => {
         message: userText,
         session_id: currentSession.value?.id || undefined,
         connection_id: conn_id || undefined,
-        model_name: model || undefined
+        model_name: model || undefined,
+        reasoning_effort: selectedReasoningValue.value || undefined
       },
       (content) => {
         if (aiMessageIndex === -1) {

--- a/package/website/src/views/agent/components/AgentHeader.vue
+++ b/package/website/src/views/agent/components/AgentHeader.vue
@@ -9,25 +9,7 @@
       </div>
       <div class="flex min-w-0 flex-col">
         <div class="flex min-w-0 items-center gap-2">
-          <h3 class="font-semibold text-slate-800 dark:text-white text-sm m-0">TrailSnap</h3>
-          <el-select
-            :model-value="modelValue"
-            @update:model-value="(val: string) => emit('update:modelValue', val)"
-            size="small"
-            class="agent-model-select"
-            placeholder="选择模型"
-            v-if="availableModels.length > 0 || isModelsLoading"
-            :loading="isModelsLoading"
-          >
-            <el-option
-              v-for="m in availableModels"
-              :key="m.conn_id + '|' + m.model"
-              :label="m.model"
-              :value="m.conn_id + '|' + m.model"
-            >
-              <span>{{ m.label }}</span>
-            </el-option>
-          </el-select>
+          <h3 class="hidden sm:block font-semibold text-slate-800 dark:text-white text-sm m-0">TrailSnap</h3>
         </div>
         <p class="text-xs text-slate-500 dark:text-slate-400 m-0 hidden sm:block">您的智能相册管家</p>
       </div>
@@ -63,9 +45,6 @@ defineProps<{
   isFullscreen: boolean;
   isSelectionMode: boolean;
   selectedCount: number;
-  availableModels: Array<{ conn_id: string, model: string, label: string }>;
-  modelValue: string;
-  isModelsLoading: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -74,7 +53,6 @@ const emit = defineEmits<{
   (e: 'close'): void;
   (e: 'cancel-selection'): void;
   (e: 'delete-selection'): void;
-  (e: 'update:modelValue', value: string): void;
 }>();
 </script>
 
@@ -83,8 +61,4 @@ const emit = defineEmits<{
   @apply px-4 py-3 border-b border-slate-100 dark:border-slate-800 flex justify-between items-center bg-white/80 dark:bg-slate-900/80 backdrop-blur-md z-10;
 }
 
-.agent-model-select {
-  width: clamp(7rem, 22vw, 11rem);
-  flex-shrink: 0;
-}
 </style>

--- a/package/website/src/views/agent/components/AgentInput.vue
+++ b/package/website/src/views/agent/components/AgentInput.vue
@@ -12,6 +12,33 @@
           class="agent-input"
           :disabled="isSelectionMode"
         ></textarea>
+        <el-popover placement="top-start" :width="300" trigger="click">
+          <template #reference>
+            <button type="button" class="agent-model-trigger" :disabled="isModelsLoading || !availableModels.length">
+              <Bot class="h-3.5 w-3.5" />
+              <span class="max-w-32 truncate">{{ currentModel?.model || (isModelsLoading ? '加载模型…' : '未配置模型') }}</span>
+              <span class="text-slate-400">·</span>
+              <span>{{ reasoningLabel(reasoning) }}</span>
+              <ChevronDown class="h-3.5 w-3.5" />
+            </button>
+          </template>
+          <div class="space-y-4">
+            <div>
+              <p class="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">模型</p>
+              <el-select :model-value="selectedModel" class="w-full" filterable @update:model-value="selectModel">
+                <el-option v-for="model in availableModels" :key="`${model.conn_id}|${model.model}`" :label="model.label" :value="`${model.conn_id}|${model.model}`" />
+              </el-select>
+            </div>
+            <div>
+              <p class="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">思考等级</p>
+              <div class="grid grid-cols-2 gap-2">
+                <button v-for="level in reasoningLevels" :key="level" type="button" class="rounded-lg border px-3 py-2 text-left text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2" :class="level === reasoning ? 'border-primary-500 bg-primary-500/10 text-primary-600 dark:text-primary-500' : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'" @click="emit('update:reasoning', level)">
+                  {{ reasoningLabel(level) }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </el-popover>
         <button
           v-if="isGenerating"
           type="button"
@@ -36,19 +63,35 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted } from 'vue';
-import { Send, Square } from 'lucide-vue-next';
+import { Send, Square, Bot, ChevronDown } from 'lucide-vue-next';
 
 const props = defineProps<{
   modelValue: string;
   isGenerating: boolean;
   isSelectionMode: boolean;
+  selectedModel: string;
+  reasoning: string;
+  availableModels: Array<{ conn_id: string; model: string; label: string; context_window: number; reasoning_levels: string[] }>;
+  isModelsLoading: boolean;
 }>();
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void;
   (e: 'send'): void;
   (e: 'abort'): void;
+  (e: 'update:selectedModel', value: string): void;
+  (e: 'update:reasoning', value: string): void;
 }>();
+
+const currentModel = computed(() => props.availableModels.find(model => `${model.conn_id}|${model.model}` === props.selectedModel));
+const reasoningLevels = computed(() => currentModel.value?.reasoning_levels?.length ? currentModel.value.reasoning_levels : ['none']);
+const reasoningLabel = (level: string) => ({ none: '不思考', minimal: '最低', low: '低', medium: '中', high: '高', xhigh: '超高', max: '最大' }[level] || level);
+const selectModel = (value: string) => {
+  emit('update:selectedModel', value);
+  const model = props.availableModels.find(item => `${item.conn_id}|${item.model}` === value);
+  const levels = model?.reasoning_levels?.length ? model.reasoning_levels : ['none'];
+  if (!levels.includes(props.reasoning)) emit('update:reasoning', levels[0]);
+};
 
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 
@@ -115,10 +158,23 @@ onMounted(resize);
 }
 
 .agent-input {
-  @apply w-full pl-4 pr-12 py-3 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl text-sm text-slate-800 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed;
+  @apply w-full pl-4 pr-12 pt-3 pb-12 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl text-sm text-slate-800 dark:text-white placeholder:text-slate-400 focus:outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed;
   /* 自适应高度由 JS 控制，这里禁用手动拖拽并隐藏初始滚动条 */
   @apply resize-none overflow-y-auto leading-6;
   max-height: 120px;
+}
+
+.agent-input:focus {
+  border-color: var(--theme-primary);
+  box-shadow: 0 0 0 2px rgba(var(--theme-rgb), 0.35);
+}
+
+.agent-model-trigger {
+  @apply absolute bottom-2 left-2 flex max-w-[calc(100%_-_4rem)] items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-slate-600 transition-colors hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-300 dark:hover:bg-slate-700 focus-visible:outline-none;
+}
+
+.agent-model-trigger:focus-visible {
+  box-shadow: 0 0 0 2px var(--theme-primary);
 }
 
 /* 输入框可变高，按钮改为贴底对齐（原先垂直居中会在多行时飘到中间） */

--- a/package/website/src/views/settings/AIModelManagement.vue
+++ b/package/website/src/views/settings/AIModelManagement.vue
@@ -4,7 +4,7 @@
       <div class="min-w-0 flex-1">
         <h2 class="text-xl font-semibold text-gray-800 dark:text-white md:text-2xl">AI 模型管理</h2>
         <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-          已默认选择推荐方案，通常无需调整。只有设备较慢或更看重效果时才需要更换。
+          管理大模型 API 连接、对话与分析模型，以及本地 AI 扩展模型。
         </p>
       </div>
       <button
@@ -13,6 +13,8 @@
         @click="loadModels"
       >{{ loading ? '刷新中…' : '刷新状态' }}</button>
     </div>
+
+    <LLMSettings />
 
     <div v-if="errorMessage" class="rounded-xl border border-amber-200 bg-amber-50 p-5 dark:border-amber-900 dark:bg-amber-950/30">
       <p class="font-medium text-amber-800 dark:text-amber-300">暂时无法连接 AI 模型服务</p>
@@ -131,6 +133,7 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { settingsApi } from '@/api/settings'
+import LLMSettings from './LLMSettings.vue'
 
 type TaskSelection = { name: string; selected: string; pending?: string; recommended: string; available: string[] }
 

--- a/package/website/src/views/settings/BasicSettings.vue
+++ b/package/website/src/views/settings/BasicSettings.vue
@@ -282,7 +282,7 @@
     <el-collapse v-model="activeNames" class="mb-8 bg-white rounded-lg shadow-sm border border-gray-100 dark:bg-gray-800 dark:border-gray-700 overflow-hidden">
       <el-collapse-item name="ai">
         <template #title>
-           <h2 class="text-lg font-semibold dark:text-white px-6">AI 相关设置</h2>
+           <h2 class="text-lg font-semibold dark:text-white px-6">AI 服务与人脸设置</h2>
         </template>
         <div class="px-6 pb-6">
           <el-form label-position="top" class="max-w-3xl">
@@ -312,7 +312,7 @@
 
         <el-collapse v-model="aiActiveNames" class="my-4 border-none">
           <!-- LLM Connections -->
-          <el-collapse-item name="connections">
+          <el-collapse-item v-if="false" name="connections">
             <template #title>
               <div class="flex items-center w-full">
                 <span class="text-sm font-medium text-gray-600 dark:text-gray-300 mr-2">大模型连接配置 (LLM Connections)</span>
@@ -350,7 +350,7 @@
           </el-collapse-item>
 
           <!-- Analysis LLM Config -->
-          <el-collapse-item name="analysis">
+          <el-collapse-item v-if="false" name="analysis">
             <template #title>
               <div class="flex items-center w-full">
                 <span class="text-sm font-medium text-gray-600 dark:text-gray-300 mr-2">大模型智能分析配置</span>
@@ -380,6 +380,7 @@
                   filterable
                   allow-create
                   @focus="fetchModelsFromApi(aiForm.analysis_connection_id)"
+                  @change="onAnalysisModelChange"
                   :loading="fetchingModels[aiForm.analysis_connection_id]"
                 >
                   <el-option
@@ -392,6 +393,11 @@
               </div>
               <div v-if="!aiForm.analysis_model_name && aiForm.analysis_connection_id" class="text-red-500 text-xs mt-1">必须指定模型名称</div>
             </el-form-item>
+            <el-form-item label="分析思考等级">
+              <el-select v-model="aiForm.analysis_reasoning_effort" class="w-full sm:w-64" placeholder="选择思考等级">
+                <el-option v-for="level in getReasoningLevels(aiForm.analysis_connection_id, aiForm.analysis_model_name)" :key="level" :label="reasoningLabel(level)" :value="level" />
+              </el-select>
+            </el-form-item>
             
             <el-form-item label="图片分析提示词">
                 <el-input v-model="aiForm.visual_evaluation_prompt" type="textarea" :rows="4" placeholder="用于生成评分和描述的提示词" />
@@ -399,7 +405,7 @@
           </el-collapse-item>
 
           <!-- Chat LLM Config -->
-          <el-collapse-item name="chat">
+          <el-collapse-item v-if="false" name="chat">
             <template #title>
               <div class="flex items-center w-full">
                 <span class="text-sm font-medium text-gray-600 dark:text-gray-300 mr-2">AI 对话默认配置</span>
@@ -429,6 +435,7 @@
                   filterable
                   allow-create
                   @focus="fetchModelsFromApi(aiForm.chat_connection_id)"
+                  @change="onChatModelChange"
                   :loading="fetchingModels[aiForm.chat_connection_id]"
                 >
                   <el-option
@@ -440,6 +447,11 @@
                 </el-select>
               </div>
               <div v-if="!aiForm.chat_model_name && aiForm.chat_connection_id" class="text-red-500 text-xs mt-1">建议指定模型名称</div>
+            </el-form-item>
+            <el-form-item label="默认思考等级">
+              <el-select v-model="aiForm.chat_reasoning_effort" class="w-full sm:w-64" placeholder="选择思考等级">
+                <el-option v-for="level in getReasoningLevels(aiForm.chat_connection_id, aiForm.chat_model_name)" :key="level" :label="reasoningLabel(level)" :value="level" />
+              </el-select>
             </el-form-item>
 
             <el-form-item label="朋友圈文案提示词">
@@ -788,7 +800,7 @@
     </el-collapse>
 
     <!-- Edit Connection Dialog -->
-    <el-dialog v-model="editDialogVisible" title="编辑大模型连接" width="500px">
+    <el-dialog v-if="false" v-model="editDialogVisible" title="编辑大模型连接" width="min(92vw, 680px)">
       <el-form label-position="top" v-if="editingConnection">
         <el-form-item label="API 提供商">
           <el-select v-model="editingConnection.provider" placeholder="选择提供商" class="w-full" :disabled="editingConnection.id === 'builtin'">
@@ -806,17 +818,32 @@
         <el-form-item label="API Key">
           <el-input v-model="editingConnection.api_key" type="password" show-password placeholder="sk-..." :disabled="editingConnection.id === 'builtin'" />
         </el-form-item>
-        <el-form-item label="可用模型 (可选)">
-          <el-select
-            v-model="editingConnection.model_names"
-            multiple
-            filterable
-            allow-create
-            default-first-option
-            placeholder="输入模型名称后按回车，不填则可以使用该连接的所有模型"
-            class="w-full"
-          >
-          </el-select>
+        <el-form-item label="模型列表">
+          <div class="w-full space-y-3">
+            <div class="flex flex-wrap gap-2">
+              <el-button type="primary" plain :loading="fetchingConnectionModels" @click="fetchEditingConnectionModels">
+                <Download class="w-4 h-4 mr-1" />获取模型列表
+              </el-button>
+              <el-button plain @click="addEditingModel"><Plus class="w-4 h-4 mr-1" />添加模型</el-button>
+            </div>
+            <div v-if="editingConnection.models.length === 0" class="rounded border border-dashed border-gray-300 dark:border-gray-600 p-4 text-center text-xs text-gray-500 dark:text-gray-400">
+              可从服务商获取，也可以手动添加模型。
+            </div>
+            <div v-for="(model, modelIndex) in editingConnection.models" :key="modelIndex" class="rounded border border-gray-200 dark:border-gray-600 p-3 space-y-3">
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <el-input v-model="model.display_name" placeholder="菜单显示名（可选）" />
+                <el-input v-model="model.model_name" placeholder="实际请求模型" />
+              </div>
+              <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
+                <el-input-number v-model="model.context_window" :min="1024" :step="1024" controls-position="right" class="w-full sm:w-48" />
+                <span class="text-xs text-gray-500 dark:text-gray-400">上下文窗口（tokens）</span>
+                <el-button type="danger" text class="sm:ml-auto" @click="editingConnection.models.splice(modelIndex, 1)">删除</el-button>
+              </div>
+              <el-checkbox-group v-model="model.reasoning_levels" class="flex flex-wrap gap-x-3">
+                <el-checkbox v-for="level in reasoningOptions" :key="level" :label="level" :value="level">{{ reasoningLabel(level) }}</el-checkbox>
+              </el-checkbox-group>
+            </div>
+          </div>
         </el-form-item>
       </el-form>
       <template #footer>
@@ -909,12 +936,25 @@ const aiForm = ref({
     api_base: string;
     api_key: string;
     model_names: string[];
+    models: ModelConfig[];
     enable: boolean;
   }>,
   analysis_connection_id: '',
   analysis_model_name: '',
+  analysis_reasoning_effort: 'none',
   chat_connection_id: '',
-  chat_model_name: ''
+  chat_model_name: '',
+  chat_reasoning_effort: 'none'
+})
+
+type ModelConfig = { model_name: string; display_name: string; context_window: number; reasoning_levels: string[] }
+const reasoningOptions = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+const reasoningLabel = (level: string) => ({ none: '关闭', minimal: '最低', low: '低', medium: '中', high: '高', xhigh: '超高', max: '最大' }[level] || level)
+const defaultModelConfig = (name = ''): ModelConfig => ({
+  model_name: name,
+  display_name: name,
+  context_window: 128000,
+  reasoning_levels: ['none', 'low', 'medium', 'high']
 })
 
 type ConnectionTestState = { status: 'idle' | 'testing' | 'valid' | 'invalid'; message: string }
@@ -955,6 +995,7 @@ const addConnection = () => {
     api_base: '',
     api_key: '',
     model_names: [],
+    models: [],
     enable: true
   }
   aiForm.value.connections.push(newConn)
@@ -984,10 +1025,14 @@ const editDialogVisible = ref(false)
 const editingConnectionIndex = ref(-1)
 const editingConnection = ref<any>(null)
 const verifying = ref(false)
+const fetchingConnectionModels = ref(false)
 
 const editConnection = (index: number) => {
   editingConnectionIndex.value = index
   editingConnection.value = JSON.parse(JSON.stringify(aiForm.value.connections[index]))
+  editingConnection.value.models = editingConnection.value.models?.length
+    ? editingConnection.value.models
+    : (editingConnection.value.model_names || []).map((name: string) => defaultModelConfig(name))
   editDialogVisible.value = true
 }
 
@@ -1000,6 +1045,8 @@ const deleteEditingConnection = () => {
 
 const saveEditingConnection = () => {
   if (editingConnectionIndex.value >= 0) {
+    editingConnection.value.models = editingConnection.value.models.filter((model: ModelConfig) => model.model_name.trim())
+    editingConnection.value.model_names = editingConnection.value.models.map((model: ModelConfig) => model.model_name.trim())
     aiForm.value.connections[editingConnectionIndex.value] = editingConnection.value
     editDialogVisible.value = false
     // Clear the cached models so it re-fetches if they changed settings
@@ -1015,6 +1062,27 @@ const saveEditingConnection = () => {
   saveAISettings();
 }
 
+const addEditingModel = () => editingConnection.value.models.push(defaultModelConfig())
+
+const fetchEditingConnectionModels = async () => {
+  if (!editingConnection.value.api_base) {
+    ElMessage.warning('请先填写 Base URL')
+    return
+  }
+  fetchingConnectionModels.value = true
+  try {
+    const res = await settingsApi.verifyConnection(editingConnection.value.api_base, editingConnection.value.api_key || '')
+    if (!res?.success) throw new Error(res?.message || '获取失败')
+    const existing = new Map<string, ModelConfig>(editingConnection.value.models.map((model: ModelConfig) => [model.model_name, model]))
+    editingConnection.value.models = res.models.map((name: string) => existing.get(name) || defaultModelConfig(name))
+    ElMessage.success(`已获取 ${res.models.length} 个模型`)
+  } catch (e: any) {
+    ElMessage.error(`获取模型失败: ${e.message || '网络错误'}`)
+  } finally {
+    fetchingConnectionModels.value = false
+  }
+}
+
 const verifyEditingConnection = async () => {
   if (!editingConnection.value.api_base) {
     ElMessage.warning('请先填写 Base URL')
@@ -1024,6 +1092,8 @@ const verifyEditingConnection = async () => {
   try {
     const res = await settingsApi.verifyConnection(editingConnection.value.api_base, editingConnection.value.api_key || '')
     if (res && res.success) {
+      const existing = new Map<string, ModelConfig>(editingConnection.value.models.map((model: ModelConfig) => [model.model_name, model]))
+      editingConnection.value.models = res.models.map((name: string) => existing.get(name) || defaultModelConfig(name))
       ElMessage.success(`连接成功！发现 ${res.models.length} 个可用模型`)
     } else {
       ElMessage.error(`验证失败: ${res?.message || '未知错误'}`)
@@ -1086,6 +1156,29 @@ const getAvailableModels = (connId: string) => {
     return conn.model_names
   }
   return fetchedModels.value[connId] || []
+}
+
+const ensureSupportedReasoning = (connId: string, modelName: string, current: string) => {
+  const levels = getReasoningLevels(connId, modelName)
+  return levels.includes(current) ? current : levels[0]
+}
+
+const onAnalysisModelChange = () => {
+  aiForm.value.analysis_reasoning_effort = ensureSupportedReasoning(
+    aiForm.value.analysis_connection_id, aiForm.value.analysis_model_name, aiForm.value.analysis_reasoning_effort
+  )
+}
+
+const onChatModelChange = () => {
+  aiForm.value.chat_reasoning_effort = ensureSupportedReasoning(
+    aiForm.value.chat_connection_id, aiForm.value.chat_model_name, aiForm.value.chat_reasoning_effort
+  )
+}
+
+const getReasoningLevels = (connId: string, modelName: string) => {
+  const conn = aiForm.value.connections.find(c => c.id === connId)
+  const model = conn?.models?.find(m => m.model_name === modelName)
+  return model?.reasoning_levels?.length ? model.reasoning_levels : ['none', 'low', 'medium', 'high']
 }
 
 const imageForm = ref({
@@ -1446,6 +1539,8 @@ const loadData = async () => {
             analysis_model_name: settings.ai.analysis_model_name || '',
             chat_connection_id: settings.ai.chat_connection_id || '',
             chat_model_name: settings.ai.chat_model_name || '',
+            analysis_reasoning_effort: settings.ai.analysis_reasoning_effort || 'none',
+            chat_reasoning_effort: settings.ai.chat_reasoning_effort || 'none',
             visual_evaluation_prompt: settings.ai.visual_evaluation_prompt || '',
             visual_narrative_prompt: settings.ai.visual_narrative_prompt || '',
             moment_day_caption_prompt: settings.ai.moment_day_caption_prompt || ''

--- a/package/website/src/views/settings/LLMSettings.vue
+++ b/package/website/src/views/settings/LLMSettings.vue
@@ -1,0 +1,294 @@
+<template>
+  <section class="space-y-4 rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800 sm:p-5">
+    <div>
+      <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">大模型连接与任务配置</h3>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">管理 OpenAI 兼容连接，并为智能分析和 AI 对话选择默认模型。</p>
+    </div>
+
+    <div class="space-y-3">
+      <article v-for="(conn, index) in aiForm.connections" :key="conn.id" class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-900 sm:flex-row sm:items-center">
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2 text-sm font-medium text-gray-800 dark:text-gray-200">
+            <span v-if="conn.id === 'builtin'" class="rounded bg-primary-500/10 px-2 py-0.5 text-xs text-primary-600 dark:text-primary-500">内置</span>
+            <span class="truncate">{{ conn.provider || 'OpenAI' }}</span>
+          </div>
+          <p class="mt-1 truncate text-xs text-gray-500 dark:text-gray-400" :title="conn.api_base">{{ conn.api_base || '未设置地址' }}</p>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">已添加 {{ conn.models?.length || 0 }} 个模型</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <el-switch v-model="conn.enable" :disabled="conn.id === 'builtin'" @change="saveAll" />
+          <el-button plain @click="editConnection(index)">编辑</el-button>
+        </div>
+      </article>
+      <el-button type="primary" plain class="w-full" @click="addConnection">+ 添加连接</el-button>
+    </div>
+
+    <div class="grid gap-4 border-t border-gray-200 pt-4 dark:border-gray-700 lg:grid-cols-2">
+      <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-600">
+        <h4 class="font-medium text-gray-800 dark:text-gray-100">大模型智能分析配置</h4>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">请使用支持视觉理解的模型。</p>
+        <div class="mt-4 space-y-3">
+          <el-select v-model="analysisValue" class="w-full" placeholder="选择分析模型" filterable @change="onAnalysisModelChange">
+            <el-option v-for="model in selectableModels" :key="model.value" :label="model.label" :value="model.value" />
+          </el-select>
+          <el-select v-model="aiForm.analysis_reasoning_effort" class="w-full" placeholder="选择思考等级">
+            <el-option v-for="level in selectedReasoningLevels(analysisValue)" :key="level" :label="reasoningLabel(level)" :value="level" />
+          </el-select>
+        </div>
+      </div>
+      <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-600">
+        <h4 class="font-medium text-gray-800 dark:text-gray-100">AI 对话默认配置</h4>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">对话框内仍可临时切换模型和思考等级。</p>
+        <div class="mt-4 space-y-3">
+          <el-select v-model="chatValue" class="w-full" placeholder="选择对话模型" filterable @change="onChatModelChange">
+            <el-option v-for="model in selectableModels" :key="model.value" :label="model.label" :value="model.value" />
+          </el-select>
+          <el-select v-model="aiForm.chat_reasoning_effort" class="w-full" placeholder="选择思考等级">
+            <el-option v-for="level in selectedReasoningLevels(chatValue)" :key="level" :label="reasoningLabel(level)" :value="level" />
+          </el-select>
+        </div>
+      </div>
+    </div>
+
+    <el-collapse>
+      <el-collapse-item name="prompts" title="高级提示词设置">
+        <div class="space-y-4 pt-2">
+          <div>
+            <p class="mb-2 text-sm text-gray-700 dark:text-gray-200">图片分析提示词</p>
+            <el-input v-model="aiForm.visual_evaluation_prompt" type="textarea" :rows="4" placeholder="用于生成评分和描述的提示词" />
+          </div>
+          <div>
+            <p class="mb-2 text-sm text-gray-700 dark:text-gray-200">朋友圈文案提示词</p>
+            <el-input v-model="aiForm.moment_day_caption_prompt" type="textarea" :rows="4" placeholder="用于生成朋友圈日文案的提示词" />
+          </div>
+        </div>
+      </el-collapse-item>
+    </el-collapse>
+
+    <div class="flex justify-end">
+      <el-button type="primary" :loading="saving" @click="saveAll">保存大模型配置</el-button>
+    </div>
+
+    <el-dialog v-model="dialogVisible" :title="editingIndex < 0 ? '添加大模型连接' : '编辑大模型连接'" width="min(94vw, 720px)" destroy-on-close>
+      <el-form v-if="draft" label-position="top">
+        <el-form-item label="API 提供商">
+          <el-select v-model="draft.provider" class="w-full" :disabled="draft.id === 'builtin'">
+            <el-option v-if="draft.id === 'builtin'" label="内置 AI" value="Built-in AI" />
+            <el-option label="OpenAI 兼容接口" value="OpenAI" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="Base URL">
+          <el-input v-model.trim="draft.api_base" placeholder="https://api.openai.com/v1" :disabled="draft.id === 'builtin'" />
+        </el-form-item>
+        <el-form-item label="API Key">
+          <el-input v-model="draft.api_key" type="password" show-password placeholder="sk-..." :disabled="draft.id === 'builtin'" />
+        </el-form-item>
+
+        <el-form-item label="模型（必填）">
+          <div class="w-full space-y-3">
+            <div class="flex flex-col gap-2 sm:flex-row">
+              <el-button plain :loading="fetchingCandidates" :disabled="!draft.api_base" @click="fetchCandidates">获取模型列表</el-button>
+              <el-select v-if="candidateModels.length" v-model="selectedCandidates" multiple collapse-tags filterable class="min-w-0 flex-1" placeholder="选择要添加的模型">
+                <el-option v-for="name in availableCandidates" :key="name" :label="name" :value="name" />
+              </el-select>
+              <el-button v-if="candidateModels.length" type="primary" plain :disabled="!selectedCandidates.length" @click="addSelectedCandidates">添加所选</el-button>
+            </div>
+            <p v-if="candidateModels.length" class="text-xs text-gray-500 dark:text-gray-400">已获取 {{ candidateModels.length }} 个候选模型，只会添加你选择的模型。</p>
+
+            <div v-for="(model, index) in draft.models" :key="index" class="space-y-3 rounded-lg border border-gray-200 p-3 dark:border-gray-600">
+              <div class="grid gap-3 sm:grid-cols-2">
+                <el-select v-model="model.model_name" filterable allow-create default-first-option placeholder="输入模型名或从候选列表选择">
+                  <el-option v-for="name in candidateModels" :key="name" :label="name" :value="name" />
+                </el-select>
+                <el-input v-model="model.display_name" placeholder="显示名称（可选）" />
+              </div>
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <el-input-number v-model="model.context_window" :min="1024" :step="1024" controls-position="right" class="w-full sm:w-48" />
+                <span class="text-xs text-gray-500 dark:text-gray-400">上下文窗口（tokens）</span>
+                <el-button type="danger" text class="sm:ml-auto" @click="draft.models.splice(index, 1)">删除</el-button>
+              </div>
+              <el-checkbox-group v-model="model.reasoning_levels" class="flex flex-wrap gap-x-3">
+                <el-checkbox v-for="level in reasoningOptions" :key="level" :label="level" :value="level">{{ reasoningLabel(level) }}</el-checkbox>
+              </el-checkbox-group>
+            </div>
+            <el-button plain class="w-full" @click="addManualModel">+ 手动添加模型</el-button>
+          </div>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <div class="flex justify-between gap-3">
+          <el-button v-if="editingIndex >= 0 && draft?.id !== 'builtin'" type="danger" plain @click="removeConnection">删除连接</el-button>
+          <span v-else></span>
+          <div>
+            <el-button @click="dialogVisible = false">取消</el-button>
+            <el-button type="primary" @click="saveDraft">保存</el-button>
+          </div>
+        </div>
+      </template>
+    </el-dialog>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { settingsApi } from '@/api/settings'
+
+type ModelConfig = { model_name: string; display_name: string; context_window: number; reasoning_levels: string[] }
+type Connection = { id: string; provider: string; api_base: string; api_key: string; model_names: string[]; models: ModelConfig[]; enable: boolean }
+type AIForm = Record<string, any> & {
+  connections: Connection[]
+  analysis_connection_id: string
+  analysis_model_name: string
+  analysis_reasoning_effort: string
+  chat_connection_id: string
+  chat_model_name: string
+  chat_reasoning_effort: string
+}
+
+const reasoningOptions = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+const reasoningLabel = (level: string) => ({ none: '关闭', minimal: '最低', low: '低', medium: '中', high: '高', xhigh: '超高', max: '最大' }[level] || level)
+const modelTemplate = (name = ''): ModelConfig => ({ model_name: name, display_name: name, context_window: 128000, reasoning_levels: ['none', 'low', 'medium', 'high'] })
+const aiForm = ref<AIForm>({ connections: [], analysis_connection_id: '', analysis_model_name: '', analysis_reasoning_effort: 'none', chat_connection_id: '', chat_model_name: '', chat_reasoning_effort: 'none' })
+const loading = ref(false)
+const saving = ref(false)
+const dialogVisible = ref(false)
+const editingIndex = ref(-1)
+const draft = ref<Connection | null>(null)
+const candidateModels = ref<string[]>([])
+const selectedCandidates = ref<string[]>([])
+const fetchingCandidates = ref(false)
+
+const selectableModels = computed(() => aiForm.value.connections.filter(conn => conn.enable).flatMap(conn => conn.models.map(model => ({
+  value: `${conn.id}|${model.model_name}`,
+  label: `${model.display_name || model.model_name} · ${conn.provider}`,
+}))))
+const analysisValue = computed({
+  get: () => aiForm.value.analysis_connection_id && aiForm.value.analysis_model_name ? `${aiForm.value.analysis_connection_id}|${aiForm.value.analysis_model_name}` : '',
+  set: value => { [aiForm.value.analysis_connection_id, aiForm.value.analysis_model_name] = value ? value.split('|', 2) : ['', ''] },
+})
+const chatValue = computed({
+  get: () => aiForm.value.chat_connection_id && aiForm.value.chat_model_name ? `${aiForm.value.chat_connection_id}|${aiForm.value.chat_model_name}` : '',
+  set: value => { [aiForm.value.chat_connection_id, aiForm.value.chat_model_name] = value ? value.split('|', 2) : ['', ''] },
+})
+const availableCandidates = computed(() => {
+  const existing = new Set(draft.value?.models.map(model => model.model_name) || [])
+  return candidateModels.value.filter(name => !existing.has(name))
+})
+
+const normalizeConnection = (connection: any): Connection => ({
+  ...connection,
+  model_names: connection.model_names || [],
+  models: connection.models?.length ? connection.models : (connection.model_names || []).map((name: string) => modelTemplate(name)),
+})
+const selectedModel = (value: string) => {
+  const [connectionId, modelName] = value.split('|', 2)
+  return aiForm.value.connections.find(conn => conn.id === connectionId)?.models.find(model => model.model_name === modelName)
+}
+const selectedReasoningLevels = (value: string) => {
+  const levels = selectedModel(value)?.reasoning_levels
+  return levels?.length ? levels : ['none']
+}
+const ensureReasoning = (value: string, current: string) => {
+  const levels = selectedReasoningLevels(value)
+  return levels.includes(current) ? current : levels[0]
+}
+const onAnalysisModelChange = () => { aiForm.value.analysis_reasoning_effort = ensureReasoning(analysisValue.value, aiForm.value.analysis_reasoning_effort) }
+const onChatModelChange = () => { aiForm.value.chat_reasoning_effort = ensureReasoning(chatValue.value, aiForm.value.chat_reasoning_effort) }
+
+async function loadSettings() {
+  loading.value = true
+  try {
+    const settings = await settingsApi.getSettings()
+    aiForm.value = { ...settings.ai, connections: (settings.ai?.connections || []).map(normalizeConnection) }
+  } catch (error: any) {
+    ElMessage.error(error.message || '加载大模型配置失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+function addConnection() {
+  editingIndex.value = -1
+  draft.value = { id: `conn_${Date.now()}`, provider: 'OpenAI', api_base: '', api_key: '', model_names: [], models: [], enable: true }
+  candidateModels.value = []
+  selectedCandidates.value = []
+  dialogVisible.value = true
+}
+function editConnection(index: number) {
+  editingIndex.value = index
+  draft.value = structuredClone(aiForm.value.connections[index])
+  candidateModels.value = []
+  selectedCandidates.value = []
+  dialogVisible.value = true
+}
+function addManualModel() { draft.value?.models.push(modelTemplate()) }
+function addSelectedCandidates() {
+  if (!draft.value) return
+  const existing = new Set(draft.value.models.map(model => model.model_name))
+  selectedCandidates.value.forEach(name => { if (!existing.has(name)) draft.value!.models.push(modelTemplate(name)) })
+  selectedCandidates.value = []
+}
+async function fetchCandidates() {
+  if (!draft.value?.api_base) return
+  fetchingCandidates.value = true
+  try {
+    const result = await settingsApi.verifyConnection(draft.value.api_base, draft.value.api_key || '')
+    if (!result?.success) throw new Error(result?.message || '获取失败')
+    candidateModels.value = [...new Set<string>(result.models || [])]
+    ElMessage.success(`获取到 ${candidateModels.value.length} 个候选模型`)
+  } catch (error: any) {
+    ElMessage.error(error.message || '获取模型列表失败')
+  } finally {
+    fetchingCandidates.value = false
+  }
+}
+async function saveDraft() {
+  if (!draft.value) return
+  const models = draft.value.models.filter(model => model.model_name.trim()).map(model => ({ ...model, model_name: model.model_name.trim(), display_name: model.display_name.trim(), reasoning_levels: model.reasoning_levels.length ? model.reasoning_levels : ['none'] }))
+  if (!draft.value.api_base.trim()) return void ElMessage.warning('请填写 Base URL')
+  if (!models.length) return void ElMessage.warning('每个连接必须至少添加一个模型')
+  const names = models.map(model => model.model_name)
+  if (new Set(names).size !== names.length) return void ElMessage.warning('同一连接中不能添加重复模型')
+  const next = { ...draft.value, models, model_names: names }
+  if (editingIndex.value < 0) aiForm.value.connections.push(next)
+  else aiForm.value.connections[editingIndex.value] = next
+  dialogVisible.value = false
+  await saveAll()
+}
+async function removeConnection() {
+  if (editingIndex.value < 0) return
+  try {
+    await ElMessageBox.confirm('确定删除这个大模型连接？', '删除连接', { type: 'warning', confirmButtonText: '删除', cancelButtonText: '取消' })
+    const removedId = aiForm.value.connections[editingIndex.value].id
+    aiForm.value.connections.splice(editingIndex.value, 1)
+    if (aiForm.value.analysis_connection_id === removedId) { aiForm.value.analysis_connection_id = ''; aiForm.value.analysis_model_name = '' }
+    if (aiForm.value.chat_connection_id === removedId) { aiForm.value.chat_connection_id = ''; aiForm.value.chat_model_name = '' }
+    dialogVisible.value = false
+    await saveAll()
+  } catch (error) { if (error !== 'cancel' && error !== 'close') ElMessage.error(String(error)) }
+}
+function ensureSelections() {
+  const values = new Set(selectableModels.value.map(model => model.value))
+  const fallback = selectableModels.value[0]?.value || ''
+  if (!values.has(analysisValue.value)) analysisValue.value = fallback
+  if (!values.has(chatValue.value)) chatValue.value = fallback
+  onAnalysisModelChange()
+  onChatModelChange()
+}
+async function saveAll() {
+  saving.value = true
+  try {
+    ensureSelections()
+    aiForm.value.connections.forEach(conn => { conn.model_names = conn.models.map(model => model.model_name) })
+    await settingsApi.updateSettings({ ai: aiForm.value })
+    ElMessage.success('大模型配置已保存')
+  } catch (error: any) {
+    ElMessage.error(error.message || '保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(loadSettings)
+</script>

--- a/package/website/tests/e2e/specs/views-coverage/views-deeper.spec.ts
+++ b/package/website/tests/e2e/specs/views-coverage/views-deeper.spec.ts
@@ -241,7 +241,7 @@ test.describe('P1 - BasicSettings 基础设置面板 @views-coverage', () => {
     })
 
     await page.goto('/settings#basic')
-    await page.locator('.el-collapse-item__header', { hasText: 'AI 相关设置' }).first().click()
+    await page.locator('.el-collapse-item__header', { hasText: 'AI 服务与人脸设置' }).first().click()
     const apiInput = page.getByLabel('AI API 地址')
     await expect(apiInput).toBeVisible({ timeout: 10_000 })
     await expect.poll(() => settingsLoaded).toBe(true)


### PR DESCRIPTION
## 描述
改进 TrailSnap 大模型连接与 Agent 对话配置体验：模型列表由用户显式挑选并保存，支持模型级上下文窗口与思考等级，并将相关入口集中到“AI 模型管理”。Agent 对话在输入框附近统一选择模型和思考等级，且只读取用户已保存模型。

## 变更类型
- [ ] 🐛 修复错误 (Bug Fix)
- [x] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [x] 🎨 代码风格调整 (Style)
- [x] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [x] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue
Closes #200

## 如何测试
- `pnpm build`（Website）
- Server 定向单测：配置、Settings API、Agent API/Service、模型列表与视觉分析相关测试，共 117 项通过
- 补充回归子集 73 项通过
- `git diff --check`

## 检查清单
- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有已执行测试均已通过
- [ ] 我已更新了相关文档