### PR TITLE
fix(backup): 修复手机备份重复、时间与实况图完整性

### DIFF
--- a/package/server/app/api/media.py
+++ b/package/server/app/api/media.py
@@ -2,6 +2,9 @@ import json
 import os
 import shutil
 import uuid
+import re
+import logging
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Header, Request, status, Form, UploadFile, File, Query
@@ -40,6 +43,68 @@ def _existing_backup_photo(db: Session, user_id: UUID, backup_key: Optional[str]
     ).first()
 
 
+def _normalized_md5(value: Optional[str]) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{32}", normalized):
+        raise HTTPException(status_code=400, detail="content_md5 must be a 32-character hexadecimal MD5")
+    return normalized
+
+
+def _existing_content_photo(db: Session, user_id: UUID, content_md5: Optional[str]):
+    if not content_md5:
+        return None
+    candidates = db.query(Photo).filter(
+        Photo.owner_id == user_id,
+        Photo.md5 == content_md5,
+        Photo.is_deleted == False,
+    ).all()
+    return next((photo for photo in candidates if photo.file_path and os.path.isfile(photo.file_path)), None)
+
+
+def _existing_content_hashes(db: Session, user_id: UUID, hashes: list[str]) -> list[str]:
+    if not hashes:
+        return []
+    rows = db.query(Photo.md5, Photo.file_path).filter(
+        Photo.owner_id == user_id,
+        Photo.is_deleted == False,
+        Photo.md5.in_(hashes),
+    ).all()
+    return list(dict.fromkeys(md5 for md5, file_path in rows if file_path and os.path.isfile(file_path)))
+
+
+def _apply_mobile_source_metadata(
+    db: Session, photo: Photo, source_photo_time: Optional[datetime], content_md5: Optional[str]
+) -> Photo:
+    changed = False
+    normalized_time = source_photo_time.replace(tzinfo=None) if source_photo_time is not None else None
+    current_time = getattr(photo, "photo_time", None)
+    upload_time = getattr(photo, "upload_time", None)
+    used_upload_fallback = current_time is None or (
+        upload_time is not None and abs((current_time - upload_time).total_seconds()) <= 5
+    )
+    if normalized_time is not None and used_upload_fallback and current_time != normalized_time:
+        # Photo.photo_time is stored as a timezone-naive local wall-clock value.
+        photo.photo_time = normalized_time
+        changed = True
+    if content_md5 and not photo.md5:
+        photo.md5 = content_md5
+        changed = True
+    if changed:
+        db.commit()
+        db.refresh(photo)
+    return photo
+
+
+def _preserve_source_file_time(file_path: str, source_photo_time: Optional[datetime]) -> None:
+    if source_photo_time is None:
+        return
+    normalized = source_photo_time.replace(tzinfo=None)
+    timestamp = normalized.timestamp()
+    os.utime(file_path, (timestamp, timestamp))
+
+
 @router.post('/backup/check', response_model=BaseResponse[dict])
 def check_mobile_backup_assets(
     payload: dict,
@@ -47,29 +112,71 @@ def check_mobile_backup_assets(
     current_user: User = Depends(get_current_user),
 ):
     keys = payload.get("keys") if isinstance(payload, dict) else None
+    hashes = payload.get("hashes", []) if isinstance(payload, dict) else None
+    source_times = payload.get("source_times", {}) if isinstance(payload, dict) else None
     if not isinstance(keys, list) or len(keys) > 200 or any(not isinstance(key, str) for key in keys):
         raise HTTPException(status_code=400, detail="keys must be a string array with at most 200 items")
+    if not isinstance(hashes, list) or len(hashes) > 200 or any(not isinstance(value, str) for value in hashes):
+        raise HTTPException(status_code=400, detail="hashes must be a string array with at most 200 items")
+    if not isinstance(source_times, dict) or len(source_times) > 200:
+        raise HTTPException(status_code=400, detail="source_times must be an object with at most 200 items")
+    parsed_source_times: dict[str, datetime] = {}
+    try:
+        for key, value in source_times.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError
+            parsed_source_times[key[:255]] = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="source_times contains an invalid datetime") from exc
+    normalized_hashes = list(dict.fromkeys(_normalized_md5(value) for value in hashes if value))
     normalized = list(dict.fromkeys(key[:255] for key in keys if key))
     if not normalized:
