### PR TITLE
fix(website): 保持照片删除后的浏览位置

### DIFF
--- a/package/website/src/components/UnifiedPhotoPage.vue
+++ b/package/website/src/components/UnifiedPhotoPage.vue
@@ -410,6 +410,36 @@ const restoreVisibleMonth = (anchor: { month?: string; top: number } | null) => 
   container.scrollBy({ top: delta, behavior: 'auto' })
 }
 
+const captureVisiblePhoto = (excludedIds: string[]) => {
+  const excluded = new Set(excludedIds)
+  const container = getScrollContainer()
+  const containerRect = container === window
+    ? { top: 0, bottom: window.innerHeight }
+    : (container as HTMLElement).getBoundingClientRect()
+  const gallery = (galleryRef.value?.$el as HTMLElement | undefined) ?? document
+  const element = Array.from(gallery.querySelectorAll<HTMLElement>('[data-photo-id]')).find((item) => {
+    const id = item.dataset.photoId
+    if (!id || excluded.has(id)) return false
+    const rect = item.getBoundingClientRect()
+    return rect.bottom > containerRect.top && rect.top < containerRect.bottom
+  })
+  return element
+    ? { id: element.dataset.photoId!, top: element.getBoundingClientRect().top }
+    : null
+}
+
+const restoreVisiblePhoto = (anchor: { id: string; top: number } | null) => {
+  if (!anchor) return
+  const gallery = (galleryRef.value?.$el as HTMLElement | undefined) ?? document
+  const element = gallery.querySelector<HTMLElement>(`[data-photo-id="${CSS.escape(anchor.id)}"]`)
+  if (!element) return
+  const container = getScrollContainer()
+  container.scrollBy({
+    top: element.getBoundingClientRect().top - anchor.top,
+    behavior: 'auto',
+  })
+}
+
 const handleRefreshData = () => {
   if (refreshingData.value || isPhotoInteractionActive.value) return
   refreshingData.value = true
@@ -681,6 +711,7 @@ const confirmMessage = computed(() => {
 })
 
 const confirmDelete = () => {
+    const scrollAnchor = captureVisiblePhoto(idsToDelete.value)
     emit('confirm-delete', idsToDelete.value, (success: boolean) => {
         if (success) {
             // Show particle if needed (usually for permanent delete)
@@ -689,6 +720,9 @@ const confirmDelete = () => {
             }
             galleryRef.value?.exitSelectionMode()
             if (lightboxDeleteId.value) closeLightbox()
+            nextTick(() => requestAnimationFrame(() => requestAnimationFrame(() => {
+                restoreVisiblePhoto(scrollAnchor)
+            })))
         }
         lightboxDeleteId.value = null
     })

--- a/package/website/src/stores/photoStore.ts
+++ b/package/website/src/stores/photoStore.ts
@@ -467,15 +467,44 @@ export const photoStoreSetup = () => {
       }
   }
 
-  const removeLocalPhoto = (photoId: string) => {
-      images.value = images.value.filter(img => img.id !== photoId);
-      // Clean map
+  const removeLocalPhotos = (photoIds: string[]) => {
+      const ids = new Set(photoIds);
+      const removedPhotos = images.value.filter(img => ids.has(img.id));
+      if (removedPhotos.length === 0) return;
+
+      images.value = images.value.filter(img => !ids.has(img.id));
       for (const [key, val] of photoOffsetMap.entries()) {
-          if (val.id === photoId) {
-              photoOffsetMap.delete(key);
-          }
+          if (ids.has(val.id)) photoOffsetMap.delete(key);
+      }
+
+      // Keep the virtual timeline in sync without clearing the whole gallery.
+      // A forced reload briefly collapses the virtual list and sends the user
+      // back to the top after every delete.
+      if (timelineStats.value) {
+          const removedByDay = new Map<string, number>();
+          removedPhotos.forEach((photo) => {
+              const date = new Date(photo.timestamp);
+              const key = `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+              removedByDay.set(key, (removedByDay.get(key) || 0) + 1);
+          });
+
+          timelineStats.value = {
+              ...timelineStats.value,
+              total_photos: Math.max(0, timelineStats.value.total_photos - removedPhotos.length),
+              timeline: timelineStats.value.timeline
+                  .map(item => ({
+                      ...item,
+                      count: Math.max(
+                          0,
+                          item.count - (removedByDay.get(`${item.year}-${item.month}-${item.day}`) || 0)
+                      )
+                  }))
+                  .filter(item => item.count > 0)
+          };
       }
   }
+
+  const removeLocalPhoto = (photoId: string) => removeLocalPhotos([photoId])
 
   const deletePhoto = async (photoId: string) => {
       await deletePhotos([photoId])
@@ -486,14 +515,7 @@ export const photoStoreSetup = () => {
           photo_ids: photoIds,
           action: 'delete'
       });
-      // Remove locally
-      images.value = images.value.filter(img => !photoIds.includes(img.id));
-      // Also update map
-      for (const [key, val] of photoOffsetMap.entries()) {
-          if (photoIds.includes(val.id)) {
-              photoOffsetMap.delete(key);
-          }
-      }
+      removeLocalPhotos(photoIds);
   }
   const resetAll = () => {
       timelineStats.value = { total_photos: 0, time_range: {start: null, end: null}, timeline: [] };
@@ -540,6 +562,7 @@ export const photoStoreSetup = () => {
     markDataStale,
     loadPhotosByMonth,
     removeLocalPhoto,
+    removeLocalPhotos,
     deletePhoto,
     deletePhotos,
     cancelAllPendingLoads,

--- a/package/website/src/views/PhotosPage.vue
+++ b/package/website/src/views/PhotosPage.vue
@@ -153,8 +153,12 @@ const handleConfirmDelete = async (ids: string[], callback: (success: boolean) =
   try {
     await photoStore.deletePhotos(ids)
     callback(true)
-    // Refresh photos after delete
-    photoStore.loadPhotos(true)
+    // deletePhotos updates the loaded list and timeline incrementally, so the
+    // virtual gallery keeps its height and current scroll position.
+    void Promise.all([
+      photoStore.fetchAvailableFilters(),
+      store.fetchAlbums(),
+    ])
   } catch (e) {
     console.error(e)
     ElMessage.error('删除失败')

--- a/package/website/src/views/album/AlbumDetail.vue
+++ b/package/website/src/views/album/AlbumDetail.vue
@@ -164,11 +164,12 @@ const handleConfirmDelete = async (ids: string[], callback: (success: boolean) =
     try {
         if (isUserAlbum.value) {
             await albumStore.removePhotosFromAlbum(albumId, ids)
+            photoStore.removeLocalPhotos(ids)
         } else {
             await photoStore.deletePhotos(ids)
         }
-        photoStore.loadAlbumPhotos(albumId, true)
         callback(true)
+        void albumStore.fetchAlbums()
     } catch (e) {
         console.error(e)
         ElMessage.error('操作失败')
@@ -196,7 +197,7 @@ const handleBatchRemoveFromAlbum = async (ids: string[]) => {
             timeout
         ])
 
-        photoStore.loadAlbumPhotos(albumId, true)
+        photoStore.removeLocalPhotos(ids)
         ElMessage.success('已移出相册')
 
         // Clear pending IDs after successful removal and reload


### PR DESCRIPTION
## 描述

修复删除照片后图库因强制清空重载而跳回页面顶部的问题。删除成功后改为增量更新本地列表与时间轴，并通过可见照片锚点在布局重排后恢复浏览位置。

## 变更类型

- [x] 🐛 修复错误 (Bug Fix)
- [x] ⚡️ 性能优化 (Performance)

## 相关 Issue

Closes #210

## 如何测试

- 在 `package/website` 执行 `pnpm build`
- 验证全部照片删除后不再强制调用 `loadPhotos(true)`
- 验证相册内删除/移除后使用本地增量更新
- 验证公共图库在删除前捕获可见照片、重排后恢复滚动锚点

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [ ] 我已更新了相关文档（本次无需文档变更）