### PR TITLE
perf(backup): 提升手机备份吞吐

### DIFF
--- a/package/server/app/api/media.py
+++ b/package/server/app/api/media.py
@@ -1,4 +1,5 @@
 import json
+import errno
 import os
 import shutil
 import uuid
@@ -594,6 +595,40 @@ def _replace_backup_file_from_chunks(
             os.remove(temporary_path)
         shutil.rmtree(chunk_dir, ignore_errors=True)
 
+
+def _finalize_chunk_upload(
+    chunk_dir: str,
+    chunks: list[int],
+    file_name: str,
+    user_id: UUID,
+    folder: Optional[str],
+    db: Session,
+) -> str:
+    """Commit uploaded chunks with one destination write and an atomic rename."""
+    final_path = storage.prepare_upload_path(file_name, user_id, folder, db)
+    temporary_path = final_path + f'.{uuid.uuid4().hex}.uploading'
+    storage.validate_target_path(temporary_path)
+    try:
+        if len(chunks) == 1:
+            source_path = os.path.join(chunk_dir, str(chunks[0]))
+            try:
+                os.replace(source_path, temporary_path)
+            except OSError as exc:
+                if exc.errno != errno.EXDEV and getattr(exc, 'winerror', None) != 17:
+                    raise
+                shutil.copyfile(source_path, temporary_path)
+        else:
+            with open(temporary_path, 'wb') as output:
+                for chunk_index in chunks:
+                    with open(os.path.join(chunk_dir, str(chunk_index)), 'rb') as source:
+                        shutil.copyfileobj(source, output, length=1024 * 1024)
+        os.replace(temporary_path, final_path)
+        return final_path
+    finally:
+        if os.path.exists(temporary_path):
+            os.remove(temporary_path)
+        shutil.rmtree(chunk_dir, ignore_errors=True)
+
 @router.post("", response_model=schemas.Photo)
 async def upload_photo_generic(
         album_id: Optional[UUID] = Form(None),
@@ -826,30 +861,10 @@ async def finish_upload_generic(
         raise HTTPException(status_code=400, detail="No chunks found")
 
     photo_id = uuid.uuid4()
-    ext = os.path.splitext(file_name)[1]
-    # Save to storage_root/year/month with conflict resolution
-    
-    def merge_and_save():
-        class _Tmp:
-            filename = file_name
-            file = None
-
-        merged_path = os.path.join(chunk_dir, "merged")
-        with open(merged_path, "wb") as outfile:
-            for chunk_idx in chunks:
-                chunk_path = os.path.join(chunk_dir, str(chunk_idx))
-                with open(chunk_path, "rb") as infile:
-                    outfile.write(infile.read())
-        with open(merged_path, "rb") as merged:
-            _Tmp.file = merged
-            final_path = storage.save_upload_file(_Tmp, photo_id, current_user.id, folder, db)
-
-        # Clean up chunks
-        shutil.rmtree(chunk_dir)
-        return final_path
-        
     try:
-        final_path = await run_in_threadpool(merge_and_save)
+        final_path = await run_in_threadpool(
+            _finalize_chunk_upload, chunk_dir, chunks, file_name, current_user.id, folder, db
+        )
         await run_in_threadpool(_preserve_source_file_time, final_path, source_photo_time)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/package/server/app/api/media.py
+++ b/package/server/app/api/media.py
@@ -645,6 +645,8 @@ async def upload_photo_generic(
 ):
     if not _is_upload_file(live_photo_video):
         live_photo_video = None
+    if not isinstance(folder, str):
+        folder = None
     if not isinstance(companion_backup_key, str):
         companion_backup_key = None
     if not isinstance(replace_existing, bool):
@@ -781,6 +783,8 @@ async def finish_upload_generic(
 ):
     if not _is_upload_file(live_photo_video):
         live_photo_video = None
+    if not isinstance(folder, str):
+        folder = None
     if not isinstance(companion_backup_key, str):
         companion_backup_key = None
     if not isinstance(replace_existing, bool):

--- a/package/server/app/service/storage.py
+++ b/package/server/app/service/storage.py
@@ -110,11 +110,16 @@ def _resolve_upload_directory(user_id: UUID, folder: Optional[str], db: Session 
     return os.path.join(root, 'uploads', *components)
 
 
-def save_upload_file(upload_file: UploadFile, file_id: UUID, user_id: UUID, folder: Optional[str] = None, db: Session = None) -> str:
+def prepare_upload_path(filename: str, user_id: UUID, folder: Optional[str] = None, db: Session = None) -> str:
     base_dir = _resolve_upload_directory(user_id, folder, db)
     os.makedirs(base_dir, exist_ok=True)
-    target_path = _ensure_unique_path(base_dir, upload_file.filename)
+    target_path = _ensure_unique_path(base_dir, filename)
     validate_target_path(target_path)
+    return target_path
+
+
+def save_upload_file(upload_file: UploadFile, file_id: UUID, user_id: UUID, folder: Optional[str] = None, db: Session = None) -> str:
+    target_path = prepare_upload_path(upload_file.filename, user_id, folder, db)
     with open(target_path, "wb") as buffer:
         shutil.copyfileobj(upload_file.file, buffer)
     return target_path

--- a/package/server/tests/unit/test_media_api.py
+++ b/package/server/tests/unit/test_media_api.py
@@ -144,6 +144,43 @@ def test_mobile_source_time_is_preserved_as_file_mtime(tmp_path):
     assert abs(target.stat().st_mtime - source_time.timestamp()) < 1
 
 
+def test_finalize_chunk_upload_moves_single_chunk_without_copying(tmp_path):
+    chunk_dir = tmp_path / "chunks"
+    chunk_dir.mkdir()
+    (chunk_dir / "0").write_bytes(b"single-chunk")
+    target = tmp_path / "uploads" / "photo.jpg"
+    target.parent.mkdir()
+
+    with patch.object(media_api.storage, "prepare_upload_path", return_value=str(target)), \
+         patch.object(media_api.storage, "validate_target_path"):
+        result = media_api._finalize_chunk_upload(
+            str(chunk_dir), [0], "photo.jpg", uuid4(), None, MagicMock(),
+        )
+
+    assert result == str(target)
+    assert target.read_bytes() == b"single-chunk"
+    assert not chunk_dir.exists()
+
+
+def test_finalize_chunk_upload_streams_multiple_chunks_to_destination(tmp_path):
+    chunk_dir = tmp_path / "chunks"
+    chunk_dir.mkdir()
+    (chunk_dir / "0").write_bytes(b"first-")
+    (chunk_dir / "1").write_bytes(b"second")
+    target = tmp_path / "uploads" / "photo.jpg"
+    target.parent.mkdir()
+
+    with patch.object(media_api.storage, "prepare_upload_path", return_value=str(target)), \
+         patch.object(media_api.storage, "validate_target_path"):
+        result = media_api._finalize_chunk_upload(
+            str(chunk_dir), [0, 1], "photo.jpg", uuid4(), None, MagicMock(),
+        )
+
+    assert result == str(target)
+    assert target.read_bytes() == b"first-second"
+    assert not chunk_dir.exists()
+
+
 def test_attach_live_photo_video_replaces_companion_atomically(tmp_path):
     image = tmp_path / "IMG_0001.jpg"
     image.write_bytes(b"image")

--- a/package/server/tests/unit/test_nightly_api_media_gaps_20260824.py
+++ b/package/server/tests/unit/test_nightly_api_media_gaps_20260824.py
@@ -239,11 +239,6 @@ async def test_finish_upload_happy_path_merges_and_saves(tmp_path):
         id=photo_id, owner_id=user.id, file_path=str(tmp_path / "saved.jpg")
     )
 
-    fake_open = MagicMock()
-    fake_buffer = MagicMock()
-    fake_buffer.read.return_value = b""
-    fake_open.return_value.__enter__.return_value = fake_buffer
-
     with patch.object(media_api, "add_tasks") as add_tasks:
         with patch.object(
             media_api.crud_album,
@@ -251,10 +246,10 @@ async def test_finish_upload_happy_path_merges_and_saves(tmp_path):
             return_value=None,
         ):
             with patch.object(
-                media_api.storage,
-                "save_upload_file",
+                media_api,
+                "_finalize_chunk_upload",
                 return_value=str(tmp_path / "saved.jpg"),
-            ):
+            ) as finalize_upload:
                 with patch.object(
                     media_api,
                     "save_and_create_photo",
@@ -266,21 +261,18 @@ async def test_finish_upload_happy_path_merges_and_saves(tmp_path):
                             "listdir",
                             return_value=["0", "1"],
                         ):
-                            with patch("builtins.open", fake_open):
-                                with patch.object(
-                                    media_api.shutil, "rmtree"
-                                ) as rmtree:
-                                    result = await media_api.finish_upload_generic(
-                                        upload_id=uuid4(),
-                                        file_name="merged.jpg",
-                                        album_id=None,
-                                        db=db,
-                                        current_user=user,
-                                    )
+                            result = await media_api.finish_upload_generic(
+                                upload_id=uuid4(),
+                                file_name="merged.jpg",
+                                album_id=None,
+                                db=db,
+                                current_user=user,
+                            )
 
     assert result is fake_photo
     add_tasks.assert_called_once()
-    rmtree.assert_called_once()
+    finalize_upload.assert_called_once()
+    assert finalize_upload.call_args.args[-2] is None
 
 
 # ---------------------------------------------------------------------------

--- a/package/website/src/composables/useGalleryBackup.ts
+++ b/package/website/src/composables/useGalleryBackup.ts
@@ -9,6 +9,8 @@ import {
   adaptTransferTuning,
   backupUploadAction,
   initialTransferTuning,
+  mapWithConcurrency,
+  shouldUseChunkedUpload,
   takeTransferBatch,
   type TransferTuning,
 } from '@/utils/backupTransfer'
@@ -372,7 +374,7 @@ async function uploadAsset(
     if (!response.ok) throw new Error(`读取临时文件失败 (${response.status})`)
     const blob = await response.blob()
     const file = new File([blob], asset.name, { type: asset.mimeType, lastModified: asset.modifiedMs })
-    if (file.size > 5 * 1024 * 1024) {
+    if (shouldUseChunkedUpload(file.size, tuning)) {
       const uploadId = await retryTransfer(() => albumService.initUpload(), config)
       await uploadChunks(uploadId, file, tuning, config, reportAbsolute)
       await waitIfPaused()
@@ -444,7 +446,7 @@ async function uploadLivePhoto(
   try {
     videoFile = await exportedFile(video)
     const folder = destinationFolder(image, config)
-    if (imageFile.file.size > 5 * 1024 * 1024) {
+    if (shouldUseChunkedUpload(imageFile.file.size, tuning)) {
       const uploadId = await retryTransfer(() => albumService.initUpload(), config)
       await uploadChunks(uploadId, imageFile.file, tuning, config, reportAbsolute)
       await waitIfPaused()
@@ -687,14 +689,18 @@ async function runBackup(options: { manual?: boolean } = {}) {
       // hash the original bytes locally and ask the server before transferring
       // them. This also catches the same file appearing in multiple phone
       // folders or under a changed MediaStore id.
-      const hashes: string[] = []
-      for (const operation of remaining) {
-        const primary = operation.pair?.image || operation.asset
-        const digest = await galleryBackupNative.calculateAssetMd5({ uri: primary.uri })
-        primary.contentMd5 = digest.md5.toLowerCase()
-        operation.md5 = primary.contentMd5
-        hashes.push(operation.md5)
-      }
+      const hashes = await mapWithConcurrency(
+        remaining,
+        transferTuning?.hashConcurrency || 1,
+        async operation => {
+          const primary = operation.pair?.image || operation.asset
+          const digest = await galleryBackupNative.calculateAssetMd5({ uri: primary.uri })
+          const md5 = digest.md5.toLowerCase()
+          primary.contentMd5 = md5
+          operation.md5 = md5
+          return md5
+        },
+      )
       const hashPresence = hashes.length ? await albumService.checkBackupKeys([], hashes) : null
       for (let index = remaining.length - 1; index >= 0; index--) {
         const operation = remaining[index]

--- a/package/website/src/utils/backupTransfer.ts
+++ b/package/website/src/utils/backupTransfer.ts
@@ -7,6 +7,7 @@ export interface BackupNetworkStatus {
 export interface TransferTuning {
   isLan: boolean
   metered: boolean
+  hashConcurrency: number
   mediaConcurrency: number
   chunkConcurrency: number
   chunkSize: number
@@ -36,6 +37,8 @@ export function backupUploadAction(
 }
 
 const MB = 1024 * 1024
+const DEFAULT_CHUNK_THRESHOLD = 5 * MB
+const LAN_CHUNK_THRESHOLD = 16 * MB
 
 export function isLanServerUrl(value: string) {
   try {
@@ -55,12 +58,12 @@ export function initialTransferTuning(serverUrl: string, network: BackupNetworkS
   const metered = !network.unmetered
   if (isLan) {
     return {
-      isLan, metered, mediaConcurrency: 3, chunkConcurrency: 2,
-      chunkSize: 8 * MB, maxInFlightBytes: 96 * MB, maxAttempts: 2,
+      isLan, metered, hashConcurrency: 4, mediaConcurrency: 4, chunkConcurrency: 2,
+      chunkSize: 8 * MB, maxInFlightBytes: 160 * MB, maxAttempts: 2,
     }
   }
   return {
-    isLan, metered, mediaConcurrency: 1, chunkConcurrency: 1,
+    isLan, metered, hashConcurrency: metered ? 1 : 2, mediaConcurrency: 1, chunkConcurrency: 1,
     chunkSize: metered ? MB : 2 * MB,
     maxInFlightBytes: metered ? 16 * MB : 32 * MB,
     maxAttempts: 3,
@@ -75,6 +78,7 @@ export function adaptTransferTuning(
   if (recentFailure) {
     return {
       ...current,
+      hashConcurrency: 1,
       mediaConcurrency: 1,
       chunkConcurrency: 1,
       chunkSize: Math.min(current.chunkSize, current.metered ? MB : 2 * MB),
@@ -83,13 +87,28 @@ export function adaptTransferTuning(
   }
   if (speedBytesPerSecond <= 0) return current
   if (current.isLan) {
-    if (speedBytesPerSecond >= 20 * MB) {
-      return { ...current, mediaConcurrency: 4, chunkConcurrency: 2, chunkSize: 8 * MB, maxInFlightBytes: 128 * MB }
+    if (speedBytesPerSecond >= 30 * MB) {
+      return {
+        ...current, hashConcurrency: 6, mediaConcurrency: 8, chunkConcurrency: 3,
+        chunkSize: 16 * MB, maxInFlightBytes: 256 * MB,
+      }
     }
-    if (speedBytesPerSecond < 2 * MB) {
-      return { ...current, mediaConcurrency: 2, chunkConcurrency: 1, chunkSize: 4 * MB, maxInFlightBytes: 64 * MB }
+    if (speedBytesPerSecond >= 12 * MB) {
+      return {
+        ...current, hashConcurrency: 4, mediaConcurrency: 6, chunkConcurrency: 2,
+        chunkSize: 8 * MB, maxInFlightBytes: 192 * MB,
+      }
     }
-    return { ...current, mediaConcurrency: 3, chunkConcurrency: 2, chunkSize: 8 * MB, maxInFlightBytes: 96 * MB }
+    if (speedBytesPerSecond < 3 * MB) {
+      return {
+        ...current, hashConcurrency: 2, mediaConcurrency: 3, chunkConcurrency: 1,
+        chunkSize: 4 * MB, maxInFlightBytes: 64 * MB,
+      }
+    }
+    return {
+      ...current, hashConcurrency: 4, mediaConcurrency: 4, chunkConcurrency: 2,
+      chunkSize: 8 * MB, maxInFlightBytes: 160 * MB,
+    }
   }
   if (!current.metered && speedBytesPerSecond >= 5 * MB) {
     return { ...current, mediaConcurrency: 2, chunkConcurrency: 2, chunkSize: 4 * MB, maxInFlightBytes: 64 * MB }
@@ -101,6 +120,33 @@ export function adaptTransferTuning(
     chunkSize: current.metered ? MB : 2 * MB,
     maxInFlightBytes: current.metered ? 16 * MB : 32 * MB,
   }
+}
+
+export function shouldUseChunkedUpload(size: number, tuning: TransferTuning) {
+  const threshold = tuning.isLan
+    ? Math.max(LAN_CHUNK_THRESHOLD, tuning.chunkSize)
+    : DEFAULT_CHUNK_THRESHOLD
+  return size > threshold
+}
+
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (!items.length) return []
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+  const worker = async () => {
+    while (true) {
+      const index = nextIndex++
+      if (index >= items.length) return
+      results[index] = await mapper(items[index], index)
+    }
+  }
+  const workers = Math.min(items.length, Math.max(1, Math.floor(concurrency)))
+  await Promise.all(Array.from({ length: workers }, worker))
+  return results
 }
 
 export function takeTransferBatch<T extends { size: number }>(items: T[], tuning: TransferTuning) {

--- a/package/website/tests/e2e/specs/settings/mobile-backup-transfer.spec.ts
+++ b/package/website/tests/e2e/specs/settings/mobile-backup-transfer.spec.ts
@@ -4,6 +4,8 @@ import {
   backupUploadAction,
   initialTransferTuning,
   isLanServerUrl,
+  mapWithConcurrency,
+  shouldUseChunkedUpload,
   takeTransferBatch,
 } from '../../../../src/utils/backupTransfer'
 
@@ -19,7 +21,13 @@ test.describe('P0 - 手机备份自适应传输 @p0', () => {
       wifi: true,
       unmetered: true,
     })
-    expect(lan).toMatchObject({ isLan: true, mediaConcurrency: 3, chunkConcurrency: 2, chunkSize: 8 * MB })
+    expect(lan).toMatchObject({
+      isLan: true,
+      hashConcurrency: 4,
+      mediaConcurrency: 4,
+      chunkConcurrency: 2,
+      chunkSize: 8 * MB,
+    })
 
     const publicWifi = initialTransferTuning('https://photos.example.com', {
       connected: true,
@@ -40,6 +48,26 @@ test.describe('P0 - 手机备份自适应传输 @p0', () => {
 
     const degraded = adaptTransferTuning(fast, 6 * MB, true)
     expect(degraded).toMatchObject({ mediaConcurrency: 1, chunkConcurrency: 1, chunkSize: 2 * MB })
+  })
+
+  test('局域网根据实测吞吐从四路提升到六路或八路', () => {
+    const initial = initialTransferTuning('http://192.168.1.8:8000', {
+      connected: true,
+      wifi: true,
+      unmetered: true,
+    })
+
+    expect(adaptTransferTuning(initial, 15 * MB)).toMatchObject({
+      mediaConcurrency: 6,
+      chunkConcurrency: 2,
+      maxInFlightBytes: 192 * MB,
+    })
+    expect(adaptTransferTuning(initial, 35 * MB)).toMatchObject({
+      mediaConcurrency: 8,
+      chunkConcurrency: 3,
+      chunkSize: 16 * MB,
+      maxInFlightBytes: 256 * MB,
+    })
   })
 
   test('计费网络始终使用小分片和单路上传', () => {
@@ -63,8 +91,40 @@ test.describe('P0 - 手机备份自适应传输 @p0', () => {
       unmetered: true,
     })
     const items = [{ size: 50 * MB }, { size: 50 * MB }, { size: MB }]
-    expect(takeTransferBatch(items, tuning)).toHaveLength(1)
-    expect(takeTransferBatch([{ size: MB }, { size: MB }, { size: MB }, { size: MB }], tuning)).toHaveLength(3)
+    expect(takeTransferBatch(items, tuning)).toHaveLength(3)
+    expect(takeTransferBatch([
+      { size: 100 * MB }, { size: 100 * MB }, { size: MB },
+    ], tuning)).toHaveLength(1)
+    expect(takeTransferBatch([{ size: MB }, { size: MB }, { size: MB }, { size: MB }], tuning)).toHaveLength(4)
+  })
+
+  test('局域网小于等于 16MB 的文件直接上传，公网仍保留 5MB 分片阈值', () => {
+    const lan = initialTransferTuning('http://10.0.0.2:8000', {
+      connected: true, wifi: true, unmetered: true,
+    })
+    const publicWifi = initialTransferTuning('https://photos.example.com', {
+      connected: true, wifi: true, unmetered: true,
+    })
+
+    expect(shouldUseChunkedUpload(16 * MB, lan)).toBe(false)
+    expect(shouldUseChunkedUpload(16 * MB + 1, lan)).toBe(true)
+    expect(shouldUseChunkedUpload(5 * MB, publicWifi)).toBe(false)
+    expect(shouldUseChunkedUpload(5 * MB + 1, publicWifi)).toBe(true)
+  })
+
+  test('MD5 任务按上限并行且保持结果顺序', async () => {
+    let active = 0
+    let peak = 0
+    const result = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async value => {
+      active++
+      peak = Math.max(peak, active)
+      await new Promise(resolve => setTimeout(resolve, 5))
+      active--
+      return value * 2
+    })
+
+    expect(result).toEqual([2, 4, 6, 8, 10])
+    expect(peak).toBe(2)
   })
 
   test('已完整备份的媒体跳过，只有不完整记录才覆盖上传', () => {


### PR DESCRIPTION
## 描述

提升手机备份在局域网环境下的实际吞吐，降低批次启动、请求调度和服务端落盘开销。

主要改动：

- 待上传资源 MD5 从串行计算改为并发计算，默认 4 路，高速阶段 6 路；失败或计费网络自动降回 1 路。
- 局域网默认媒体并发从 3 路提升到 4 路；实测吞吐稳定后自适应提升到 6 路，高速场景提升到 8 路。
- 局域网分片并发最高提升到 3，分片大小最高提升到 16MB，同时在途字节上限随并发提升。
- 局域网 16MB 以内文件直接上传，不再进入初始化、分片、完成三段式流程；公网仍保留 5MB 阈值。
- 服务端分片完成时，单分片直接原子移动到目标路径；多分片流式写入目标临时文件后原子改名，避免先合并再复制。
- 补充分片落盘、上传阈值、MD5 并发、自适应并发和在途字节约束测试。

## 变更类型

- [ ] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [x] ⚡ 性能优化 (Performance)
- [x] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue

Closes #216

## 如何测试

- 后端针对性测试：`python -m pytest tests/unit/test_media_api.py tests/unit/test_nightly_storage_exif_facecluster_gaps_20260824.py -q`
  - 36 passed
- 前端生产构建：`pnpm build`
  - 通过
- 传输策略 E2E：`pnpm exec playwright test tests/e2e/specs/settings/mobile-backup-transfer.spec.ts --project=chromium`
  - 8 passed
- `git diff --check`
  - 通过

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [ ] 我已更新了相关文档