-        return BaseResponse.success(data={"existing": [], "complete": [], "live_photos": []})
-    rows = db.query(Photo.backup_key, Photo.file_type, Photo.file_path).filter(
+        existing_hashes = []
+        if normalized_hashes:
+            existing_hashes = _existing_content_hashes(db, current_user.id, normalized_hashes)
+        return BaseResponse.success(data={"existing": [], "complete": [], "live_photos": [], "hashes": existing_hashes})
+    photos = db.query(Photo).filter(
         Photo.owner_id == current_user.id,
         Photo.backup_key.in_(normalized),
     ).all()
     existing: list[str] = []
     complete: list[str] = []
     live_photos: list[str] = []
-    for backup_key, file_type, file_path in rows:
-        existing.append(backup_key)
-        if not file_path or not os.path.isfile(file_path):
+    repaired_live_type = False
+    for photo in photos:
+        existing.append(photo.backup_key)
+        if not photo.file_path or not os.path.isfile(photo.file_path):
             continue
-        complete.append(backup_key)
-        if file_type == FileType.live_photo and storage.get_live_photo_vide(file_path):
-            live_photos.append(backup_key)
+        complete.append(photo.backup_key)
+        live_video = storage.get_live_photo_vide(photo.file_path)
+        if not live_video:
+            thumb_path = _get_thumbnail_path(photo.owner_id, photo.id, db, 'medium')
+            embedded_video = os.path.splitext(thumb_path)[0] + '.mp4'
+            if os.path.isfile(embedded_video):
+                live_video = embedded_video
+        if live_video:
+            live_photos.append(photo.backup_key)
+            if photo.file_type != FileType.live_photo:
+                photo.file_type = FileType.live_photo
+                db.add(photo)
+                repaired_live_type = True
+    if repaired_live_type:
+        db.commit()
+    if parsed_source_times:
+        metadata_photos = db.query(Photo).filter(
+            Photo.owner_id == current_user.id,
+            Photo.backup_key.in_(list(parsed_source_times)),
+        ).all()
+        for photo in metadata_photos:
+            _apply_mobile_source_metadata(db, photo, parsed_source_times.get(photo.backup_key), None)
+    existing_hashes = []
+    if normalized_hashes:
+        existing_hashes = _existing_content_hashes(db, current_user.id, normalized_hashes)
     return BaseResponse.success(data={
         "existing": existing,
         "complete": complete,
         "live_photos": live_photos,
+        "hashes": existing_hashes,
     })
 
 
@@ -420,6 +527,10 @@ def _attach_live_photo_video(
     image_photo.file_type = FileType.live_photo
     db.commit()
     db.refresh(image_photo)
+    logging.getLogger(__name__).info(
+        "Saved mobile live-photo companion: photo_id=%s image=%s video=%s bytes=%s",
+        image_photo.id, image_photo.file_path, target_path, os.path.getsize(target_path),
+    )
 
     if companion and companion.id != image_photo.id:
         same_file = os.path.normcase(os.path.abspath(companion.file_path)) == os.path.normcase(os.path.abspath(target_path))
@@ -482,6 +593,8 @@ async def upload_photo_generic(
         album_id: Optional[UUID] = Form(None),
         folder: Optional[str] = Form(None),
         backup_key: Optional[str] = Form(None),
+        source_photo_time: Optional[datetime] = Form(None),
+        content_md5: Optional[str] = Form(None),
         companion_backup_key: Optional[str] = Form(None),
         live_photo_video: Optional[UploadFile] = File(None),
         replace_existing: bool = Form(False),
@@ -497,8 +610,11 @@ async def upload_photo_generic(
         replace_existing = False
     if not isinstance(backup_key, str):
         backup_key = None
+    if not isinstance(source_photo_time, datetime):
+        source_photo_time = None
     if backup_key and len(backup_key) > 255:
         raise HTTPException(status_code=400, detail="backup_key is too long")
+    content_md5 = _normalized_md5(content_md5)
     if live_photo_video:
         image_stem, image_ext = os.path.splitext(file.filename or '')
         video_stem, video_ext = os.path.splitext(live_photo_video.filename or '')
@@ -513,6 +629,7 @@ async def upload_photo_generic(
     if existing:
         if replace_existing:
             existing = await run_in_threadpool(_replace_backup_file, db, existing, file, current_user.id)
+            await run_in_threadpool(_preserve_source_file_time, existing.file_path, source_photo_time)
         if live_photo_video:
             await run_in_threadpool(
                 _attach_live_photo_video, db, existing, live_photo_video, companion_backup_key, current_user.id
@@ -522,7 +639,18 @@ async def upload_photo_generic(
                 add_tasks, db, current_user.id, existing.id, existing.file_path,
                 _live_photo_video_path(existing.file_path, live_photo_video.filename) if live_photo_video else None,
             )
-        return existing
+        return await run_in_threadpool(
+            _apply_mobile_source_metadata, db, existing, source_photo_time, content_md5
+        )
+    duplicate = await run_in_threadpool(_existing_content_photo, db, current_user.id, content_md5)
+    if duplicate:
+        if live_photo_video:
+            await run_in_threadpool(
+                _attach_live_photo_video, db, duplicate, live_photo_video, companion_backup_key, current_user.id
+            )
+        return await run_in_threadpool(
+            _apply_mobile_source_metadata, db, duplicate, source_photo_time, content_md5
+        )
     if album_id:
         # Verify album exists
         db_album = await run_in_threadpool(crud_album.get_album, db, album_id=album_id, user_id=current_user.id)
@@ -534,12 +662,17 @@ async def upload_photo_generic(
     # Save file
     try:
         file_path = await run_in_threadpool(storage.save_upload_file, file, photo_id, current_user.id, folder, db)
+        await run_in_threadpool(_preserve_source_file_time, file_path, source_photo_time)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     # Create and Save
     live_photo_video_path = None
     try:
-        photo = await run_in_threadpool(save_and_create_photo, db, file_path, file.filename, album_id, photo_id, user_id=current_user.id, backup_key=backup_key)
+        photo = await run_in_threadpool(
+            save_and_create_photo, db, file_path, file.filename, album_id, photo_id,
+            user_id=current_user.id, backup_key=backup_key,
+            source_photo_time=source_photo_time, source_md5=content_md5,
+        )
         if live_photo_video:
             live_photo_video_path = await run_in_threadpool(
                 _attach_live_photo_video, db, photo, live_photo_video, companion_backup_key, current_user.id
@@ -597,6 +730,8 @@ async def finish_upload_generic(
         album_id: Optional[UUID] = Form(None),
         folder: Optional[str] = Form(None),
         backup_key: Optional[str] = Form(None),
+        source_photo_time: Optional[datetime] = Form(None),
+        content_md5: Optional[str] = Form(None),
         companion_backup_key: Optional[str] = Form(None),
         live_photo_video: Optional[UploadFile] = File(None),
         replace_existing: bool = Form(False),
@@ -611,8 +746,11 @@ async def finish_upload_generic(
         replace_existing = False
     if not isinstance(backup_key, str):
         backup_key = None
+    if not isinstance(source_photo_time, datetime):
+        source_photo_time = None
     if backup_key and len(backup_key) > 255:
         raise HTTPException(status_code=400, detail="backup_key is too long")
+    content_md5 = _normalized_md5(content_md5)
     if live_photo_video:
         image_stem, image_ext = os.path.splitext(file_name or '')
         video_stem, video_ext = os.path.splitext(live_photo_video.filename or '')
@@ -637,6 +775,7 @@ async def finish_upload_generic(
             existing = await run_in_threadpool(
                 _replace_backup_file_from_chunks, db, existing, chunk_dir, chunks, current_user.id
             )
+            await run_in_threadpool(_preserve_source_file_time, existing.file_path, source_photo_time)
         if live_photo_video:
             await run_in_threadpool(
                 _attach_live_photo_video, db, existing, live_photo_video, companion_backup_key, current_user.id
@@ -648,7 +787,19 @@ async def finish_upload_generic(
             )
         else:
             await run_in_threadpool(shutil.rmtree, _chunk_dir(current_user.id, upload_id, db), True)
-        return existing
+        return await run_in_threadpool(
+            _apply_mobile_source_metadata, db, existing, source_photo_time, content_md5
+        )
+    duplicate = await run_in_threadpool(_existing_content_photo, db, current_user.id, content_md5)
+    if duplicate:
+        await run_in_threadpool(shutil.rmtree, _chunk_dir(current_user.id, upload_id, db), True)
+        if live_photo_video:
+            await run_in_threadpool(
+                _attach_live_photo_video, db, duplicate, live_photo_video, companion_backup_key, current_user.id
+            )
+        return await run_in_threadpool(
+            _apply_mobile_source_metadata, db, duplicate, source_photo_time, content_md5
+        )
     if album_id:
         # Verify album exists
         db_album = await run_in_threadpool(crud_album.get_album, db, album_id=album_id, user_id=current_user.id)
@@ -693,13 +844,18 @@ async def finish_upload_generic(
         
     try:
         final_path = await run_in_threadpool(merge_and_save)
+        await run_in_threadpool(_preserve_source_file_time, final_path, source_photo_time)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     # Create and Save
     live_photo_video_path = None
     try:
-        photo = await run_in_threadpool(save_and_create_photo, db, final_path, file_name, album_id, photo_id, user_id=current_user.id, backup_key=backup_key)
+        photo = await run_in_threadpool(
+            save_and_create_photo, db, final_path, file_name, album_id, photo_id,
+            user_id=current_user.id, backup_key=backup_key,
+            source_photo_time=source_photo_time, source_md5=content_md5,
+        )
         if live_photo_video:
             live_photo_video_path = await run_in_threadpool(
                 _attach_live_photo_video, db, photo, live_photo_video, companion_backup_key, current_user.id

--- a/package/server/app/crud/photo.py
+++ b/package/server/app/crud/photo.py
@@ -169,7 +169,11 @@ def get_photo_metadata(db: Session, photo_id: UUID, user_id: UUID = None):
     return query.first()
 
 
-def save_and_create_photo(db: Session, file_path: str, file_name: str, album_id: Optional[UUID], photo_id: UUID, user_id: UUID = None, backup_key: Optional[str] = None):
+def save_and_create_photo(
+    db: Session, file_path: str, file_name: str, album_id: Optional[UUID], photo_id: UUID,
+    user_id: UUID = None, backup_key: Optional[str] = None,
+    source_photo_time: Optional[datetime] = None, source_md5: Optional[str] = None,
+):
     # Determine file type
     ext = os.path.splitext(file_name)[1]
     file_type = FileType.image
@@ -192,7 +196,8 @@ def save_and_create_photo(db: Session, file_path: str, file_name: str, album_id:
         height=height,
         duration=duration,
         filename=file_name,
-        photo_time=extracted_meta["photo_time"]
+        photo_time=extracted_meta["photo_time"] or source_photo_time,
+        md5=source_md5,
     )
 
     db_photo = create_photo(db, photo_create, album_id, file_path, photo_id=photo_id, user_id=user_id, backup_key=backup_key)
@@ -856,6 +861,7 @@ def create_photo(db: Session, photo: photo_schemas.PhotoCreate, album_id: Option
         photo_time=photo.photo_time or datetime.now(),
         owner_id=user_id,
         backup_key=backup_key,
+        md5=photo.md5,
     )
 
     if album_id:

--- a/package/server/app/service/tasks/basic.py
+++ b/package/server/app/service/tasks/basic.py
@@ -16,7 +16,7 @@ register_heif_opener()
 from sqlalchemy.orm import Session
 
 from app.db.models.task import Task, TaskStatus, TaskType
-from app.db.models.photo import FileType
+from app.db.models.photo import FileType, Photo
 from app.db.models.index_log import IndexLog
 import app.crud.photo
 from app.schemas.metadata import PhotoMetadataCreate
@@ -359,7 +359,27 @@ class BasicTaskStrategy(BaseTaskStrategy):
         # 分支 B：Photo 已存在，走 "先查再插/更新" 幂等补齐 PhotoMetadata。
         for data in pre_created_items:
             photo_id = str(data['photo_id'])
+            photo_schema = data.get('photo')
             meta_schema = data.get('metadata')
+            # 手机上传会先创建 Photo，再异步执行 PROCESS_BASIC。Motion Photo
+            # 的内嵌视频是在这个阶段才被识别和提取，因此必须把检测结果
+            # 回写到预创建记录，否则前端永远只会把它当普通图片。
+            try:
+                db_photo = db.get(Photo, data['photo_id'])
+                if db_photo is not None and photo_schema is not None:
+                    if photo_schema.file_type == FileType.live_photo:
+                        db_photo.file_type = FileType.live_photo
+                    if photo_schema.md5 and not db_photo.md5:
+                        db_photo.md5 = photo_schema.md5
+                    for field in ('size', 'width', 'height', 'duration'):
+                        value = getattr(photo_schema, field, None)
+                        if value is not None:
+                            setattr(db_photo, field, value)
+                    db.add(db_photo)
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    f"Failed to refresh pre-created photo {photo_id}: {e}"
+                )
             if not meta_schema:
                 continue
             try:

--- a/package/server/tests/unit/test_media_api.py
+++ b/package/server/tests/unit/test_media_api.py
@@ -60,21 +60,78 @@ def test_backup_check_distinguishes_existing_complete_and_live_photo(tmp_path):
 
     db = MagicMock()
     db.query.return_value.filter.return_value.all.return_value = [
-        ("photo", FileType.image, str(photo)),
-        ("live", FileType.live_photo, str(live_image)),
-        ("incomplete-live", FileType.live_photo, str(incomplete_live)),
-        ("missing", FileType.image, str(tmp_path / "missing.jpg")),
+        SimpleNamespace(id=uuid4(), owner_id=owner_id, backup_key="photo", file_type=FileType.image, file_path=str(photo)),
+        SimpleNamespace(id=uuid4(), owner_id=owner_id, backup_key="live", file_type=FileType.live_photo, file_path=str(live_image)),
+        SimpleNamespace(id=uuid4(), owner_id=owner_id, backup_key="incomplete-live", file_type=FileType.live_photo, file_path=str(incomplete_live)),
+        SimpleNamespace(id=uuid4(), owner_id=owner_id, backup_key="missing", file_type=FileType.image, file_path=str(tmp_path / "missing.jpg")),
     ]
 
-    result = media_api.check_mobile_backup_assets(
-        {"keys": ["photo", "live", "incomplete-live", "missing"]},
-        db=db,
-        current_user=SimpleNamespace(id=owner_id),
-    )
+    with patch.object(media_api, "_get_thumbnail_path", side_effect=lambda _owner, photo_id, _db, _size: str(tmp_path / f"{photo_id}.webp")):
+        result = media_api.check_mobile_backup_assets(
+            {"keys": ["photo", "live", "incomplete-live", "missing"]},
+            db=db,
+            current_user=SimpleNamespace(id=owner_id),
+        )
 
     assert set(result.data["existing"]) == {"photo", "live", "incomplete-live", "missing"}
     assert set(result.data["complete"]) == {"photo", "live", "incomplete-live"}
     assert result.data["live_photos"] == ["live"]
+
+
+def test_backup_check_repairs_image_type_when_mp4_sidecar_exists(tmp_path):
+    owner_id = uuid4()
+    image = tmp_path / "IMG_0001.jpg"
+    image.write_bytes(b"image")
+    image.with_suffix(".mp4").write_bytes(b"video")
+    photo = SimpleNamespace(
+        id=uuid4(), owner_id=owner_id, backup_key="image-key",
+        file_type=FileType.image, file_path=str(image),
+    )
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [photo]
+
+    result = media_api.check_mobile_backup_assets(
+        {"keys": ["image-key"]}, db=db, current_user=SimpleNamespace(id=owner_id),
+    )
+
+    assert result.data["live_photos"] == ["image-key"]
+    assert photo.file_type == FileType.live_photo
+    db.commit.assert_called_once()
+
+
+def test_mobile_source_metadata_repairs_upload_time_fallback_without_overwriting_exif():
+    db = MagicMock()
+    upload_time = media_api.datetime(2026, 9, 8, 8, 0, 0)
+    phone_time = media_api.datetime(2024, 2, 3, 10, 20, 30)
+    fallback_photo = SimpleNamespace(photo_time=upload_time, upload_time=upload_time, md5=None)
+
+    media_api._apply_mobile_source_metadata(db, fallback_photo, phone_time, "a" * 32)
+
+    assert fallback_photo.photo_time == phone_time
+    assert fallback_photo.md5 == "a" * 32
+
+    exif_time = media_api.datetime(2023, 1, 2, 3, 4, 5)
+    exif_photo = SimpleNamespace(photo_time=exif_time, upload_time=upload_time, md5="b" * 32)
+    media_api._apply_mobile_source_metadata(db, exif_photo, phone_time, "c" * 32)
+    assert exif_photo.photo_time == exif_time
+    assert exif_photo.md5 == "b" * 32
+
+
+def test_mobile_md5_validation_normalizes_hex_and_rejects_invalid_values():
+    assert media_api._normalized_md5("A" * 32) == "a" * 32
+    with pytest.raises(HTTPException) as exc_info:
+        media_api._normalized_md5("not-an-md5")
+    assert exc_info.value.status_code == 400
+
+
+def test_mobile_source_time_is_preserved_as_file_mtime(tmp_path):
+    target = tmp_path / "no-exif.jpg"
+    target.write_bytes(b"image")
+    source_time = media_api.datetime(2024, 6, 7, 8, 9, 10)
+
+    media_api._preserve_source_file_time(str(target), source_time)
+
+    assert abs(target.stat().st_mtime - source_time.timestamp()) < 1
 
 
 def test_attach_live_photo_video_replaces_companion_atomically(tmp_path):

--- a/package/server/tests/unit/test_nightly_basic_batch_gaps_20260818.py
+++ b/package/server/tests/unit/test_nightly_basic_batch_gaps_20260818.py
@@ -481,6 +481,30 @@ def test_handle_completion_pre_created_inserts_photo_metadata(monkeypatch):
     assert worker.scan_status["added"] == 0
 
 
+def test_handle_completion_marks_pre_created_motion_photo_as_live(monkeypatch):
+    from app.db.models.photo import FileType
+
+    strategy = _strategy()
+    db = MagicMock()
+    db_photo = SimpleNamespace(
+        file_type=FileType.image, md5=None, size=1, width=None, height=None, duration=None,
+    )
+    db.get.return_value = db_photo
+    db.query.return_value.filter.return_value.first.return_value = None
+    worker = MagicMock()
+    worker.scan_status = {"added": 0, "processed_files": 0}
+    photo_id = uuid4()
+    data = _photo_create_data(photo_id, str(uuid4()), is_pre_created=True)
+    data["photo"].file_type = FileType.live_photo
+    data["photo"].md5 = "f" * 32
+    item = {"status": "completed", "task_id": uuid4(), "result": {"photo_create_data": data}}
+
+    _run(strategy.handle_completion(worker, [item], db))
+
+    assert db_photo.file_type == FileType.live_photo
+    assert db_photo.md5 == "f" * 32
+
+
 def test_handle_completion_skips_metadata_when_no_metadata_schema():
     strategy = _strategy()
     db = MagicMock()

--- a/package/server/tests/unit/test_nightly_crud_photo_gaps_20260821.py
+++ b/package/server/tests/unit/test_nightly_crud_photo_gaps_20260821.py
@@ -179,6 +179,26 @@ def test_save_and_create_photo_defaults_to_image_for_jpg():
     assert db_photo.file_type == FileType.image
 
 
+def test_save_and_create_photo_uses_phone_time_and_md5_when_file_has_no_timestamp():
+    from app.crud import photo as crud_photo
+
+    db = MagicMock()
+    phone_time = datetime(2024, 6, 7, 8, 9, 10)
+    digest = "d" * 32
+    with _ALBUM_PATCHES, \
+         patch.object(crud_photo.storage, "generate_thumbnail"), \
+         patch.object(crud_photo.storage, "get_file_size", return_value=512), \
+         patch.object(crud_photo.storage, "get_image_dimensions", return_value=(640, 480, 0.0)), \
+         patch.object(crud_photo, "extract_metadata", return_value={"photo_time": None}):
+        db_photo = crud_photo.save_and_create_photo(
+            db, "/data/no-exif.jpg", "no-exif.jpg", None, uuid4(),
+            source_photo_time=phone_time, source_md5=digest,
+        )
+
+    assert db_photo.photo_time == phone_time
+    assert db_photo.md5 == digest
+
+
 # ---------------------------------------------------------------------------
 # replace_photo_file
 # ---------------------------------------------------------------------------

--- a/package/website/android/app/src/main/java/cn/trailsnap/app/GalleryBackupPlugin.java
+++ b/package/website/android/app/src/main/java/cn/trailsnap/app/GalleryBackupPlugin.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -167,7 +168,15 @@ public class GalleryBackupPlugin extends Plugin {
             List<Asset> regularVideos = includeVideos && videoPermissionGranted()
                 ? query(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, "video", videoModified, videoId, limit, sourcePaths, false)
                 : new ArrayList<>();
-            List<Asset> probedVideos = videoPermissionGranted()
+            // A fresh image scan already discovers each image's companion by
+            // name. Starting the late-companion probe at video id 0 would walk
+            // the entire historical video library again and return old live
+            // photos as if they were new backup work.
+            boolean initializeCompanionCursor = shouldInitializeCompanionCursor(companionVideoId, imageModified, imageId);
+            long companionBaselineId = initializeCompanionCursor && videoPermissionGranted()
+                ? latestAssetId(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, sourcePaths)
+                : companionVideoId;
+            List<Asset> probedVideos = videoPermissionGranted() && !initializeCompanionCursor
                 ? query(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, "video", 0L, companionVideoId, limit, sourcePaths, true)
                 : new ArrayList<>();
             for (Asset asset : images) asset.liveCompanion = findLiveCompanion(asset);
@@ -205,7 +214,7 @@ public class GalleryBackupPlugin extends Plugin {
                 nextVideoModified = lastRegularVideo.modifiedMs;
                 nextVideoId = lastRegularVideo.id;
             }
-            long nextCompanionVideoId = companionVideoId;
+            long nextCompanionVideoId = companionBaselineId;
             if (!probedVideos.isEmpty()) nextCompanionVideoId = probedVideos.get(probedVideos.size() - 1).id;
             JSObject result = new JSObject();
             result.put("assets", items);
@@ -265,6 +274,37 @@ public class GalleryBackupPlugin extends Plugin {
             }
         }
         return new long[] { count, bytes };
+    }
+
+    private long latestAssetId(Uri collection, List<String> sourcePaths) {
+        StringBuilder where = new StringBuilder("1 = 1");
+        List<String> args = new ArrayList<>();
+        appendSourcePathSelection(where, args, sourcePaths);
+        ContentResolver resolver = getContext().getContentResolver();
+        Cursor queried;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Bundle queryArgs = new Bundle();
+            queryArgs.putString(ContentResolver.QUERY_ARG_SQL_SELECTION, where.toString());
+            queryArgs.putStringArray(ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS, args.toArray(new String[0]));
+            queryArgs.putStringArray(ContentResolver.QUERY_ARG_SORT_COLUMNS, new String[] { MediaStore.MediaColumns._ID });
+            queryArgs.putInt(ContentResolver.QUERY_ARG_SORT_DIRECTION, ContentResolver.QUERY_SORT_DIRECTION_DESCENDING);
+            queryArgs.putInt(ContentResolver.QUERY_ARG_LIMIT, 1);
+            queried = resolver.query(collection, new String[] { MediaStore.MediaColumns._ID }, queryArgs, null);
+        } else {
+            queried = resolver.query(collection, new String[] { MediaStore.MediaColumns._ID }, where.toString(),
+                args.toArray(new String[0]), MediaStore.MediaColumns._ID + " DESC LIMIT 1");
+        }
+        try (Cursor cursor = queried) {
+            return cursor != null && cursor.moveToFirst() ? cursor.getLong(0) : 0L;
+        }
+    }
+
+    static boolean shouldInitializeCompanionCursor(long companionVideoId, long imageModified, long imageId) {
+        return companionVideoId == 0L && imageModified == 0L && imageId == 0L;
+    }
+
+    static long chooseTakenMs(long dateTakenMs, long dateAddedSeconds) {
+        return dateTakenMs > 0L ? dateTakenMs : Math.max(0L, dateAddedSeconds) * 1000L;
     }
 
     @PluginMethod
@@ -421,7 +461,7 @@ public class GalleryBackupPlugin extends Plugin {
         String[] projection = {
             MediaStore.MediaColumns._ID, MediaStore.MediaColumns.DISPLAY_NAME, MediaStore.MediaColumns.MIME_TYPE,
             MediaStore.MediaColumns.SIZE, MediaStore.MediaColumns.DATE_MODIFIED, takenColumnName,
-            pathColumn
+            MediaStore.MediaColumns.DATE_ADDED, pathColumn
         };
         SelectionSpec selection = idOnly
             ? buildIdSelection(afterId, sourcePaths)
@@ -452,6 +492,7 @@ public class GalleryBackupPlugin extends Plugin {
             int sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE);
             int modifiedColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_MODIFIED);
             int takenColumn = cursor.getColumnIndex(takenColumnName);
+            int addedColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_ADDED);
             int pathIndex = cursor.getColumnIndexOrThrow(pathColumn);
             while (cursor.moveToNext()) {
                 long id = cursor.getLong(idColumn);
@@ -467,7 +508,7 @@ public class GalleryBackupPlugin extends Plugin {
                     cursor.getString(mimeColumn),
                     cursor.getLong(sizeColumn),
                     cursor.getLong(modifiedColumn) * 1000L,
-                    takenColumn >= 0 ? cursor.getLong(takenColumn) : 0L,
+                    chooseTakenMs(takenColumn >= 0 ? cursor.getLong(takenColumn) : 0L, cursor.getLong(addedColumn)),
                     relativePath,
                     mediaDirectory,
                     Uri.withAppendedPath(collection, String.valueOf(id))
@@ -633,7 +674,8 @@ public class GalleryBackupPlugin extends Plugin {
             : MediaStore.Images.ImageColumns.DATE_TAKEN;
         String[] projection = {
             MediaStore.MediaColumns._ID, MediaStore.MediaColumns.DISPLAY_NAME, MediaStore.MediaColumns.MIME_TYPE,
-            MediaStore.MediaColumns.SIZE, MediaStore.MediaColumns.DATE_MODIFIED, takenColumnName, pathColumn
+            MediaStore.MediaColumns.SIZE, MediaStore.MediaColumns.DATE_MODIFIED, takenColumnName,
+            MediaStore.MediaColumns.DATE_ADDED, pathColumn
         };
         StringBuilder selection = new StringBuilder("LOWER(" + MediaStore.MediaColumns.DISPLAY_NAME + ") IN (");
         List<String> args = new ArrayList<>();
@@ -658,13 +700,14 @@ public class GalleryBackupPlugin extends Plugin {
             String relativePath = modern ? normalizeRelativePath(rawPath) : normalizeLegacyAssetPath(rawPath);
             String directory = modern ? normalizeRelativePath(rawPath) : new File(rawPath).getParent();
             int takenIndex = cursor.getColumnIndex(takenColumnName);
+            int addedIndex = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_ADDED);
             return new Asset(
                 id, kind,
                 cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)),
                 cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE)),
                 cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE)),
                 cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_MODIFIED)) * 1000L,
-                takenIndex >= 0 ? cursor.getLong(takenIndex) : 0L,
+                chooseTakenMs(takenIndex >= 0 ? cursor.getLong(takenIndex) : 0L, cursor.getLong(addedIndex)),
                 relativePath, directory, Uri.withAppendedPath(collection, String.valueOf(id))
             );
         } catch (SecurityException ignored) {
@@ -714,6 +757,37 @@ public class GalleryBackupPlugin extends Plugin {
         } catch (Exception error) {
             output.delete();
             call.reject("导出图库文件失败", error);
+        }
+    }
+
+    @PluginMethod
+    public void calculateAssetMd5(PluginCall call) {
+        String uriValue = call.getString("uri");
+        if (uriValue == null) {
+            call.reject("缺少图库资产 URI");
+            return;
+        }
+        Uri sourceUri = Uri.parse(uriValue);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (!originalMediaPermissionGranted()) {
+                call.reject("未授予照片位置权限，无法读取原始媒体文件", "ORIGINAL_MEDIA_PERMISSION_REQUIRED");
+                return;
+            }
+            sourceUri = MediaStore.setRequireOriginal(sourceUri);
+        }
+        try (InputStream input = getContext().getContentResolver().openInputStream(sourceUri)) {
+            if (input == null) throw new IllegalStateException("无法打开图库原始文件");
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] buffer = new byte[256 * 1024];
+            int read;
+            while ((read = input.read(buffer)) != -1) digest.update(buffer, 0, read);
+            StringBuilder hex = new StringBuilder(32);
+            for (byte value : digest.digest()) hex.append(String.format(Locale.ROOT, "%02x", value & 0xff));
+            JSObject result = new JSObject();
+            result.put("md5", hex.toString());
+            call.resolve(result);
+        } catch (Exception error) {
+            call.reject("计算图库文件 MD5 失败", error);
         }
     }
 

--- a/package/website/android/app/src/test/java/cn/trailsnap/app/GalleryBackupPluginTest.java
+++ b/package/website/android/app/src/test/java/cn/trailsnap/app/GalleryBackupPluginTest.java
@@ -2,6 +2,7 @@ package cn.trailsnap.app;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
@@ -32,5 +33,18 @@ public class GalleryBackupPluginTest {
     public void unsupportedExtensionsAreRejected() {
         assertFalse(GalleryBackupPlugin.isSupportedLivePairName("IMG_0001.png", "IMG_0001.mp4"));
         assertFalse(GalleryBackupPlugin.isSupportedLivePairName("IMG_0001.heic", "IMG_0001.mp4"));
+    }
+
+    @Test
+    public void freshScanBaselinesHistoricalCompanionVideosOnlyOnce() {
+        assertTrue(GalleryBackupPlugin.shouldInitializeCompanionCursor(0L, 0L, 0L));
+        assertFalse(GalleryBackupPlugin.shouldInitializeCompanionCursor(10L, 0L, 0L));
+        assertFalse(GalleryBackupPlugin.shouldInitializeCompanionCursor(0L, 1_000L, 2L));
+    }
+
+    @Test
+    public void mediaStoreDateAddedIsUsedWhenDateTakenIsMissing() {
+        assertEquals(1_700_000_000_123L, GalleryBackupPlugin.chooseTakenMs(1_700_000_000_123L, 42L));
+        assertEquals(1_700_000_000_000L, GalleryBackupPlugin.chooseTakenMs(0L, 1_700_000_000L));
     }
 }

--- a/package/website/src/api/album.ts
+++ b/package/website/src/api/album.ts
@@ -107,7 +107,7 @@ export const albumService = {
   },
 
   // Upload (Simple)
-  async uploadPhoto(file: File, albumId?: string, folder?: string, backupKey?: string, onProgress?: (loaded: number, total?: number) => void, replaceExisting = false) {
+  async uploadPhoto(file: File, albumId?: string, folder?: string, backupKey?: string, onProgress?: (loaded: number, total?: number) => void, replaceExisting = false, sourcePhotoTime?: string, contentMd5?: string) {
     const formData = new FormData();
     formData.append('file', file);
     if (albumId) {
@@ -115,6 +115,8 @@ export const albumService = {
     }
     if (folder) formData.append('folder', folder);
     if (backupKey) formData.append('backup_key', backupKey);
+    if (sourcePhotoTime) formData.append('source_photo_time', sourcePhotoTime);
+    if (contentMd5) formData.append('content_md5', contentMd5);
     if (replaceExisting) formData.append('replace_existing', 'true');
     const data = await request.post<Photo>('/api/medias', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
@@ -124,12 +126,14 @@ export const albumService = {
     return data.data;
   },
 
-  async uploadLivePhoto(image: File, video: File, folder: string | undefined, imageBackupKey: string, videoBackupKey: string, replaceExisting = false, onProgress?: (loaded: number, total?: number) => void) {
+  async uploadLivePhoto(image: File, video: File, folder: string | undefined, imageBackupKey: string, videoBackupKey: string, replaceExisting = false, onProgress?: (loaded: number, total?: number) => void, sourcePhotoTime?: string, contentMd5?: string) {
     const formData = new FormData();
     formData.append('file', image);
     formData.append('live_photo_video', video);
     formData.append('backup_key', imageBackupKey);
     formData.append('companion_backup_key', videoBackupKey);
+    if (sourcePhotoTime) formData.append('source_photo_time', sourcePhotoTime);
+    if (contentMd5) formData.append('content_md5', contentMd5);
     if (replaceExisting) formData.append('replace_existing', 'true');
     if (folder) formData.append('folder', folder);
     const data = await request.post<Photo>('/api/medias', formData, {
@@ -167,7 +171,7 @@ export const albumService = {
       });
   },
 
-  async finishUpload(uploadId: string, fileName: string, albumId?: string, folder?: string, backupKey?: string, replaceExisting = false) {
+  async finishUpload(uploadId: string, fileName: string, albumId?: string, folder?: string, backupKey?: string, replaceExisting = false, sourcePhotoTime?: string, contentMd5?: string) {
       const formData = new FormData();
       formData.append('upload_id', uploadId);
       formData.append('file_name', fileName);
@@ -176,18 +180,22 @@ export const albumService = {
       }
       if (folder) formData.append('folder', folder);
       if (backupKey) formData.append('backup_key', backupKey);
+      if (sourcePhotoTime) formData.append('source_photo_time', sourcePhotoTime);
+      if (contentMd5) formData.append('content_md5', contentMd5);
       if (replaceExisting) formData.append('replace_existing', 'true');
       const data = await request.post<Photo>('/api/medias/upload/finish', formData, { timeout: 120000 });
       return data.data;
   },
 
-  async finishLivePhotoUpload(uploadId: string, imageName: string, video: File, folder: string | undefined, imageBackupKey: string, videoBackupKey: string, replaceExisting = false, onProgress?: (loaded: number, total?: number) => void) {
+  async finishLivePhotoUpload(uploadId: string, imageName: string, video: File, folder: string | undefined, imageBackupKey: string, videoBackupKey: string, replaceExisting = false, onProgress?: (loaded: number, total?: number) => void, sourcePhotoTime?: string, contentMd5?: string) {
       const formData = new FormData();
       formData.append('upload_id', uploadId);
       formData.append('file_name', imageName);
       formData.append('live_photo_video', video);
       formData.append('backup_key', imageBackupKey);
       formData.append('companion_backup_key', videoBackupKey);
+      if (sourcePhotoTime) formData.append('source_photo_time', sourcePhotoTime);
+      if (contentMd5) formData.append('content_md5', contentMd5);
       if (replaceExisting) formData.append('replace_existing', 'true');
       if (folder) formData.append('folder', folder);
       const data = await request.post<Photo>('/api/medias/upload/finish', formData, {
@@ -197,18 +205,20 @@ export const albumService = {
       return data.data;
   },
 
-  async checkBackupKeys(keys: string[]) {
+  async checkBackupKeys(keys: string[], hashes: string[] = [], sourceTimes: Record<string, string> = {}) {
     const data = await request.post<{
       existing: string[]
       complete?: string[]
       live_photos?: string[]
-    }>('/api/medias/backup/check', { keys });
+      hashes?: string[]
+    }>('/api/medias/backup/check', { keys, hashes, source_times: sourceTimes });
     return {
       existing: new Set(data.data.existing),
       // Keep ordinary-photo backups compatible with servers predating the
       // richer completeness response.
       complete: new Set(data.data.complete ?? data.data.existing),
       livePhotos: new Set(data.data.live_photos ?? []),
+      hashes: new Set(data.data.hashes ?? []),
     };
   },
 

--- a/package/website/src/composables/useGalleryBackup.ts
+++ b/package/website/src/composables/useGalleryBackup.ts
@@ -46,6 +46,7 @@ interface BackupOperation {
   pair: LivePair | null
   coveredAssets: GalleryAsset[]
   replaceExisting: boolean
+  md5?: string
 }
 
 interface ActiveUpload {
@@ -150,8 +151,8 @@ async function saveSettings(next: GalleryBackupSettings) {
 }
 
 function cursorScopeKey(config: GalleryBackupSettings = settings.value) {
-  // v5 rechecks pairs previously rejected because Android MediaStore reported
-  // incompatible DATE_TAKEN values for the still image and companion video.
+  // Keep the v5 scope stable so upgrading does not force a full-library rescan.
+  // Fresh v5 cursors receive the corrected native companion-video baseline.
   const input = JSON.stringify({ version: 5, includeVideos: config.includeVideos, sourcePaths: [...config.sourcePaths].sort() })
   let hash = 2166136261
   for (let index = 0; index < input.length; index++) {
@@ -376,7 +377,10 @@ async function uploadAsset(
       await uploadChunks(uploadId, file, tuning, config, reportAbsolute)
       await waitIfPaused()
       await retryTransfer(
-        () => albumService.finishUpload(uploadId, file.name, undefined, destinationFolder(asset, config), asset.backupKey, replaceExisting),
+        () => albumService.finishUpload(
+          uploadId, file.name, undefined, destinationFolder(asset, config), asset.backupKey,
+          replaceExisting, sourcePhotoTime(asset), asset.contentMd5,
+        ),
         config,
       )
     } else {
@@ -385,6 +389,7 @@ async function uploadAsset(
         () => albumService.uploadPhoto(
           file, undefined, destinationFolder(asset, config), asset.backupKey,
           loaded => reportAbsolute(Math.min(file.size, loaded)), replaceExisting,
+          sourcePhotoTime(asset), asset.contentMd5,
         ),
         config,
       )
@@ -443,24 +448,32 @@ async function uploadLivePhoto(
       const uploadId = await retryTransfer(() => albumService.initUpload(), config)
       await uploadChunks(uploadId, imageFile.file, tuning, config, reportAbsolute)
       await waitIfPaused()
-      await retryTransfer(
+      const saved = await retryTransfer(
         () => albumService.finishLivePhotoUpload(
           uploadId, imageFile.file.name, videoFile.file, folder, image.backupKey, video.backupKey,
           replaceExisting,
           loaded => reportAbsolute(imageFile.file.size + loaded),
+          sourcePhotoTime(image), image.contentMd5,
         ),
         config,
       )
+      if (saved.file_type !== 'live_photo') {
+        throw new Error('服务端未保存实况照片的视频部分，请确认 App 与服务端已升级到同一版本')
+      }
     } else {
       await waitIfPaused()
-      await retryTransfer(
+      const saved = await retryTransfer(
         () => albumService.uploadLivePhoto(
           imageFile.file, videoFile.file, folder, image.backupKey, video.backupKey,
           replaceExisting,
           loaded => reportAbsolute(loaded),
+          sourcePhotoTime(image), image.contentMd5,
         ),
         config,
       )
+      if (saved.file_type !== 'live_photo') {
+        throw new Error('服务端未保存实况照片的视频部分，请确认 App 与服务端已升级到同一版本')
+      }
     }
     reportAbsolute(totalSize)
   } finally {
@@ -485,6 +498,14 @@ function destinationFolder(asset: GalleryAsset, config: GalleryBackupSettings) {
   if (config.organizeMode === 'preserve') return joinFolder(base, asset.relativePath)
   const date = new Date(asset.takenMs || asset.modifiedMs || Date.now())
   return joinFolder(base, String(date.getFullYear()), String(date.getMonth() + 1).padStart(2, '0'))
+}
+
+function sourcePhotoTime(asset: GalleryAsset) {
+  if (!asset.takenMs) return undefined
+  const date = new Date(asset.takenMs)
+  if (Number.isNaN(date.getTime())) return undefined
+  const pad = (value: number) => String(value).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
 }
 
 function updateQueueStatus(backupKey: string, next: BackupQueueStatus) {
@@ -559,6 +580,8 @@ async function runBackup(options: { manual?: boolean } = {}) {
     if (totalItems.value > 0) await syncNotification(true, 'running')
     await waitIfPaused()
     const completedLivePairs = new Set<string>()
+    const seenAssetKeys = new Set<string>()
+    const seenContentHashes = new Set<string>()
 
     while (true) {
       await waitIfPaused()
@@ -573,19 +596,34 @@ async function runBackup(options: { manual?: boolean } = {}) {
         if (page.hasMore) continue
         break
       }
+      const freshAssets = page.assets.filter(asset => {
+        if (seenAssetKeys.has(asset.backupKey)) return false
+        seenAssetKeys.add(asset.backupKey)
+        return true
+      })
+      if (!freshAssets.length) {
+        cursor.imageModified = page.imageModified
+        cursor.imageId = page.imageId
+        cursor.videoModified = page.videoModified
+        cursor.videoId = page.videoId
+        cursor.companionVideoId = page.companionVideoId
+        await saveCursor(cursor, runCursorKey)
+        if (page.hasMore) continue
+        break
+      }
       if (!runSettings.includeVideos) {
         // A returned video is a late companion for an image that was already
         // scanned, so it was not included in countAssets' image-only total.
-        totalItems.value += page.assets.filter(asset => asset.kind === 'video').length
+        totalItems.value += freshAssets.filter(asset => asset.kind === 'video').length
         const companionBytes = new Map<string, number>()
-        for (const asset of page.assets) {
+        for (const asset of freshAssets) {
           const pair = livePhotoPair(asset)
           if (pair) companionBytes.set(pair.video.backupKey, pair.video.size)
         }
         totalBytes.value += [...companionBytes.values()].reduce((sum, size) => sum + Math.max(0, size), 0)
       }
       const operations = new Map<string, BackupOperation>()
-      for (const asset of page.assets) {
+      for (const asset of freshAssets) {
         const pair = livePhotoPair(asset)
         const key = pair?.image.backupKey || asset.backupKey
         const existingOperation = operations.get(key)
@@ -613,15 +651,24 @@ async function runBackup(options: { manual?: boolean } = {}) {
         relativePath: operation.relativePath,
         status: 'pending',
       }))
-      const keysToCheck = new Set(page.assets.map(asset => asset.backupKey))
-      page.assets.forEach(asset => {
+      const keysToCheck = new Set(freshAssets.map(asset => asset.backupKey))
+      freshAssets.forEach(asset => {
         const pair = livePhotoPair(asset)
         if (pair) {
           keysToCheck.add(pair.image.backupKey)
           keysToCheck.add(pair.video.backupKey)
         }
       })
-      const presence = await albumService.checkBackupKeys([...keysToCheck])
+      const sourceTimes = Object.fromEntries(freshAssets.flatMap(asset => {
+        const values: Array<[string, string]> = []
+        const ownTime = sourcePhotoTime(asset)
+        if (ownTime) values.push([asset.backupKey, ownTime])
+        const pair = livePhotoPair(asset)
+        const imageTime = pair ? sourcePhotoTime(pair.image) : undefined
+        if (pair && imageTime) values.push([pair.image.backupKey, imageTime])
+        return values
+      }))
+      const presence = await albumService.checkBackupKeys([...keysToCheck], [], sourceTimes)
       const remaining: BackupOperation[] = []
       for (const operation of operations.values()) {
         const action = backupUploadAction(operation.key, Boolean(operation.pair), presence)
@@ -634,6 +681,34 @@ async function runBackup(options: { manual?: boolean } = {}) {
           if (operation.pair) completedLivePairs.add(operation.key)
         } else {
           remaining.push(operation)
+        }
+      }
+      // Stable MediaStore ids are the fast path. For assets not known by id,
+      // hash the original bytes locally and ask the server before transferring
+      // them. This also catches the same file appearing in multiple phone
+      // folders or under a changed MediaStore id.
+      const hashes: string[] = []
+      for (const operation of remaining) {
+        const primary = operation.pair?.image || operation.asset
+        const digest = await galleryBackupNative.calculateAssetMd5({ uri: primary.uri })
+        primary.contentMd5 = digest.md5.toLowerCase()
+        operation.md5 = primary.contentMd5
+        hashes.push(operation.md5)
+      }
+      const hashPresence = hashes.length ? await albumService.checkBackupKeys([], hashes) : null
+      for (let index = remaining.length - 1; index >= 0; index--) {
+        const operation = remaining[index]
+        const isDuplicate = !operation.pair && Boolean(operation.md5) && (
+          hashPresence?.hashes.has(operation.md5!) || seenContentHashes.has(operation.md5!)
+        )
+        if (isDuplicate) {
+          remaining.splice(index, 1)
+          updateQueueStatus(operation.key, 'skipped')
+          skipped.value++
+          processedItems.value += operation.coveredAssets.length
+          processedBytes.value += operation.coveredAssets.reduce((sum, asset) => sum + Math.max(0, asset.size), 0)
+        } else if (operation.md5) {
+          seenContentHashes.add(operation.md5)
         }
       }
       await syncNotification()

--- a/package/website/src/native/galleryBackup.ts
+++ b/package/website/src/native/galleryBackup.ts
@@ -11,6 +11,7 @@ export interface GalleryAsset {
   backupKey: string
   relativePath: string
   takenMs: number
+  contentMd5?: string
   liveCompanion?: GalleryAsset
 }
 
@@ -38,6 +39,7 @@ interface GalleryBackupNativePlugin {
   }>
   listAssets(options: GalleryCursor & { limit: number; includeVideos: boolean; sourcePaths: string[] }): Promise<GalleryCursor & { assets: GalleryAsset[]; hasMore: boolean }>
   exportAsset(options: { uri: string; fileName: string }): Promise<{ path: string }>
+  calculateAssetMd5(options: { uri: string }): Promise<{ md5: string }>
   releaseAsset(options: { path: string }): Promise<void>
   getNetworkStatus(): Promise<{ connected: boolean; wifi: boolean; unmetered: boolean }>
   countAssets(options: GalleryCursor & { includeVideos: boolean; sourcePaths: string[] }): Promise<{ count: number; bytes: number }>

--- a/package/website/src/utils/backupTransfer.ts
+++ b/package/website/src/utils/backupTransfer.ts
@@ -18,6 +18,7 @@ export interface BackupPresence {
   existing: ReadonlySet<string>
   complete: ReadonlySet<string>
   livePhotos: ReadonlySet<string>
+  hashes?: ReadonlySet<string>
 }
 
 export type BackupUploadAction = 'skip' | 'upload' | 'replace'


### PR DESCRIPTION
## 描述

修复 Android 手机备份中增量扫描重复、照片来源时间丢失、内容重复上传和 JPG+MP4 实况图视频缺失的问题。

主要改动：

- 新扫描时以当前视频游标作为伴随视频基线，避免反复探测全部历史视频；备份批次增加资源级去重。
- 从 Android MediaStore 读取拍摄/创建时间并传给服务端，作为缺少 EXIF 和文件名时间时的回退值，同时保留文件修改时间。
- 上传前计算 MD5，通过备份检查接口跳过服务端已有内容；服务端写入时再次执行内容去重。
- 支持同目录、同名主体的 JPG/JPEG+MP4/MOV 实况照片配对，确保视频伴随文件落盘并标记为 `live_photo`。
- 服务端未保存视频时客户端明确报错，不再静默推进备份游标；检查接口可修复已有伴随视频但类型仍为普通图片的记录。
- 修复预创建照片记录在 Motion Photo 提取完成后未更新为实况类型的问题。

## 变更类型

- [x] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [x] ⚡️ 性能优化 (Performance)
- [x] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue

Closes #208

## 如何测试

- `pwsh .\tests\scripts\run-tests.ps1 -Layer unit -Level smoke`
  - Server：2409 passed，48 deselected
  - AI：335 passed
  - CLI：13 passed
- `uv run python -m pytest tests/unit/test_media_api.py tests/unit/test_nightly_basic_batch_gaps_20260818.py tests/unit/test_media_streaming_api.py -q`
  - 55 passed
- `pnpm build`
  - 构建通过
- Android Gradle 测试在当前 Windows 环境启动前因 Java loopback 连接失败，未进入代码编译或测试阶段；由 CI 继续验证。

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有可运行的测试均已通过
- [ ] 我已更新了相关文档