### PR TITLE
fix(website): 优化实况图加载体验

### DIFF
--- a/package/website/src/components/PhotoLightbox.vue
+++ b/package/website/src/components/PhotoLightbox.vue
@@ -252,14 +252,20 @@
                         v-if="isPlayingLive"
                         ref="liveVideoRef"
                         :key="image.id"
-                        class="absolute inset-0 w-full h-full object-contain z-10 pointer-events-none"
+                        class="live-photo-video absolute inset-0 w-full h-full object-contain z-10 pointer-events-none transition-opacity duration-200"
+                        :class="isLiveVideoVisible ? 'opacity-100' : 'opacity-0'"
                         :style="videoStyle"
                         autoplay
+                        preload="auto"
                         playsinline
                         x5-playsinline
                         webkit-playsinline
+                        controlslist="nodownload noplaybackrate nofullscreen"
+                        disablepictureinpicture
                         :loop="false"
+                        @playing="onLivePlaying"
                         @ended="onLiveEnded"
+                        @error="onLiveError"
                         @loadedmetadata="onVideoLoaded"
                     >
                         <source :src="image.live_photo_video_url" type="video/mp4" />
@@ -703,6 +709,7 @@ const swipeOffset = ref(0)
 const isSwipeAnimating = ref(false)
 let swipeAnimationTimer: ReturnType<typeof setTimeout> | null = null
 const isPlayingLive = ref(false)
+const isLiveVideoVisible = ref(false)
 const liveVideoRef = ref<HTMLVideoElement | null>(null)
 const videoStyle = ref<Record<string, string>>({})
 
