### PR TITLE
test(nightly): cover artifact agent and settings gaps

### DIFF
--- a/package/server/tests/unit/test_nightly_ai_artifact_api_gaps_20260909.py
+++ b/package/server/tests/unit/test_nightly_ai_artifact_api_gaps_20260909.py
@@ -1,0 +1,125 @@
+"""2026-09-09 nightly gap tests for the AI artifact API.
+
+These tests exercise the router layer directly so ownership checks, share
+tokens, and HTML export headers are covered without starting the HTTP app.
+"""
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api import ai_artifact as artifact_api
+from app.db.base import Base
+from app.db.models.ai_artifact import AIArtifact
+from app.db.models.user import User
+
+pytestmark = [pytest.mark.smoke]
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _user(db, name):
+    user = User(id=uuid4(), username=name, hashed_password="x")
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _artifact(user_id):
+    return AIArtifact(
+        user_id=user_id,
+        artifact_type="travel_story",
+        title="九寨沟流水账",
+        content_json={"summary": "秋天很美", "sections": [{"heading": "湖", "body": "蓝色的水"}]},
+        html_content=None,
+        html_config={"style_name": "editorial"},
+        source_photo_ids=[],
+        source_ticket_ids=[],
+        status="draft",
+        version=1,
+        updated_at=datetime(2026, 9, 8, 8, 0, 0),
+    )
+
+
+def test_list_artifact_endpoint_returns_serialized_rows(db):
+    user = _user(db, "artifact-api-owner")
+    artifact = _artifact(user.id)
+    db.add(artifact)
+    db.commit()
+
+    response = artifact_api.list_artifacts(skip=0, limit=20, current_user=user, db=db)
+    assert response.code == 0
+    assert response.data[0]["title"] == "九寨沟流水账"
+    assert response.data[0]["artifact_type"] == "travel_story"
+
+
+def test_get_artifact_endpoint_rejects_foreign_or_missing_rows(db):
+    owner, stranger = _user(db, "artifact-api-a"), _user(db, "artifact-api-b")
+    artifact = _artifact(owner.id)
+    db.add(artifact)
+    db.commit()
+
+    assert artifact_api.get_artifact(str(artifact.id), current_user=owner, db=db).data["id"] == str(artifact.id)
+    with pytest.raises(Exception) as foreign:
+        artifact_api.get_artifact(str(artifact.id), current_user=stranger, db=db)
+    with pytest.raises(Exception) as missing:
+        artifact_api.get_artifact(str(uuid4()), current_user=owner, db=db)
+    assert foreign.value.status_code == 404
+    assert missing.value.status_code == 404
+
+
+def test_export_artifact_html_sets_download_and_referrer_headers(db):
+    user = _user(db, "artifact-api-export")
+    artifact = _artifact(user.id)
+    db.add(artifact)
+    db.commit()
+
+    response = artifact_api.export_artifact_html(str(artifact.id), current_user=user, db=db)
+    assert response.status_code == 200
+    assert response.media_type.startswith("text/html")
+    assert "attachment; filename=trailsnap-story.html" in response.headers["content-disposition"]
+    assert response.headers["referrer-policy"] == "no-referrer"
+    assert "蓝色的水" in response.body.decode("utf-8")
+
+
+def test_share_public_and_revoke_artifact_flow(db):
+    user = _user(db, "artifact-api-share")
+    artifact = _artifact(user.id)
+    db.add(artifact)
+    db.commit()
+
+    share = artifact_api.share_artifact(str(artifact.id), current_user=user, db=db)
+    token = share.data["share_path"].rsplit(".", 1)[1]
+    public = artifact_api.get_shared_artifact(f"{artifact.id}.{token}", db=db)
+    assert public.status_code == 200
+    assert "Content-Security-Policy" in public.headers
+    assert artifact.version == 2
+    assert artifact.html_config["share"]["enabled"] is True
+
+    revoked = artifact_api.revoke_artifact_share(str(artifact.id), current_user=user, db=db)
+    assert revoked.data == {"revoked": True}
+    assert "share" not in artifact.html_config
+    assert artifact.version == 3
+
+    with pytest.raises(Exception) as exc:
+        artifact_api.get_shared_artifact(f"{artifact.id}.{token}", db=db)
+    assert exc.value.status_code == 404
+
+
+def test_public_artifact_rejects_malformed_share_token(db):
+    _user(db, "artifact-api-malformed")
+    with pytest.raises(Exception) as exc:
+        artifact_api.get_shared_artifact("not-a-token", db=db)
+    assert exc.value.status_code == 404

