### PR TITLE
test(nightly): cover agent and AI service gaps

### DIFF
--- a/package/ai/tests/test_nightly_face_model_lifecycle_gaps_20260908.py
+++ b/package/ai/tests/test_nightly_face_model_lifecycle_gaps_20260908.py
@@ -1,0 +1,94 @@
+"""Nightly gap tests for InsightFace model lifecycle (2026-09-08)."""
+import gc
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+def _install_fake_insightface(monkeypatch):
+    insightface = types.ModuleType("insightface")
+    app_module = types.ModuleType("insightface.app")
+    face_analysis = MagicMock(name="FaceAnalysis")
+    app_module.FaceAnalysis = face_analysis
+    insightface.app = app_module
+    monkeypatch.setitem(sys.modules, "insightface", insightface)
+    monkeypatch.setitem(sys.modules, "insightface.app", app_module)
+    return face_analysis
+
+
+def test_load_insightface_model_configures_selected_model(monkeypatch, tmp_path):
+    from app.services import face_service
+
+    face_analysis = _install_fake_insightface(monkeypatch)
+    monkeypatch.setattr(face_service.ai_model_manager, "get_model_selection", lambda _: "buffalo_l")
+    monkeypatch.setattr(face_service.settings, "MODEL_PATH", str(tmp_path / "models"))
+    monkeypatch.setattr(
+        face_service,
+        "get_onnx_providers",
+        lambda: (["CPUExecutionProvider"], [{" intra_op_num_threads ": 2}]),
+    )
+
+    app = face_service.load_insightface_model()
+
+    assert app is face_analysis.return_value
+    kwargs = face_analysis.call_args.kwargs
+    assert kwargs["name"] == "buffalo_l"
+    assert kwargs["root"] == str(tmp_path.resolve())
+    assert kwargs["providers"] == ["CPUExecutionProvider"]
+    assert kwargs["provider_options"] == [{" intra_op_num_threads ": 2}]
+    app.prepare.assert_called_once_with(ctx_id=0, det_size=(640, 640))
+
+
+def test_release_model_clears_internal_sessions_and_caches(monkeypatch):
+    from app.services import face_service
+
+    insightface = types.ModuleType("insightface")
+    utils_module = types.ModuleType("insightface.utils")
+    face_align = types.ModuleType("insightface.utils.face_align")
+    face_align.clear_cache = MagicMock()
+    utils_module.face_align = face_align
+    insightface.utils = utils_module
+    monkeypatch.setitem(sys.modules, "insightface", insightface)
+    monkeypatch.setitem(sys.modules, "insightface.utils", utils_module)
+    monkeypatch.setitem(sys.modules, "insightface.utils.face_align", face_align)
+
+    inner = SimpleNamespace(
+        session=object(),
+        model=object(),
+        input_names=["input"],
+        output_names=["output"],
+    )
+    app = SimpleNamespace(
+        models={"detection": inner},
+        det_model=object(),
+        rec_model=object(),
+        cls_model=object(),
+    )
+    with patch.object(face_service.gc, "collect") as collect:
+        face_service.release_model(app)
+
+    face_align.clear_cache.assert_called_once()
+    collect.assert_called()
+    for attribute in ("models", "det_model", "rec_model", "cls_model"):
+        assert not hasattr(app, attribute)
+    assert not hasattr(inner, "session")
+    assert not hasattr(inner, "model")
+    assert not hasattr(inner, "input_names")
+    assert not hasattr(inner, "output_names")
+
+
+def test_process_image_rejects_invalid_image_bytes(monkeypatch):
+    from app.services import face_service
+
+    monkeypatch.setattr(face_service.ai_model_manager, "is_ready", lambda _: True)
+    monkeypatch.setattr(face_service.model_manager, "get_model", lambda _: MagicMock())
+    monkeypatch.setattr(face_service.cv2, "imdecode", lambda data, flags: None)
+
+    with pytest.raises(ValueError, match="Invalid image data"):
+        face_service.FaceRecognitionService().process_image(b"not-an-image")
+