@@ -917,6 +924,7 @@ const onVideoLoaded = (e: Event) => {
 }
 
 const toggleLivePlayback = () => {
+    isLiveVideoVisible.value = false
     if (isPlayingLive.value) {
         // Stop
         isPlayingLive.value = false
@@ -926,7 +934,19 @@ const toggleLivePlayback = () => {
     }
 }
 
+const onLivePlaying = () => {
+    requestAnimationFrame(() => {
+        if (isPlayingLive.value) isLiveVideoVisible.value = true
+    })
+}
+
 const onLiveEnded = () => {
+    isLiveVideoVisible.value = false
+    isPlayingLive.value = false
+}
+
+const onLiveError = () => {
+    isLiveVideoVisible.value = false
     isPlayingLive.value = false
 }
 
@@ -1158,6 +1178,7 @@ watch(() => props.image, async (newImg, oldImg) => {
     highlightedOCR.value = null
     highlightedFace.value = null
     videoStyle.value = {}
+    isLiveVideoVisible.value = false
     isDragging.value = false // Ensure dragging is reset
     processingMenuVisible.value = false
     closeMobileMenu()
@@ -1196,6 +1217,7 @@ watch(() => props.image, async (newImg, oldImg) => {
 })
 
 watch(() => props.visible, async (newVal) => {
+    isLiveVideoVisible.value = false
     if (newVal && props.image) {
         pushLightboxHistoryEntry()
         document.body.style.overflow = 'hidden'
@@ -1845,6 +1867,15 @@ const handleEditorSave = async (blob: Blob, filename: string, mode: 'replace' | 
 </script>
 
 <style scoped>
+.live-photo-video::-webkit-media-controls,
+.live-photo-video::-webkit-media-controls-enclosure,
+.live-photo-video::-webkit-media-controls-panel,
+.live-photo-video::-webkit-media-controls-play-button,
+.live-photo-video::-webkit-media-controls-start-playback-button {
+    display: none !important;
+    -webkit-appearance: none;
+}
+
 .viewer-controls-enter-active,
 .viewer-controls-leave-active {
     transition: opacity 180ms ease, transform 180ms ease;

--- a/package/website/src/views/toolbox/SwipeFilter.vue
+++ b/package/website/src/views/toolbox/SwipeFilter.vue
@@ -136,13 +136,19 @@
               <video
                 v-if="photo.file_type === 'live_photo' && index === 0 && livePlayRequested && currentThumbLoaded"
                 :key="photo.id"
-                class="absolute inset-0 w-full h-full object-contain pointer-events-none"
+                class="live-photo-video absolute inset-0 w-full h-full object-contain pointer-events-none transition-opacity duration-200"
+                :class="liveVideoVisible ? 'opacity-100' : 'opacity-0'"
                 autoplay
                 muted
+                preload="auto"
                 playsinline
                 webkit-playsinline
                 x5-playsinline
+                controlslist="nodownload noplaybackrate nofullscreen"
+                disablepictureinpicture
+                @playing="onLivePlaying"
                 @ended="onLiveEnded"
+                @error="onLiveError"
               >
                 <source :src="toServerUrl(`/api/medias/${photo.id}/video`)" type="video/mp4" />
               </video>
@@ -600,17 +606,35 @@ const formatDuration = (photo: Photo) => {
 
 // 实况图播放：仅顶层、且封面加载完毕后播放一次；播完停在封面图，点击 LIVE 徽标可重播。
 const livePlayRequested = ref(false)
+// 视频元素挂载后仍可能短暂显示 Android WebView 的原生播放占位图。
+// 保持视频透明，直到浏览器确认已开始播放；期间继续展示已经加载好的照片封面。
+const liveVideoVisible = ref(false)
 const toggleLivePlayback = () => {
   if (!currentPhoto.value || currentPhoto.value.file_type !== 'live_photo') return
   if (!currentThumbLoaded.value) return
+  liveVideoVisible.value = false
   livePlayRequested.value = !livePlayRequested.value
+}
+const onLivePlaying = () => {
+  // 等到下一次绘制再显现，确保第一帧已经进入视频合成层。
+  requestAnimationFrame(() => {
+    if (livePlayRequested.value) liveVideoVisible.value = true
+  })
 }
 // 视频自然播完：卸载视频回到封面图，等待用户点击重播。
 const onLiveEnded = () => {
+  liveVideoVisible.value = false
+  livePlayRequested.value = false
+}
+const onLiveError = () => {
+  liveVideoVisible.value = false
   livePlayRequested.value = false
 }
 watch(weakNetwork, (weak) => {
-  if (weak && livePlayRequested.value) livePlayRequested.value = false
+  if (weak && livePlayRequested.value) {
+    liveVideoVisible.value = false
+    livePlayRequested.value = false
+  }
 })
 
 // 拖拽状态
@@ -626,6 +650,7 @@ const isLightboxVisible = ref(false)
 
 // 卡片切换：重置实况图播放意图，并对未就绪的当前封面启动弱网慢加载探测。
 watch(currentPhoto, (photo) => {
+  liveVideoVisible.value = false
   livePlayRequested.value = !weakNetwork.value && photo?.file_type === 'live_photo'
   if (photo && !loadedThumbIds.value.has(photo.id)) {
     armSlowLoadProbe(photo.id)
@@ -1093,6 +1118,15 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.live-photo-video::-webkit-media-controls,
+.live-photo-video::-webkit-media-controls-enclosure,
+.live-photo-video::-webkit-media-controls-panel,
+.live-photo-video::-webkit-media-controls-play-button,
+.live-photo-video::-webkit-media-controls-start-playback-button {
+  display: none !important;
+  -webkit-appearance: none;
+}
+
 .guide-fade-enter-active,
 .guide-fade-leave-active {
   transition: opacity 0.25s ease;


### PR DESCRIPTION
## 描述
修复 Android 等移动端环境中实况图视频加载时暴露巨大原生播放占位图标的问题。

视频元素在首帧真正开始播放前保持透明，由照片封面承接加载过程；开始播放后以短暂淡入过渡显示。播放失败或结束时回退到封面，并通过 WebKit 媒体控件样式进一步屏蔽浏览器原生播放按钮。照片筛选页和照片详情页采用一致行为。

## 变更类型
- [x] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [ ] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue
Closes #204

## 如何测试
- 在 `package/website` 执行 `pnpm build`，构建通过。
- 在弱网或移动端 WebView 中打开实况图：加载期间应持续显示封面，不出现原生播放占位图；开始播放后视频平滑淡入；播放结束或失败后恢复封面。

## 检查清单
- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [ ] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [ ] 我已更新了相关文档