--- a/package/server/tests/unit/test_nightly_backend_low_coverage_gaps_20260909.py
+++ b/package/server/tests/unit/test_nightly_backend_low_coverage_gaps_20260909.py
@@ -1,0 +1,80 @@
+"""2026-09-09 nightly tests for remaining backend low-coverage helpers."""
+import asyncio
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+def test_abort_chat_session_marks_session():
+    from app.service.agent import service as agent_service
+
+    session_id = str(uuid4())
+    agent_service._aborted_sessions.pop(session_id, None)
+    agent_service.abort_chat_session(session_id)
+    assert agent_service._aborted_sessions[session_id] is True
+
+
+def test_model_context_window_prefers_explicit_model_and_falls_back():
+    from app.service.agent.service import _model_context_window
+
+    model = SimpleNamespace(model_name="qwen-max", context_window=262144)
+    connection = SimpleNamespace(id="conn-1", models=[model])
+    settings = SimpleNamespace(
+        analysis_connection_id="conn-default",
+        analysis_model_name="analysis-model",
+        connections=[connection],
+    )
+    assert _model_context_window(settings, connection_id="conn-1", model_name="qwen-max") == 262144
+
+    settings_without_models = SimpleNamespace(
+        analysis_connection_id="missing",
+        analysis_model_name="missing-model",
+        connections=[],
+    )
+    assert _model_context_window(settings_without_models) == 128000
+
+
+def test_agent_skill_tools_list_and_report_load_errors():
+    from app.service.agent.tools import get_agent_tools
+
+    tools = {tool.name: tool for tool in get_agent_tools(str(uuid4()))}
+    listed = json.loads(tools["list_skills"].func())
+    assert isinstance(listed["skills"], list)
+
+    error = json.loads(tools["load_skill"].func("definitely-not-a-skill"))
+    assert "error" in error
+
+
+@pytest.mark.asyncio
+async def test_task_queue_manager_priority_order_and_unknown_category():
+    from app.service.task_worker import TaskQueueManager
+
+    manager = TaskQueueManager()
+    await manager.put_batch("CPU", [{"id": "low"}], priority=1)
+    await manager.put_batch("CPU", [{"id": "high"}], priority=10)
+    await manager.put_batch("MISSING", [{"id": "ignored"}], priority=10)
+
+    assert manager.item_count("CPU") == 2
+    assert manager.qsize("MISSING") == 0
+    assert manager.get_lowest_priority("CPU") == 1
+    assert await manager.get_batch("CPU") == [{"id": "high"}]
+    assert await manager.get_batch("CPU") == [{"id": "low"}]
+    assert await manager.get_batch("MISSING") == []
+    manager.task_done("CPU")
+
+
+def test_day_caption_timezone_and_bounds_helpers_are_defensive():
+    from app.service.moment.day_caption_service import _resolve_tz, day_bounds_utc
+    from datetime import date
+
+    assert _resolve_tz("") is not None
+    assert _resolve_tz("Asia/Shanghai") is not None
+    assert _resolve_tz("not/a-zone") is not None
+
+    start, end = day_bounds_utc(date(2026, 9, 9), "ignored-for-compat")
+    assert (start.hour, start.minute, start.second) == (0, 0, 0)
+    assert (end - start).total_seconds() == 86400

--- a/package/server/tests/unit/test_nightly_settings_path_gaps_20260909.py
+++ b/package/server/tests/unit/test_nightly_settings_path_gaps_20260909.py
@@ -1,0 +1,48 @@
+"""2026-09-09 nightly tests for settings path and storage-root helpers."""
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api import settings as settings_api
+
+pytestmark = [pytest.mark.smoke]
+
+
+def test_path_validator_rejects_empty_and_traversal():
+    for value, fragment in [("", "Invalid path"), ("../secret", "traversal detected")]:
+        with pytest.raises(HTTPException) as exc:
+            settings_api.PathValidator.validate(value)
+        assert exc.value.status_code == 400
+        assert fragment in exc.value.detail
+
+
+def test_path_validator_requires_existing_directory(tmp_path):
+    missing = tmp_path / "missing"
+    with pytest.raises(HTTPException) as missing_exc:
+        settings_api.PathValidator.validate(str(missing))
+    assert missing_exc.value.status_code == 400
+    assert "does not exist" in missing_exc.value.detail
+
+    target = tmp_path / "photos"
+    target.mkdir()
+    assert settings_api.PathValidator.validate(f"  {target}  ") == str(target.resolve())
+
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("x", encoding="utf-8")
+    with pytest.raises(HTTPException) as file_exc:
+        settings_api.PathValidator.validate(str(file_path))
+    assert "not a directory" in file_exc.value.detail
+
+
+def test_get_storage_root_falls_back_to_uploads_and_closes_db():
+    db = MagicMock()
+    config = MagicMock()
+    config.storage.photo_storage_path = ""
+    settings_api.config_manager.get_user_config = MagicMock(return_value=config)
+
+    assert settings_api.get_storage_root("user-id", db) == "uploads"
+    db.close.assert_called_once()
+
+    config.storage.photo_storage_path = "/photos/root"
+    assert settings_api.get_storage_root("user-id", db) == "/photos/root"


### PR DESCRIPTION
## 📌 关联 Issue
Closes #225

## 🧩 改动说明
本 PR 仅新增 3 个后端单元测试文件，补齐 2026-09-09 夜间覆盖率扫描中的 6 个低覆盖模块：

- `api/ai_artifact.py`：列表 / 详情 / 导出 / 分享 / 撤销 / 非法 token
- `service/agent/service.py`：会话中止、模型上下文窗口选择与兜底
- `service/agent/tools.py`：Skill 列表与加载错误
- `service/task_worker.py`：队列优先级、未知分类、队列统计
- `service/moment/day_caption_service.py`：时区兜底与日期边界
- `api/settings.py`：路径校验与存储根路径回退

## ✅ 自测
- 新增 13 个单元测试：13 passed
- 本地完整 E2E：350 passed / 4 skipped / 0 failed
- teardown：1 passed
- 后端基线覆盖率：80%
- AI 基线覆盖率：80%

## 📋 CLA
I have read and agree to the CLA