--- a/package/ai/tests/test_nightly_llm_manager_gaps_20260908.py
+++ b/package/ai/tests/test_nightly_llm_manager_gaps_20260908.py
@@ -1,0 +1,35 @@
+"""Nightly gap tests for llama.cpp executable discovery (2026-09-08)."""
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+def test_llama_executable_prefers_configured_existing_path(monkeypatch, tmp_path):
+    from app.services import llm_manager
+
+    executable = tmp_path / "llama-server.exe"
+    executable.write_text("", encoding="utf-8")
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(executable))
+
+    with pytest.MonkeyPatch.context() as isolated:
+        isolated.setattr(llm_manager.shutil, "which", lambda _: None)
+        assert llm_manager.LLMProcessManager._llama_server_executable() == str(executable)
+
+
+def test_llama_executable_falls_back_to_path_discovery(monkeypatch):
+    from app.services import llm_manager
+
+    monkeypatch.delenv("LLAMA_SERVER_PATH", raising=False)
+    monkeypatch.setattr(llm_manager.shutil, "which", lambda name: f"/opt/{name}")
+
+    assert llm_manager.LLMProcessManager._llama_server_executable() == "/opt/llama-server"
+
+
+def test_llama_executable_raises_actionable_error_when_missing(monkeypatch):
+    from app.services import llm_manager
+
+    monkeypatch.delenv("LLAMA_SERVER_PATH", raising=False)
+    monkeypatch.setattr(llm_manager.shutil, "which", lambda _: None)
+
+    with pytest.raises(RuntimeError, match="llama-server 未安装"):
+        llm_manager.LLMProcessManager._llama_server_executable()

--- a/package/ai/tests/test_nightly_ticket_parser_datetime_gaps_20260908.py
+++ b/package/ai/tests/test_nightly_ticket_parser_datetime_gaps_20260908.py
@@ -1,0 +1,35 @@
+"""Nightly gap tests for train-ticket departure datetime geometry (2026-09-08)."""
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+def _poly(x, y, w=20, h=10):
+    return [[x, y], [x + w, y], [x + w, y + h], [x, y + h]]
+
+
+def test_build_departure_datetime_pairs_nearest_date_and_time_with_year():
+    from app.services.ticket_parser import _build_departure_datetime
+
+    texts = ["2025年", "01月09日", "17:12", "18:20"]
+    polys = [_poly(0, 0), _poly(20, 0), _poly(50, 0), _poly(200, 200)]
+
+    assert _build_departure_datetime(texts, polys) == "2025年01月09日 17:12"
+
+
+def test_build_departure_datetime_time_only_prefers_leftmost_horizontal_candidate():
+    from app.services.ticket_parser import _build_departure_datetime
+
+    texts = ["17:12", "18:20"]
+    polys = [_poly(100, 0), _poly(10, 0)]
+
+    assert _build_departure_datetime(texts, polys) == "18:20"
+
+
+def test_build_departure_datetime_date_only_prefers_topmost_candidate():
+    from app.services.ticket_parser import _build_departure_datetime
+
+    texts = ["01月09日", "02月10日"]
+    polys = [_poly(0, 100), _poly(0, 10)]
+
+    assert _build_departure_datetime(texts, polys) == "02月10日"

