### PR TITLE
fix(backup): 修复实况视频上传对象误判

### DIFF
--- a/package/server/app/api/media.py
+++ b/package/server/app/api/media.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Header, Request, status, Form, UploadFile, File, Query
 from fastapi.responses import FileResponse, StreamingResponse, Response
 from starlette.concurrency import run_in_threadpool
+from starlette.datastructures import UploadFile as StarletteUploadFile
 import anyio
 import base64
 from sqlalchemy.orm import Session
@@ -32,6 +33,11 @@ from app.api.deps import get_current_user
 from app.db.models.user import User
 
 router = APIRouter()
+
+
+def _is_upload_file(value: object) -> bool:
+    """Accept the concrete upload type produced by Starlette's multipart parser."""
+    return isinstance(value, StarletteUploadFile)
 
 
 def _existing_backup_photo(db: Session, user_id: UUID, backup_key: Optional[str]):
@@ -602,7 +608,7 @@ async def upload_photo_generic(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_user)
 ):
-    if not isinstance(live_photo_video, UploadFile):
+    if not _is_upload_file(live_photo_video):
         live_photo_video = None
     if not isinstance(companion_backup_key, str):
         companion_backup_key = None
@@ -738,7 +744,7 @@ async def finish_upload_generic(
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_user)
 ):
-    if not isinstance(live_photo_video, UploadFile):
+    if not _is_upload_file(live_photo_video):
         live_photo_video = None
     if not isinstance(companion_backup_key, str):
         companion_backup_key = None

--- a/package/server/tests/unit/test_media_api.py
+++ b/package/server/tests/unit/test_media_api.py
@@ -9,9 +9,19 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException
 from fastapi import UploadFile
+from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from app.api import media as media_api
 from app.db.models.photo import FileType
+
+
+def test_upload_file_check_accepts_starlette_multipart_instance():
+    upload = StarletteUploadFile(
+        filename="IMG_0001.mp4",
+        file=io.BytesIO(b"video"),
+    )
+
+    assert media_api._is_upload_file(upload)
 
 
 pytestmark = [pytest.mark.smoke, pytest.mark.module_photo]


### PR DESCRIPTION
## 描述

跟进 #209 的真实设备回归结果：修复 JPG+MP4 实况照片的伴随视频在服务端被错误忽略的问题。

FastAPI 的 multipart 解析实际产生 `starlette.datastructures.UploadFile`，原代码使用其子类 `fastapi.UploadFile` 做 `isinstance` 判断，因此有效 MP4 会被误判为空。接口仍返回 200，但只保存 JPG，客户端随后提示服务端未保存视频部分。

本 PR 改为按 Starlette 上传基类判断，并加入对应回归测试。

## 变更类型

- [x] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [x] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue

Closes #208

## 如何测试

- `python -m pytest tests/unit/test_media_api.py tests/unit/test_media_streaming_api.py -q`：33 passed
- vivo V2309A / Android 16 / App 0.14.0 真实设备回归
- `IMG_20260120_125119.jpg` 与同名 MP4 成功同时落盘
- MP4：6,061,939 字节，H.264 1440×1080、AAC、2.683 秒

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [ ] 我已更新了相关文档