--- a/package/server/tests/unit/test_nightly_agent_context_gaps_20260908.py
+++ b/package/server/tests/unit/test_nightly_agent_context_gaps_20260908.py
@@ -1,0 +1,96 @@
+"""Nightly gap tests for Agent context compression (2026-09-08).
+
+Targets ``app/service/agent/service.py`` helpers that remained uncovered:
+structured message serialization, summary LLM construction, and successful
+history compression with persisted context.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+pytestmark = [pytest.mark.smoke]
+
+USER_ID = "00000000-0000-0000-0000-000000000001"
+SESSION_ID = "00000000-0000-0000-0000-000000000002"
+
+
+def test_messages_to_text_serializes_structured_content():
+    from app.service.agent import service as agent_service
+
+    messages = [
+        SystemMessage(content="system prompt"),
+        HumanMessage(content=[{"type": "text", "text": "找上周的西湖照片"}]),
+        AIMessage(content=[{"type": "text", "text": "找到 3 张"}]),
+        HumanMessage(content=""),
+    ]
+
+    text = agent_service._messages_to_text(messages)
+
+    assert "system prompt" not in text
+    assert "用户：" in text
+    assert "助手：" in text
+    assert "找上周的西湖照片" in text
+    assert "找到 3 张" in text
+    assert text.count("\n") == 1  # empty content is omitted
+
+
+def test_get_summary_llm_uses_configured_analysis_connection():
+    from app.service.agent import service as agent_service
+
+    connection = SimpleNamespace(
+        id="analysis-1",
+        enable=True,
+        api_key="sk-test",
+        api_base="https://api.example.com/v1",
+    )
+    user_config = SimpleNamespace(
+        ai=SimpleNamespace(
+            analysis_connection_id="analysis-1",
+            analysis_model_name="summary-model",
+            connections=[connection],
+        )
+    )
+    db = object()
+
+    with patch.object(agent_service.config_manager, "get_user_config", return_value=user_config):
+        with patch.object(agent_service, "ChatOpenAI") as chat_openai:
+            result = agent_service._get_summary_llm(USER_ID, db)
+
+    assert result is chat_openai.return_value
+    kwargs = chat_openai.call_args.kwargs
+    assert kwargs["model"] == "summary-model"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["base_url"] == "https://api.example.com/v1"
+    assert kwargs["temperature"] == 0.2
+    assert kwargs["timeout"] == 30
+
+
+def test_compress_history_if_needed_persists_summary_and_keeps_recent():
+    from app.service.agent import service as agent_service
+
+    system = SystemMessage(content="system prompt")
+    old = [HumanMessage(content=f"old-{i}") for i in range(25)]
+    recent = [HumanMessage(content=f"recent-{i}") for i in range(10)]
+    messages = [system] + old + recent
+
+    llm = SimpleNamespace(invoke=MagicMock(return_value=SimpleNamespace(content="摘要内容")))
+    db = object()
+
+    with patch.object(agent_service, "_get_summary_llm", return_value=llm):
+        with patch.object(agent_service.agent_crud, "get_context_summary", return_value="旧摘要") as get_summary:
+            with patch.object(agent_service.agent_crud, "update_context_summary") as update_summary:
+                result = agent_service.compress_history_if_needed(messages, USER_ID, SESSION_ID, db)
+
+    get_summary.assert_called_once_with(db, SESSION_ID)
+    update_summary.assert_called_once_with(db, SESSION_ID, "摘要内容")
+    assert len(result) == 12
+    assert result[0] is system
+    assert isinstance(result[1], SystemMessage)
+    assert "【历史对话摘要】" in result[1].content
+    assert "摘要内容" in result[1].content
+    assert result[2:] == recent
+    assert all("old-" not in m.content for m in result[2:])
+

--- a/package/server/tests/unit/test_nightly_agent_search_helpers_gaps_20260908.py
+++ b/package/server/tests/unit/test_nightly_agent_search_helpers_gaps_20260908.py
@@ -1,0 +1,60 @@
+"""Nightly gap tests for Agent photo-search helpers (2026-09-08)."""
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+def test_base_agent_photo_search_query_builds_safe_projection():
+    from app.service.agent import tools as agent_tools
+    from app.db.models.photo import Photo
+
+    db = MagicMock()
+    query = MagicMock()
+    query.outerjoin.return_value = query
+    db.query.return_value = query
+
+    result = agent_tools._base_agent_photo_search_query(db, "user-1")
+
+    assert result is query.filter.return_value
+    db.query.assert_called_once_with(Photo.id, Photo.photo_time)
+    assert query.outerjoin.call_count == 2
+    query.filter.assert_called_once()
+
+
+def test_build_search_summary_aggregates_dates_locations_and_tags():
+    from app.service.agent import tools as agent_tools
+
+    db = MagicMock()
+    date_query = MagicMock()
+    date_query.filter.return_value.first.return_value = (datetime(2026, 9, 1), datetime(2026, 9, 7))
+    city_query = MagicMock()
+    city_query.filter.return_value.group_by.return_value.order_by.return_value.limit.return_value.all.return_value = [("北京", 3), ("杭州", 2)]
+    tag_query = MagicMock()
+    tag_query.join.return_value.filter.return_value.group_by.return_value.order_by.return_value.limit.return_value.all.return_value = [("旅行", 4)]
+    db.query.side_effect = [date_query, MagicMock(), city_query, MagicMock(), tag_query, MagicMock()]
+
+    filtered = MagicMock()
+    id_subquery = filtered.with_entities.return_value.order_by.return_value.subquery.return_value
+
+    summary = agent_tools._build_search_summary(db, filtered, None)
+
+    assert summary == {
+        "date_range": ["2026-09-01", "2026-09-07"],
+        "top_locations": {"北京": 3, "杭州": 2},
+        "top_tags": {"旅行": 4},
+    }
+    assert id_subquery is not None
+
+
+def test_build_search_summary_returns_empty_when_projection_fails():
+    from app.service.agent import tools as agent_tools
+
+    db = MagicMock()
+    filtered = MagicMock()
+    filtered.with_entities.side_effect = RuntimeError("projection failed")
+
+    assert agent_tools._build_search_summary(db, filtered, None) == {}
+

--- a/package/server/tests/unit/test_nightly_day_caption_context_gaps_20260908.py
+++ b/package/server/tests/unit/test_nightly_day_caption_context_gaps_20260908.py
@@ -1,0 +1,87 @@
+"""Nightly gap tests for day-caption context preparation (2026-09-08)."""
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from app.db.models.photo import FileType
+
+pytestmark = [pytest.mark.smoke]
+
+USER_ID = UUID("00000000-0000-0000-0000-000000000001")
+DAY = date(2026, 9, 8)
+
+
+def _photo(photo_id, file_type=FileType.image):
+    return SimpleNamespace(id=photo_id, file_type=file_type)
+
+
+def test_dedup_similar_photos_preserves_videos_and_unclustered_images():
+    from app.service.moment import day_caption_service as svc
+
+    photos = [
+        _photo("representative"),
+        _photo("duplicate"),
+        _photo("video", FileType.video),
+        _photo("no-embedding"),
+    ]
+    db = MagicMock()
+
+    with patch.object(svc, "dedup_day_photo_ids", return_value=({"representative"}, {"total_candidates": 2})) as dedup:
+        with patch.object(svc, "_fetch_clustered_photo_ids", return_value={"representative", "duplicate"}):
+            result, original_count = svc._dedup_similar_photos(db, USER_ID, DAY, photos)
+
+    dedup.assert_called_once_with(db, USER_ID, DAY)
+    assert [p.id for p in result] == ["representative", "video", "no-embedding"]
+    assert original_count == 3
+
+
+def test_build_materials_aggregates_locations_people_descriptions_and_tags():
+    from app.service.moment import day_caption_service as svc
+
+    photos = [_photo("p1"), _photo("p2", FileType.video)]
+    db = MagicMock()
+    location_query = MagicMock()
+    location_query.outerjoin.return_value.filter.return_value.all.return_value = [
+        (SimpleNamespace(city="杭州", district="西湖", address="西湖景区"), "西湖"),
+        (SimpleNamespace(city="杭州", district="余杭", address=""), None),
+    ]
+    people_query = MagicMock()
+    people_query.join.return_value.filter.return_value.all.return_value = [("Alice",), ("Alice",), ("Bob",)]
+    description_query = MagicMock()
+    description_query.filter.return_value.all.return_value = [
+        SimpleNamespace(narrative="西湖边的傍晚", description="", tags=["旅行", "旅行", "夜景"]),
+        SimpleNamespace(narrative="", description="备用描述", tags=[]),
+    ]
+    db.query.side_effect = [location_query, people_query, description_query]
+
+    materials = svc._build_materials(db, photos, image_original_count=3)
+
+    assert materials["locations"] == ["西湖", "杭州 · 余杭"]
+    assert materials["people"] == ["Alice", "Bob"]
+    assert materials["descriptions"] == ["西湖边的傍晚", "备用描述"]
+    assert materials["tags"] == ["旅行", "夜景"]
+    assert materials["counts"] == {"image": 1, "video": 1, "image_original": 3}
+
+
+def test_prepare_context_rejects_scope_and_returns_cached_caption():
+    from app.service.moment import day_caption_service as svc
+
+    db = MagicMock()
+    with pytest.raises(ValueError, match="只支持全部照片视图"):
+        svc._prepare_context(
+            USER_ID, db, DAY, "Asia/Shanghai", "album", None,
+            None, None, None, False,
+        )
+
+    cached = SimpleNamespace(caption="已有文案")
+    with patch.object(svc.moment_crud, "get_caption", return_value=cached) as get_caption:
+        result = svc._prepare_context(
+            USER_ID, db, DAY, "Asia/Shanghai", "all", None,
+            "poetic", "conn", "model", False,
+        )
+
+    get_caption.assert_called_once_with(db, USER_ID, "all", None, DAY)
+    assert result == ("已有文案", {})

--- a/package/server/tests/unit/test_nightly_watch_gaps_20260908.py
+++ b/package/server/tests/unit/test_nightly_watch_gaps_20260908.py
@@ -1,0 +1,267 @@
+"""Nightly watch gap tests for 2026-09-08.
+
+Covers five modules selected from the fresh coverage scan:
+
+* ``app.core.logger`` -- queue setup and date-based filename switching.
+* ``app.service.moment.day_caption_service`` -- sync caption normalization and empty output.
+* ``app.service.agent.service`` -- successful agent executor construction and memory injection.
+* ``app.service.agent.tools`` -- search summary aggregation and exception fallback.
+* ``app.crud.album`` -- album deletion and shared-user creation paths.
+"""
+
+import logging
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+import app.core.logger as logger_module
+from app.crud import album as album_crud
+from app.service.agent import service as agent_service
+from app.service.agent.tools import _build_search_summary
+from app.service.moment import day_caption_service as caption_service
+
+
+pytestmark = [pytest.mark.smoke]
+
+
+# ---------------------------------------------------------------------------
+# app.core.logger
+# ---------------------------------------------------------------------------
+
+
+def test_setup_logging_writes_json_and_uses_queue_handler(monkeypatch, tmp_path):
+    """setup_logging must install one queue handler and emit one JSON file line."""
+    root = logging.getLogger()
+    named = ["uvicorn", "uvicorn.access", "uvicorn.error", "fastapi"]
+    old_handlers = {name: list(logging.getLogger(name).handlers) for name in named}
+    old_root_handlers = list(root.handlers)
+    monkeypatch.setattr(logger_module, "LOG_DIR", str(tmp_path))
+
+    try:
+        listener = logger_module.setup_logging(filename="nightly-watch")
+        logging.getLogger("app").info(
+            "watch log",
+            extra={"operation": "nightly", "params": {"run": 1}, "result": "ok"},
+        )
+        listener.stop()
+
+        assert any(isinstance(h, logging.handlers.QueueHandler) for h in root.handlers)
+        log_files = list(tmp_path.glob("nightly-watch-*.log"))
+        assert len(log_files) == 1
+        import json
+
+        payload = json.loads(log_files[0].read_text(encoding="utf-8").splitlines()[0])
+        assert payload["message"] == "watch log"
+        assert payload["operation"] == "nightly"
+        assert payload["params"] == {"run": 1}
+    finally:
+        root.handlers = old_root_handlers
+        for name, handlers in old_handlers.items():
+            logging.getLogger(name).handlers = handlers
+
+
+def test_daily_rotating_handler_emit_switches_to_today_file(tmp_path):
+    handler = logger_module.DailySizeRotatingFileHandler(
+        filename="rollover", log_dir=str(tmp_path), maxBytes=1024, backupCount=2
+    )
+    try:
+        handler.current_date = date.today() - timedelta(days=1)
+        record = logging.LogRecord(
+            name="app.test", level=logging.INFO, pathname=__file__, lineno=1,
+            msg="new day", args=(), exc_info=None,
+        )
+        handler.emit(record)
+        expected = handler._get_filename(date.today())
+        assert handler.baseFilename == expected
+        assert Path(expected).exists()
+        assert Path(expected).read_text(encoding="utf-8").strip() == "new day"
+    finally:
+        handler.close()
+
+
+# ---------------------------------------------------------------------------
+# app.service.moment.day_caption_service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_caption_sync_accepts_list_content_and_strips_think():
+    user_id, db, day = uuid4(), MagicMock(), date(2026, 9, 8)
+    materials = {
+        "_connection": SimpleNamespace(api_key="k", api_base=""),
+        "_model_name": "caption-model",
+        "_system_prompt": "system",
+        "_user_prompt": "user",
+        "_photo_count": 2,
+    }
+    llm = MagicMock()
+    llm.invoke.return_value = SimpleNamespace(
+        content=[{"type": "text", "text": '<think>hidden</think>"西湖夜色"'}]
+    )
+    saved = SimpleNamespace(caption="西湖夜色", model_name="caption-model")
+
+    with patch.object(caption_service, "_prepare_context", return_value=(None, materials)), \
+         patch.object(caption_service, "_build_llm", return_value=llm), \
+         patch.object(caption_service.moment_crud, "upsert_caption", return_value=saved) as upsert:
+        result = await caption_service.generate_caption_sync(
+            user_id, db, day, "Asia/Shanghai", force=True
+        )
+
+    assert result == {
+        "caption": "西湖夜色", "cached": False,
+        "source": "ai", "model_name": "caption-model",
+    }
+    assert upsert.call_args.args[5] == "西湖夜色"
+
+
+@pytest.mark.asyncio
+async def test_generate_caption_sync_rejects_empty_visible_caption():
+    user_id, db, day = uuid4(), MagicMock(), date(2026, 9, 8)
+    materials = {
+        "_connection": SimpleNamespace(api_key="k", api_base=""),
+        "_model_name": "caption-model",
+        "_system_prompt": "system",
+        "_user_prompt": "user",
+    }
+    llm = MagicMock()
+    llm.invoke.return_value = SimpleNamespace(content="<think>only reasoning</think>")
+
+    with patch.object(caption_service, "_prepare_context", return_value=(None, materials)), \
+         patch.object(caption_service, "_build_llm", return_value=llm), \
+         patch.object(caption_service.moment_crud, "upsert_caption") as upsert:
+        with pytest.raises(RuntimeError, match="LLM 返回为空"):
+            await caption_service.generate_caption_sync(
+                user_id, db, day, "Asia/Shanghai", force=True
+            )
+
+    upsert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# app.service.agent.service
+# ---------------------------------------------------------------------------
+
+
+def test_get_agent_executor_success_injects_tools_and_memory():
+    user_id, session_id, db = str(uuid4()), str(uuid4()), MagicMock()
+    connection = SimpleNamespace(
+        id="conn-1", enable=True, api_key="key", api_base="https://ai.example/v1"
+    )
+    config = SimpleNamespace(
+        ai=SimpleNamespace(
+            analysis_connection_id="conn-1",
+            analysis_model_name="watch-model",
+            connections=[connection],
+        )
+    )
+    fake_llm, fake_agent = MagicMock(), MagicMock()
+
+    with patch.object(agent_service.config_manager, "get_user_config", return_value=config), \
+         patch.object(agent_service, "FixedChatOpenAI", return_value=fake_llm) as llm_call, \
+         patch.object(agent_service, "get_agent_tools", return_value=["tool"]) as tools_call, \
+         patch.object(agent_service, "create_agent", return_value=fake_agent) as create_call, \
+         patch("app.service.agent.memory.build_memory_prompt", return_value="长期记忆：西湖") as memory_call:
+        agent, prompt = agent_service.get_agent_executor(
+            user_id, session_id, db, user_input="杭州的一天"
+        )
+
+    assert agent is fake_agent
+    assert "长期记忆：西湖" in prompt
+    assert date.today().strftime("%Y-%m-%d") in prompt
+    assert tools_call.call_args.args == (user_id,)
+    assert tools_call.call_args.kwargs == {"session_id": session_id}
+    assert create_call.call_args.args == (fake_llm, ["tool"])
+    assert llm_call.call_args.kwargs["model"] == "watch-model"
+    assert llm_call.call_args.kwargs["api_key"] == "key"
+    assert llm_call.call_args.kwargs["base_url"] == "https://ai.example/v1"
+    memory_call.assert_called_once_with(db, user_id, user_input="杭州的一天")
+
+
+# ---------------------------------------------------------------------------
+# app.service.agent.tools
+# ---------------------------------------------------------------------------
+
+
+def test_build_search_summary_returns_empty_when_projection_fails():
+    db, filtered_query = MagicMock(), MagicMock()
+    filtered_query.with_entities.side_effect = RuntimeError("projection failed")
+
+    assert _build_search_summary(db, filtered_query, None) == {}
+
+
+def test_build_search_summary_aggregates_dates_locations_and_tags():
+    db, filtered_query = MagicMock(), MagicMock()
+    date_query = MagicMock()
+    date_query.filter.return_value.first.return_value = (
+        datetime(2026, 9, 1), datetime(2026, 9, 8)
+    )
+    city_query = MagicMock()
+    city_query.filter.return_value.group_by.return_value.order_by.return_value.limit.return_value.all.return_value = [
+        ("杭州", 12), ("上海", 5)
+    ]
+    tag_query = MagicMock()
+    tag_query.join.return_value.filter.return_value.group_by.return_value.order_by.return_value.limit.return_value.all.return_value = [
+        ("旅行", 9), ("夜景", 4)
+    ]
+    # The function also creates nested id subqueries through db.query(...).
+    db.query.side_effect = [date_query, MagicMock(), city_query, MagicMock(), tag_query, MagicMock()]
+
+    summary = _build_search_summary(db, filtered_query, None)
+
+    assert summary["date_range"] == ["2026-09-01", "2026-09-08"]
+    assert summary["top_locations"] == {"杭州": 12, "上海": 5}
+    assert summary["top_tags"] == {"旅行": 9, "夜景": 4}
+
+
+# ---------------------------------------------------------------------------
+# app.crud.album
+# ---------------------------------------------------------------------------
+
+
+def test_delete_album_deletes_existing_album_and_commits():
+    db, album = MagicMock(), SimpleNamespace(id=uuid4())
+
+    with patch.object(album_crud, "get_album", return_value=album) as get_album:
+        result = album_crud.delete_album(db, album.id)
+
+    assert result is not None
+    get_album.assert_called_once_with(db, album.id)
+    db.delete.assert_called_once_with(album)
+    db.commit.assert_called_once()
+
+
+def test_delete_album_returns_none_when_album_missing():
+    db = MagicMock()
+
+    with patch.object(album_crud, "get_album", return_value=None):
+        result = album_crud.delete_album(db, uuid4())
+
+    assert result is None
+    db.delete.assert_not_called()
+    db.commit.assert_not_called()
+
+
+def test_create_album_resolves_shared_users_from_database():
+    db, owner, shared = MagicMock(), uuid4(), uuid4()
+    payload = SimpleNamespace(
+        name="共享相册", description="desc", type="normal", condition=None,
+        threshold=None, shared_users=[shared],
+    )
+    def fake_album(**kwargs):
+        return SimpleNamespace(**kwargs)
+    db.query.return_value.filter.return_value.all.return_value = [shared]
+
+    with patch.object(album_crud, "Album", side_effect=fake_album):
+        result = album_crud.create_album(db, payload, query_embedding=None, user_id=owner)
+
+    assert result is not None
+    assert result.shared_users == [shared]
+    assert result.owner_id == owner
+    db.query.return_value.filter.return_value.all.assert_called_once()
+    db.add.assert_called_once_with(result)
+    db.commit.assert_called_once()
+    db.refresh.assert_called_once_with(result)


### PR DESCRIPTION
## 描述

根据 2026-09-08 夜间测试值守的覆盖率扫描，为后端 Agent / 朋友圈文案服务和 AI 服务补充 18 个聚焦单元测试。仅新增测试文件，不修改业务代码。

Closes #202

## 变更类型

- [x] ✅ 测试增加/修改 (Tests)

## 相关 Issue

Closes #202

## 如何测试

- 新增后端单元测试：9 passed。
- 新增 AI 单元测试：9 passed。
- 完整 E2E full：343 passed / 4 skipped / 0 failed，teardown 1 passed。
- 已按夜间值守流程生成覆盖率扫描与测试日志。

## 2026-09-08 夜间值守第二轮更新

- 新增 10 个后端单元测试，覆盖 `core/logger.py`、`service/moment/day_caption_service.py`、`service/agent/service.py`、`service/agent/tools.py`、`crud/album.py`。
- 本地后端单元全量：exit 0。
- 完整 E2E full：343 passed / 4 skipped / 0 failed，teardown 1 passed。
- 本轮提交：`37507fb507ddcb29467560a387bddfe978bd2dc5`。

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [x] 我已更新了相关文档


## 2026-09-08 rebase 后复测

- 分支已 rebase 到最新 `master`（`6db55aea`），当前提交：`b21e6d9242a9af003815e5d55633f33683080c50`。
- 完整 E2E full 复测通过：**350 passed / 4 skipped / 0 failed**；setup 与 teardown 各 1 passed。
- 覆盖扫描沿用本轮生成报告；新增测试未修改业务代码。
- 下一步等待 rebase 后 GitHub workflows 全部通过后合入 `master`。
