### PR TITLE
feat(requirements): 增加匿名提交和管理总览

### DIFF
--- a/package/requirement-platform/server/migrations/versions/9c73e1ab420d_public_requirement_numbers_and_guests.py
+++ b/package/requirement-platform/server/migrations/versions/9c73e1ab420d_public_requirement_numbers_and_guests.py
@@ -1,0 +1,49 @@
+"""public requirement numbers and guest submissions
+
+Revision ID: 9c73e1ab420d
+Revises: 34a8c51d92f0
+Create Date: 2026-09-09
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "9c73e1ab420d"
+down_revision: Union[str, None] = "34a8c51d92f0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("requirements") as batch_op:
+        batch_op.add_column(sa.Column("public_number", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("submitter_name", sa.String(length=50), nullable=True))
+        batch_op.add_column(sa.Column("submitter_contact", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("anonymous_upload_token_hash", sa.String(length=64), nullable=True))
+        batch_op.alter_column("created_by", existing_type=sa.String(length=36), nullable=True)
+
+    connection = op.get_bind()
+    rows = connection.execute(sa.text("SELECT id FROM requirements ORDER BY created_at, id")).fetchall()
+    for number, row in enumerate(rows, start=1):
+        connection.execute(
+            sa.text("UPDATE requirements SET public_number = :number WHERE id = :id"),
+            {"number": number, "id": row[0]},
+        )
+    op.create_index("ix_requirements_public_number", "requirements", ["public_number"], unique=True)
+
+    with op.batch_alter_table("requirement_attachments") as batch_op:
+        batch_op.alter_column("uploaded_by", existing_type=sa.String(length=36), nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("requirement_attachments") as batch_op:
+        batch_op.alter_column("uploaded_by", existing_type=sa.String(length=36), nullable=False)
+    op.drop_index("ix_requirements_public_number", table_name="requirements")
+    with op.batch_alter_table("requirements") as batch_op:
+        batch_op.alter_column("created_by", existing_type=sa.String(length=36), nullable=False)
+        batch_op.drop_column("anonymous_upload_token_hash")
+        batch_op.drop_column("submitter_contact")
+        batch_op.drop_column("submitter_name")
+        batch_op.drop_column("public_number")

--- a/package/requirement-platform/server/requirement_platform/config.py
+++ b/package/requirement-platform/server/requirement_platform/config.py
@@ -18,6 +18,7 @@ class Settings:
     )
     daily_submission_limit: int = int(os.getenv("RP_DAILY_SUBMISSION_LIMIT", "5"))
     max_open_requirements: int = int(os.getenv("RP_MAX_OPEN_REQUIREMENTS", "20"))
+    non_admin_hourly_submission_limit: int = int(os.getenv("RP_NON_ADMIN_HOURLY_SUBMISSION_LIMIT", "20"))
     upload_dir: str = os.getenv("RP_UPLOAD_DIR", "./data/uploads")
     max_attachment_bytes: int = int(os.getenv("RP_MAX_ATTACHMENT_BYTES", str(5 * 1024 * 1024)))
     max_attachments_per_requirement: int = int(os.getenv("RP_MAX_ATTACHMENTS_PER_REQUIREMENT", "5"))

--- a/package/requirement-platform/server/requirement_platform/main.py
+++ b/package/requirement-platform/server/requirement_platform/main.py
@@ -1,4 +1,5 @@
 import hashlib
+import hashlib
 import json
 import secrets
 from contextlib import asynccontextmanager
@@ -21,6 +22,7 @@ from .db import get_db, init_db
 from .models import (
     BackgroundJob,
     AgentToken,
+    AuditEvent,
     GitHubIdentity,
     OAuthLoginGrant,
     ReleaseBatch,
@@ -71,12 +73,14 @@ def user_data(row: User, db: Session) -> dict:
     return data
 
 
-def requirement_data(row: Requirement, db: Session, *, include_private: bool = False) -> dict:
+def requirement_data(row: Requirement, db: Session, *, include_private: bool = False, include_contact: bool = False) -> dict:
     data = RequirementRead.model_validate(row).model_dump(mode="json")
     if not include_private:
         data["log_text"] = None
-    creator = db.query(User.username).filter(User.id == row.created_by).scalar()
-    data["created_by_name"] = creator or "匿名"
+    creator = db.query(User.username).filter(User.id == row.created_by).scalar() if row.created_by else None
+    data["created_by_name"] = creator or row.submitter_name or "匿名用户"
+    if not include_contact:
+        data["submitter_contact"] = None
     data["follower_count"] = db.query(func.count(RequirementFollower.id)).filter(
         RequirementFollower.requirement_id == row.id
     ).scalar() or 0
@@ -104,6 +108,10 @@ def requirement_data(row: Requirement, db: Session, *, include_private: bool = F
 def enqueue_github_sync(db: Session, row: Requirement) -> None:
     if row.github_issue_number or (row.visibility == "public" and row.status == "candidate"):
         enqueue(db, "github_issue", row.id, f"github_issue:{row.id}:{row.status}:{secrets.token_hex(6)}")
+
+
+def next_requirement_number(db: Session) -> int:
+    return (db.query(func.max(Requirement.public_number)).scalar() or 0) + 1
 
 
 def can_access_private_data(row: Requirement, user: User | None) -> bool:
@@ -423,26 +431,43 @@ def revoke_agent_token(token_id: str, actor: User = Depends(manager), db: Sessio
 
 
 @app.post("/api/requirements")
-def create_requirement(payload: RequirementCreate, user: User = Depends(current_user), db: Session = Depends(get_db)):
-    since = datetime.now(timezone.utc) - timedelta(days=1)
-    daily = db.query(func.count(Requirement.id)).filter(Requirement.created_by == user.id, Requirement.created_at >= since).scalar() or 0
-    if daily >= settings.daily_submission_limit:
-        raise HTTPException(status_code=429, detail="Daily submission limit reached")
-    terminal = {"rejected", "duplicate", "withdrawn", "closed", "released"}
-    open_count = db.query(func.count(Requirement.id)).filter(
-        Requirement.created_by == user.id, Requirement.status.notin_(terminal), Requirement.deleted_at.is_(None)
-    ).scalar() or 0
-    if open_count >= settings.max_open_requirements:
-        raise HTTPException(status_code=429, detail="Too many open requirements")
-    row = Requirement(created_by=user.id, **payload.model_dump())
+def create_requirement(payload: RequirementCreate, user: User | None = Depends(optional_user), db: Session = Depends(get_db)):
+    is_manager = bool(user and user.role in {"admin", "owner"})
+    if not is_manager:
+        since = datetime.now(timezone.utc) - timedelta(hours=1)
+        manager_ids = db.query(User.id).filter(User.role.in_({"admin", "owner"}))
+        recent = db.query(func.count(Requirement.id)).filter(
+            Requirement.created_at >= since,
+            or_(Requirement.created_by.is_(None), Requirement.created_by.notin_(manager_ids)),
+        ).scalar() or 0
+        if recent >= settings.non_admin_hourly_submission_limit:
+            raise HTTPException(status_code=429, detail="所有非管理员用户每小时最多提交 20 条需求，请稍后再试")
+    values = payload.model_dump()
+    if user:
+        values["submitter_name"] = None
+        values["submitter_contact"] = None
+    else:
+        values["visibility"] = "public"
+        values["submitter_name"] = (values.get("submitter_name") or "").strip() or None
+        values["submitter_contact"] = (values.get("submitter_contact") or "").strip() or None
+    upload_token = secrets.token_urlsafe(32) if not user else None
+    row = Requirement(
+        public_number=next_requirement_number(db), created_by=user.id if user else None,
+        anonymous_upload_token_hash=hashlib.sha256(upload_token.encode()).hexdigest() if upload_token else None,
+        **values,
+    )
     db.add(row)
     db.flush()
-    db.add(RequirementFollower(requirement_id=row.id, user_id=user.id))
-    audit(db, user.id, "requirement.created", "requirement", row.id, type=row.type)
+    if user:
+        db.add(RequirementFollower(requirement_id=row.id, user_id=user.id))
+    audit(db, user.id if user else None, "requirement.created", "requirement", row.id, type=row.type, status=row.status)
     enqueue(db, "triage", row.id, f"triage:{row.id}:v{row.version}")
     db.commit()
     db.refresh(row)
-    return ok(requirement_data(row, db, include_private=True), "submitted")
+    data = requirement_data(row, db, include_private=bool(user), include_contact=is_manager)
+    if upload_token:
+        data["upload_token"] = upload_token
+    return ok(data, "submitted")
 
 
 ALLOWED_ATTACHMENT_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".txt", ".log", ".json", ".pdf"}
@@ -451,12 +476,19 @@ IMAGE_ATTACHMENT_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
 
 @app.post("/api/requirements/{requirement_id}/attachments")
 async def upload_requirement_attachment(
-    requirement_id: str, file: UploadFile = File(...), user: User = Depends(current_user), db: Session = Depends(get_db)
+    requirement_id: str, file: UploadFile = File(...), user: User | None = Depends(optional_user),
+    x_requirement_upload_token: str | None = Header(default=None), db: Session = Depends(get_db)
 ):
     row = db.query(Requirement).filter(Requirement.id == requirement_id, Requirement.deleted_at.is_(None)).first()
     if not row:
         raise HTTPException(status_code=404, detail="Requirement not found")
-    if not can_access_private_data(row, user):
+    anonymous_token_ok = bool(
+        not user and x_requirement_upload_token and row.anonymous_upload_token_hash
+        and secrets.compare_digest(
+            hashlib.sha256(x_requirement_upload_token.encode()).hexdigest(), row.anonymous_upload_token_hash
+        )
+    )
+    if not can_access_private_data(row, user) and not anonymous_token_ok:
         raise HTTPException(status_code=403, detail="Not allowed")
     count = db.query(func.count(RequirementAttachment.id)).filter(
         RequirementAttachment.requirement_id == row.id
@@ -485,13 +517,13 @@ async def upload_requirement_attachment(
         target.unlink(missing_ok=True)
         raise
     attachment = RequirementAttachment(
-        requirement_id=row.id, uploaded_by=user.id, original_name=original_name, stored_name=stored_name,
+        requirement_id=row.id, uploaded_by=user.id if user else None, original_name=original_name, stored_name=stored_name,
         content_type=(file.content_type or "application/octet-stream")[:100], size_bytes=size,
         kind="image" if suffix in IMAGE_ATTACHMENT_EXTENSIONS else "file",
     )
     db.add(attachment)
     db.flush()
-    audit(db, user.id, "requirement.attachment_uploaded", "requirement", row.id,
+    audit(db, user.id if user else None, "requirement.attachment_uploaded", "requirement", row.id,
           attachment_id=attachment.id, name=original_name, size_bytes=size)
     db.commit()
     return ok({"id": attachment.id, "name": original_name, "content_type": attachment.content_type,
@@ -550,10 +582,61 @@ def list_requirements(
     if type:
         query = query.filter(Requirement.type == type)
     if q:
-        pattern = f"%{q.strip()}%"
-        query = query.filter(or_(Requirement.title.ilike(pattern), Requirement.description.ilike(pattern)))
+        search = q.strip()
+        pattern = f"%{search}%"
+        number_text = search.upper().removeprefix("REQ-").lstrip("0") or "0"
+        conditions = [Requirement.title.ilike(pattern), Requirement.description.ilike(pattern)]
+        if number_text.isdigit():
+            conditions.append(Requirement.public_number == int(number_text))
+        query = query.filter(or_(*conditions))
     rows = query.order_by(Requirement.created_at.desc()).offset(skip).limit(limit).all()
-    return ok([requirement_data(row, db, include_private=is_manager or bool(user and row.created_by == user.id)) for row in rows])
+    return ok([requirement_data(
+        row, db,
+        include_private=is_manager or bool(user and row.created_by == user.id),
+        include_contact=is_manager,
+    ) for row in rows])
+
+
+@app.get("/api/requirements/number/{public_number}")
+def get_requirement_by_number(public_number: int, user: User | None = Depends(optional_user), db: Session = Depends(get_db)):
+    row = db.query(Requirement).filter(
+        Requirement.public_number == public_number, Requirement.deleted_at.is_(None)
+    ).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Requirement not found")
+    allowed = row.visibility == "public" or bool(user and (user.id == row.created_by or user.role in {"admin", "owner"}))
+    if not allowed:
+        raise HTTPException(status_code=404, detail="Requirement not found")
+    is_manager = bool(user and user.role in {"admin", "owner"})
+    return ok(requirement_data(row, db, include_private=is_manager or bool(user and user.id == row.created_by), include_contact=is_manager))
+
+
+@app.get("/api/requirements/{requirement_id}/history")
+def requirement_history(requirement_id: str, user: User | None = Depends(optional_user), db: Session = Depends(get_db)):
+    row = db.query(Requirement).filter(Requirement.id == requirement_id, Requirement.deleted_at.is_(None)).first()
+    if not row or (row.visibility != "public" and not user) or (
+        row.visibility != "public" and user and user.id != row.created_by and user.role not in {"admin", "owner"}
+    ):
+        raise HTTPException(status_code=404, detail="Requirement not found")
+    allowed_actions = {
+        "requirement.created", "requirement.updated", "requirement.status_changed", "requirement.withdrawn",
+        "requirement.candidate", "requirement.needs_information", "requirement.rejected", "requirement.deferred",
+        "requirement.duplicate", "requirement.closed", "triage.queued", "triage.completed",
+    }
+    events = db.query(AuditEvent).filter(
+        AuditEvent.object_type == "requirement", AuditEvent.object_id == row.id,
+        AuditEvent.action.in_(allowed_actions),
+    ).order_by(AuditEvent.created_at).all()
+    result = []
+    for event in events:
+        actor_name = db.query(User.username).filter(User.id == event.actor_id).scalar() if event.actor_id else None
+        details = event.details or {}
+        result.append({
+            "id": event.id, "action": event.action, "actor_name": actor_name or "系统",
+            "before": details.get("before"), "after": details.get("after") or details.get("status"),
+            "reason": details.get("reason"), "created_at": event.created_at.isoformat(),
+        })
+    return ok(result)
 
 
 @app.get("/api/requirements/{requirement_id}")
@@ -565,7 +648,7 @@ def get_requirement(requirement_id: str, user: User | None = Depends(optional_us
     if not allowed:
         raise HTTPException(status_code=404, detail="Requirement not found")
     include_private = bool(user and (user.id == row.created_by or user.role in {"admin", "owner"}))
-    return ok(requirement_data(row, db, include_private=include_private))
+    return ok(requirement_data(row, db, include_private=include_private, include_contact=bool(user and user.role in {"admin", "owner"})))
 
 
 @app.patch("/api/requirements/{requirement_id}")
@@ -584,12 +667,14 @@ def update_requirement(
         setattr(row, key, value)
     row.version += 1
     if row.status == "needs_information":
+        before = row.status
         row.status = "submitted"
+        audit(db, user.id, "requirement.status_changed", "requirement", row.id, before=before, after=row.status)
     enqueue_github_sync(db, row)
     enqueue(db, "triage", row.id, f"triage:{row.id}:v{row.version}")
     audit(db, user.id, "requirement.updated", "requirement", row.id, version=row.version)
     db.commit()
-    return ok(requirement_data(row, db, include_private=True))
+    return ok(requirement_data(row, db, include_private=True, include_contact=user.role in {"admin", "owner"}))
 
 
 @app.post("/api/requirements/{requirement_id}/withdraw")
@@ -600,9 +685,10 @@ def withdraw_requirement(requirement_id: str, user: User = Depends(current_user)
         raise HTTPException(status_code=404, detail="Requirement not found")
     if row.status in {"scheduled", "developing", "testing", "release_ready", "released"}:
         raise HTTPException(status_code=409, detail="Scheduled requirement cannot be withdrawn")
+    before = row.status
     row.status = "withdrawn"
     enqueue_github_sync(db, row)
-    audit(db, user.id, "requirement.withdrawn", "requirement", row.id)
+    audit(db, user.id, "requirement.withdrawn", "requirement", row.id, before=before, after=row.status)
     db.commit()
     return ok(requirement_data(row, db, include_private=True))
 
@@ -636,9 +722,10 @@ def queue_triage(requirement_id: str, actor: User = Depends(manager), db: Sessio
         raise HTTPException(status_code=404, detail="Requirement not found")
     key = f"triage:{row.id}:v{row.version}:manual:{int(datetime.now().timestamp()) // 60}"
     job = enqueue(db, "triage", row.id, key)
+    before = row.status
     row.status = "triaging"
     enqueue_github_sync(db, row)
-    audit(db, actor.id, "triage.queued", "requirement", row.id, job_id=job.id)
+    audit(db, actor.id, "triage.queued", "requirement", row.id, job_id=job.id, before=before, after=row.status)
     db.commit()
     return ok({"job_id": job.id})
 
@@ -664,6 +751,7 @@ def review_requirement(requirement_id: str, payload: ReviewInput, actor: User = 
             ).first()
             if not exists:
                 db.add(RequirementFollower(requirement_id=target.id, user_id=follower.user_id))
+    before = row.status
     row.status = status_by_action[payload.action]
     row.review_reason = payload.reason
     row.priority = payload.priority
@@ -673,7 +761,8 @@ def review_requirement(requirement_id: str, payload: ReviewInput, actor: User = 
         metadata_json={"priority": payload.priority, "risk_level": payload.risk_level, "duplicate_of_id": payload.duplicate_of_id},
     ))
     enqueue_github_sync(db, row)
-    audit(db, actor.id, f"requirement.{payload.action}", "requirement", row.id, reason=payload.reason)
+    audit(db, actor.id, f"requirement.{payload.action}", "requirement", row.id,
+          before=before, after=row.status, reason=payload.reason)
     db.commit()
     return ok(requirement_data(row, db, include_private=True))
 
@@ -683,10 +772,12 @@ def close_requirement(requirement_id: str, payload: ReasonInput, actor: User = D
     row = db.query(Requirement).filter(Requirement.id == requirement_id, Requirement.deleted_at.is_(None)).first()
     if not row:
         raise HTTPException(status_code=404, detail="Requirement not found")
+    before = row.status
     row.status, row.review_reason = "closed", payload.reason
     enqueue_github_sync(db, row)
     db.add(ReviewDecision(requirement_id=row.id, reviewer_id=actor.id, action="close", reason=payload.reason))
-    audit(db, actor.id, "requirement.closed", "requirement", row.id, reason=payload.reason)
+    audit(db, actor.id, "requirement.closed", "requirement", row.id,
+          before=before, after=row.status, reason=payload.reason)
     db.commit()
     return ok(requirement_data(row, db, include_private=True))
 
@@ -768,6 +859,7 @@ def import_github_issues(actor: User = Depends(manager), db: Session = Depends(g
             updated += 1
             continue
         row = Requirement(
+            public_number=next_requirement_number(db),
             type=kind, title=(issue.get("title") or f"GitHub Issue #{number}")[:160],
             description=((issue.get("body") or "GitHub Issue 未提供正文").strip() or "GitHub Issue 未提供正文")[:8000],
             severity="medium", visibility="public", status=issue_status, source="github", created_by=actor.id,
@@ -924,8 +1016,11 @@ def lock_batch(batch_id: str, actor: User = Depends(manager), db: Session = Depe
         requirement = db.query(Requirement).filter(Requirement.id == item.requirement_id).first()
         if requirement:
             item.requirement_snapshot = requirement_snapshot(requirement)
+            before = requirement.status
             requirement.status = "scheduled"
             enqueue_github_sync(db, requirement)
+            audit(db, actor.id, "requirement.status_changed", "requirement", requirement.id,
+                  before=before, after=requirement.status, reason=f"加入版本 {batch.version_name}")
     enqueue(db, "github_milestone", batch.id, f"github_milestone:{batch.id}")
     audit(db, actor.id, "release_batch.locked", "release_batch", batch.id, count=len(items))
     db.commit()
@@ -975,8 +1070,11 @@ def update_batch_status(batch_id: str, payload: BatchStatusInput, actor: User = 
         for item in items:
             requirement = db.query(Requirement).filter(Requirement.id == item.requirement_id).first()
             if requirement and (requirement_status != "released" or item.delivery_status == "completed"):
+                before_status = requirement.status
                 requirement.status = requirement_status
                 enqueue_github_sync(db, requirement)
+                audit(db, actor.id, "requirement.status_changed", "requirement", requirement.id,
+                      before=before_status, after=requirement.status, reason=payload.reason)
     audit(db, actor.id, "release_batch.status_changed", "release_batch", batch.id, before=before, after=payload.status, reason=payload.reason)
     db.commit()
     return ok(batch_data(batch, db, include_private=True))
@@ -998,8 +1096,11 @@ def update_delivery_status(
     requirement = db.query(Requirement).filter(Requirement.id == item.requirement_id).first()
     mapping = {"developing": "developing", "pr_open": "developing", "testing": "testing", "completed": "release_ready"}
     if requirement and payload.status in mapping:
+        before_status = requirement.status
         requirement.status = mapping[payload.status]
         enqueue_github_sync(db, requirement)
+        audit(db, actor.id, "requirement.status_changed", "requirement", requirement.id,
+              before=before_status, after=requirement.status, reason=f"版本交付状态：{payload.status}")
     audit(db, actor.id, "release_batch.delivery_status", "release_batch", batch_id, item_id=item.id, status=payload.status)
     db.commit()
     return ok({"id": item.id, "delivery_status": item.delivery_status})
@@ -1012,6 +1113,28 @@ def list_jobs(_actor: User = Depends(manager), db: Session = Depends(get_db)):
         "id": row.id, "job_type": row.job_type, "object_id": row.object_id, "status": row.status,
         "attempts": row.attempts, "last_error": row.last_error, "created_at": row.created_at.isoformat(),
     } for row in rows])
+
+
+@app.get("/api/admin/dashboard")
+def dashboard(_actor: User = Depends(manager), db: Session = Depends(get_db)):
+    base = db.query(Requirement).filter(Requirement.deleted_at.is_(None))
+    status_rows = db.query(Requirement.status, func.count(Requirement.id)).filter(
+        Requirement.deleted_at.is_(None)
+    ).group_by(Requirement.status).all()
+    type_rows = db.query(Requirement.type, func.count(Requirement.id)).filter(
+        Requirement.deleted_at.is_(None)
+    ).group_by(Requirement.type).all()
+    since = datetime.now(timezone.utc) - timedelta(days=7)
+    return ok({
+        "total": base.count(),
+        "new_last_7_days": base.filter(Requirement.created_at >= since).count(),
+        "pending_review": base.filter(Requirement.status.in_({"submitted", "triaging", "pending_review"})).count(),
+        "in_progress": base.filter(Requirement.status.in_({"scheduled", "developing", "testing", "release_ready"})).count(),
+        "github_linked": base.filter(Requirement.github_issue_number.is_not(None)).count(),
+        "anonymous": base.filter(Requirement.created_by.is_(None)).count(),
+        "by_status": {status: count for status, count in status_rows},
+        "by_type": {kind: count for kind, count in type_rows},
+    })
 
 
 @app.post("/api/hooks/github")

--- a/package/requirement-platform/server/requirement_platform/mcp_server.py
+++ b/package/requirement-platform/server/requirement_platform/mcp_server.py
@@ -7,6 +7,7 @@ from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.mcpserver import MCPServer
+from sqlalchemy import func
 
 from .config import settings
 from .db import SessionLocal
@@ -74,7 +75,8 @@ def _identity(required_scope: str) -> tuple[AgentToken, User]:
 
 def _requirement_dict(row: Requirement) -> dict[str, Any]:
     return {
-        "id": row.id, "type": row.type, "title": row.title, "description": row.description,
+        "id": row.id, "public_number": row.public_number, "reference": f"REQ-{row.public_number}",
+        "type": row.type, "title": row.title, "description": row.description,
         "current_behavior": row.current_behavior, "expected_behavior": row.expected_behavior,
         "steps_to_reproduce": row.steps_to_reproduce, "severity": row.severity,
         "product_version": row.product_version, "visibility": row.visibility, "status": row.status,
@@ -104,10 +106,13 @@ def list_requirements(status: str | None = None, query: str | None = None, inclu
 
 @mcp.tool()
 def get_requirement(requirement_id: str) -> dict[str, Any]:
-    """读取一个需求的完整管理信息。"""
+    """读取一个需求的完整管理信息；支持 UUID 或 REQ-123 公共编号。"""
     _identity("requirements:read")
     with SessionLocal() as db:
-        row = db.query(Requirement).filter(Requirement.id == requirement_id).first()
+        number_text = requirement_id.upper().removeprefix("REQ-").lstrip("0") or "0"
+        row = db.query(Requirement).filter(
+            Requirement.public_number == int(number_text)
+        ).first() if number_text.isdigit() else db.query(Requirement).filter(Requirement.id == requirement_id).first()
         if not row:
             raise ValueError("需求不存在")
         return _requirement_dict(row)
@@ -122,7 +127,8 @@ def create_requirement(type: str, title: str, description: str, severity: str = 
     if visibility not in {"public", "private"} or len(title.strip()) < 4 or len(description.strip()) < 10:
         raise ValueError("需求内容或公开范围无效")
     with SessionLocal() as db:
-        row = Requirement(type=type, title=title.strip(), description=description.strip(), severity=severity,
+        public_number = (db.query(func.max(Requirement.public_number)).scalar() or 0) + 1
+        row = Requirement(public_number=public_number, type=type, title=title.strip(), description=description.strip(), severity=severity,
                           visibility=visibility, expected_behavior=expected_behavior, created_by=actor.id)
         db.add(row)
         db.flush()

--- a/package/requirement-platform/server/requirement_platform/models.py
+++ b/package/requirement-platform/server/requirement_platform/models.py
@@ -36,6 +36,7 @@ class Requirement(Base):
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=new_id)
+    public_number: Mapped[int | None] = mapped_column(Integer, nullable=True, unique=True, index=True)
     type: Mapped[str] = mapped_column(String(24), index=True)
     title: Mapped[str] = mapped_column(String(160), index=True)
     description: Mapped[str] = mapped_column(Text)
@@ -58,7 +59,10 @@ class Requirement(Base):
     github_issue_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     github_state: Mapped[str | None] = mapped_column(String(24), nullable=True)
     source: Mapped[str] = mapped_column(String(16), default="platform", index=True)
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    created_by: Mapped[str | None] = mapped_column(String(36), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+    submitter_name: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    submitter_contact: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    anonymous_upload_token_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, onupdate=utcnow)
     version: Mapped[int] = mapped_column(Integer, default=1)
@@ -72,7 +76,7 @@ class RequirementAttachment(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=new_id)
     requirement_id: Mapped[str] = mapped_column(String(36), ForeignKey("requirements.id", ondelete="CASCADE"), index=True)
-    uploaded_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    uploaded_by: Mapped[str | None] = mapped_column(String(36), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
     original_name: Mapped[str] = mapped_column(String(255))
     stored_name: Mapped[str] = mapped_column(String(255), unique=True)
     content_type: Mapped[str] = mapped_column(String(100))

--- a/package/requirement-platform/server/requirement_platform/schemas.py
+++ b/package/requirement-platform/server/requirement_platform/schemas.py
@@ -69,15 +69,21 @@ class RequirementCreate(BaseModel):
     product_version: str | None = Field(default=None, max_length=50)
     environment: dict[str, Any] = Field(default_factory=dict)
     visibility: Literal["public", "private"] = "public"
+    submitter_name: str | None = Field(default=None, max_length=50)
+    submitter_contact: str | None = Field(default=None, max_length=255)
 
 
 class RequirementUpdate(BaseModel):
+    type: Literal["bug", "improvement", "feature"] | None = None
     title: str | None = Field(default=None, min_length=4, max_length=160)
     description: str | None = Field(default=None, min_length=10, max_length=8000)
     log_text: str | None = Field(default=None, max_length=20000)
     current_behavior: str | None = Field(default=None, max_length=3000)
     expected_behavior: str | None = Field(default=None, max_length=3000)
     steps_to_reproduce: str | None = Field(default=None, max_length=4000)
+    severity: Literal["low", "medium", "high", "critical"] | None = None
+    product_version: str | None = Field(default=None, max_length=50)
+    visibility: Literal["public", "private"] | None = None
     environment: dict[str, Any] | None = None
 
 
@@ -115,6 +121,7 @@ class BatchStatusInput(BaseModel):
 class RequirementRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: str
+    public_number: int | None
     type: str
     title: str
     description: str
@@ -135,7 +142,9 @@ class RequirementRead(BaseModel):
     github_issue_url: str | None
     github_state: str | None
     source: str
-    created_by: str
+    created_by: str | None
+    submitter_name: str | None
+    submitter_contact: str | None
     created_at: datetime
     updated_at: datetime
     version: int

--- a/package/requirement-platform/server/requirement_platform/seed_demo.py
+++ b/package/requirement-platform/server/requirement_platform/seed_demo.py
@@ -70,7 +70,7 @@ def main() -> None:
         requirements = []
         for i, (type_, title, desc, severity, status, priority, name, followers) in enumerate(demo):
             row = Requirement(
-                type=type_, title=title, description=desc, severity=severity, status=status, priority=priority,
+                public_number=i + 1, type=type_, title=title, description=desc, severity=severity, status=status, priority=priority,
                 risk_level="medium", visibility="public", created_by=users[name].id,
                 created_at=base - timedelta(days=len(demo) - i, hours=i % 5),
                 updated_at=base - timedelta(days=len(demo) - i - 1, hours=(len(demo) - i) % 7),

--- a/package/requirement-platform/server/requirement_platform/services.py
+++ b/package/requirement-platform/server/requirement_platform/services.py
@@ -144,6 +144,7 @@ def analyze_requirement(db: Session, requirement_id: str) -> TriageReport:
         report=report,
         confidence=max(0.0, min(confidence, 1.0)),
     )
+    before = requirement.status
     requirement.status = "pending_review"
     db.add(row)
     if requirement.github_issue_number:
@@ -151,7 +152,8 @@ def analyze_requirement(db: Session, requirement_id: str) -> TriageReport:
             db, "github_issue", requirement.id,
             f"github_issue:{requirement.id}:pending_review:v{requirement.version}",
         )
-    audit(db, None, "triage.completed", "requirement", requirement.id, provider=provider)
+    audit(db, None, "triage.completed", "requirement", requirement.id,
+          provider=provider, before=before, after=requirement.status)
     db.commit()
     db.refresh(row)
     return row
@@ -224,7 +226,7 @@ class GitHubClient:
             f"## 当前行为\n{requirement.current_behavior or '未提供'}\n\n"
             f"## 期望行为\n{requirement.expected_behavior or '未提供'}\n\n"
             f"## 验收与审核\n{requirement.review_reason or '已通过人工审核'}\n\n"
-            f"Requirement-ID: `{requirement.id}`"
+            f"Requirement: `REQ-{requirement.public_number or requirement.id}`"
         )
         return self._request(
             "POST", f"/repos/{settings.github_repo}/issues",
@@ -276,6 +278,30 @@ class GitHubClient:
             "PATCH", f"/repos/{settings.github_repo}/issues/{issue_number}", json={"labels": retained}
         )
 
+    def sync_issue(self, requirement: Requirement) -> dict[str, Any]:
+        issue = self.get_issue(requirement.github_issue_number)
+        retained = [
+            label["name"] for label in issue.get("labels", [])
+            if not label.get("name", "").lower().startswith(STATUS_LABEL_PREFIX)
+            and label.get("name", "").lower() not in {"bug", "enhancement"}
+        ]
+        retained.extend([
+            "bug" if requirement.type == "bug" else "enhancement",
+            self.ensure_status_label(requirement.status),
+        ])
+        body = (
+            f"由 TrailSnap 需求管理平台同步。\n\n"
+            f"## 需求描述\n{requirement.description}\n\n"
+            f"## 当前行为\n{requirement.current_behavior or '未提供'}\n\n"
+            f"## 期望行为\n{requirement.expected_behavior or '未提供'}\n\n"
+            f"## 验收与审核\n{requirement.review_reason or '暂无'}\n\n"
+            f"Requirement: `REQ-{requirement.public_number or requirement.id}`"
+        )
+        return self._request(
+            "PATCH", f"/repos/{settings.github_repo}/issues/{requirement.github_issue_number}",
+            json={"title": requirement.title, "body": body, "labels": retained},
+        )
+
     def create_milestone(self, batch: ReleaseBatch) -> dict[str, Any]:
         return self._request(
             "POST",
@@ -295,7 +321,7 @@ def sync_requirement_issue(db: Session, requirement_id: str) -> None:
         raise ValueError("Requirement not found")
     client = GitHubClient()
     if requirement.github_issue_number:
-        data = client.sync_status_label(requirement.github_issue_number, requirement.status)
+        data = client.sync_issue(requirement)
         requirement.github_state = data.get("state", requirement.github_state)
         audit(db, None, "github.issue.labels_synced", "requirement", requirement.id,
               issue_number=requirement.github_issue_number, status=requirement.status)

--- a/package/requirement-platform/server/tests/test_platform_flow.py
+++ b/package/requirement-platform/server/tests/test_platform_flow.py
@@ -306,3 +306,74 @@ def test_github_status_sync_preserves_unmanaged_labels(monkeypatch):
     GitHubClient().sync_status_label(42, "testing")
     patch_request = next(item for item in requests if item[0] == "PATCH")
     assert patch_request[2]["json"]["labels"] == ["bug", "status: testing"]
+
+
+def test_github_full_issue_sync_updates_content_and_preserves_custom_labels(monkeypatch):
+    requests = []
+
+    def fake_request(_self, method, path, **kwargs):
+        requests.append((method, path, kwargs))
+        if method == "GET" and path.endswith("/issues/42"):
+            return {"number": 42, "state": "open", "labels": [
+                {"name": "documentation"}, {"name": "bug"}, {"name": "status: submitted"},
+            ]}
+        if method == "GET" and path.endswith("/labels"):
+            return [{"name": "status: testing"}]
+        return {"number": 42, "state": "open"}
+
+    monkeypatch.setattr(GitHubClient, "_request", fake_request)
+    requirement = type("RequirementStub", (), {
+        "github_issue_number": 42, "title": "新的标题", "description": "新的描述",
+        "current_behavior": None, "expected_behavior": "新的期望", "review_reason": None,
+        "type": "feature", "status": "testing", "public_number": 123,
+    })()
+    GitHubClient().sync_issue(requirement)
+    payload = next(item for item in requests if item[0] == "PATCH")[2]["json"]
+    assert payload["title"] == "新的标题"
+    assert "新的描述" in payload["body"]
+    assert payload["labels"] == ["documentation", "enhancement", "status: testing"]
+
+
+def test_anonymous_number_history_dashboard_and_manager_edit():
+    with TestClient(app) as client:
+        response = client.post("/api/requirements", json={
+            "type": "feature", "title": "匿名用户希望增加地图导出",
+            "description": "希望可以把相册中的旅行轨迹导出为通用地图文件。",
+            "submitter_name": "旅行者", "submitter_contact": "traveler@example.com",
+        })
+        assert response.status_code == 200, response.text
+        created = response.json()["data"]
+        assert created["public_number"] > 0
+        assert created["created_by"] is None
+        assert created["submitter_contact"] is None
+        assert created["upload_token"]
+
+        upload = client.post(
+            f"/api/requirements/{created['id']}/attachments",
+            headers={"X-Requirement-Upload-Token": created["upload_token"]},
+            files={"file": ("details.txt", b"anonymous details", "text/plain")},
+        )
+        assert upload.status_code == 200, upload.text
+
+        public_detail = client.get(f"/api/requirements/number/{created['public_number']}")
+        assert public_detail.status_code == 200
+        assert public_detail.json()["data"]["created_by_name"] == "旅行者"
+        assert public_detail.json()["data"]["submitter_contact"] is None
+
+        history = client.get(f"/api/requirements/{created['id']}/history")
+        assert history.status_code == 200
+        assert history.json()["data"][0]["action"] == "requirement.created"
+
+        owner = client.post(
+            "/api/auth/login", json={"identifier": "owner@example.com", "password": "password123"}
+        ).json()["data"]
+        edited = client.patch(
+            f"/api/requirements/{created['id']}", headers=auth(owner["token"]),
+            json={"title": "管理员完善后的地图导出需求", "severity": "high"},
+        )
+        assert edited.status_code == 200, edited.text
+        assert edited.json()["data"]["submitter_contact"] == "traveler@example.com"
+
+        dashboard = client.get("/api/admin/dashboard", headers=auth(owner["token"]))
+        assert dashboard.status_code == 200
+        assert dashboard.json()["data"]["anonymous"] >= 1

--- a/package/requirement-platform/web/src/App.vue
+++ b/package/requirement-platform/web/src/App.vue
@@ -61,7 +61,7 @@
         </div>
 
         <div class="filters">
-          <el-input v-model="filters.q" clearable placeholder="搜索需求标题、关键词或描述..." :prefix-icon="Search" class="search" @keyup.enter="loadRequirements" @clear="loadRequirements" />
+          <el-input v-model="filters.q" clearable placeholder="搜索 REQ 编号、标题、关键词或描述..." :prefix-icon="Search" class="search" @keyup.enter="loadRequirements" @clear="loadRequirements" />
           <el-select v-model="filters.type" clearable placeholder="全部类型" class="select" @change="loadRequirements">
             <el-option label="新功能" value="feature" /><el-option label="体验优化" value="improvement" /><el-option label="问题修复" value="bug" />
           </el-select>
@@ -74,6 +74,23 @@
         </div>
 
         <RequirementTable :items="sortedRequirements" :manager="isManager" :user="user" @open="openDetail" @action="onRowAction" />
+      </section>
+
+      <!-- ============ 管理总览 ============ -->
+      <section v-else-if="tab === 'dashboard' && isManager">
+        <div class="page-head"><div class="page-head-left"><div class="page-head-icon"><el-icon :size="26"><DataAnalysis /></el-icon></div><div><h1>需求总览</h1><p class="desc">掌握需求规模、审核积压和版本推进情况。</p></div></div></div>
+        <div v-if="dashboard" class="dashboard-cards">
+          <article class="panel dashboard-card"><strong>{{ dashboard.total }}</strong><span>全部需求</span></article>
+          <article class="panel dashboard-card"><strong>{{ dashboard.new_last_7_days }}</strong><span>近 7 天新增</span></article>
+          <article class="panel dashboard-card"><strong>{{ dashboard.pending_review }}</strong><span>待处理</span></article>
+          <article class="panel dashboard-card"><strong>{{ dashboard.in_progress }}</strong><span>开发发布中</span></article>
+          <article class="panel dashboard-card"><strong>{{ dashboard.github_linked }}</strong><span>已关联 GitHub</span></article>
+          <article class="panel dashboard-card"><strong>{{ dashboard.anonymous }}</strong><span>匿名提交</span></article>
+        </div>
+        <div v-if="dashboard" class="dashboard-grid">
+          <article class="panel"><h2>状态分布</h2><div v-for="(count, status) in dashboard.by_status" :key="status" class="distribution-row"><span>{{ statusLabel(status) }}</span><strong>{{ count }}</strong></div></article>
+          <article class="panel"><h2>类型分布</h2><div v-for="(count, kind) in dashboard.by_type" :key="kind" class="distribution-row"><span>{{ typeLabel(kind) }}</span><strong>{{ count }}</strong></div></article>
+        </div>
       </section>
 
       <!-- ============ 提交需求 ============ -->
@@ -89,14 +106,11 @@
           </div>
         </div>
 
-        <div v-if="!user" class="panel empty">
-          <el-icon><User /></el-icon>
-          <div>请先登录或注册，再提交需求</div>
-          <div class="actions" style="justify-content: center"><el-button type="primary" @click="authDialog = true">登录 / 注册</el-button></div>
-        </div>
-
-        <div v-else class="submit-layout">
+        <div class="submit-layout">
           <el-form class="panel submit-form" label-position="top" @submit.prevent="submitRequirement" @paste="handlePaste">
+            <el-alert v-if="!user" type="info" :closable="false" show-icon title="你正在匿名提交">
+              无需登录即可提交。昵称和联系方式均为可选，联系方式仅管理员可见；匿名需求将公开展示。
+            </el-alert>
             <div class="section">
               <h2 class="section-head"><el-icon><DocumentAdd /></el-icon>基本信息</h2>
               <el-form-item label="类型" required>
@@ -115,6 +129,15 @@
                 <el-input v-model="requirementForm.title" maxlength="160" show-word-limit placeholder="请输入简洁清晰的标题" />
                 <div class="field-hint">必填，4–160 字。用简短的语句概括需求的核心内容。</div>
               </el-form-item>
+              <div v-if="!user" class="form-grid">
+                <el-form-item label="提交人昵称（可选）">
+                  <el-input v-model="requirementForm.submitter_name" maxlength="50" show-word-limit placeholder="如何称呼你" />
+                </el-form-item>
+                <el-form-item label="联系方式（可选）">
+                  <el-input v-model="requirementForm.submitter_contact" maxlength="255" show-word-limit placeholder="邮箱或其他联系方式" />
+                  <div class="field-hint">仅管理员可见，不会出现在公开页面。</div>
+                </el-form-item>
+              </div>
             </div>
 
             <div class="section">
@@ -172,17 +195,21 @@
                   <el-input v-model="requirementForm.product_version" maxlength="50" show-word-limit placeholder="例如 0.14.1" />
                   <div class="field-hint">最多 50 个字符。如果与特定版本相关，请填写版本号。</div>
                 </el-form-item>
-                <el-form-item label="公开范围">
+                <el-form-item v-if="user" label="公开范围">
                   <el-radio-group v-model="requirementForm.visibility">
                     <el-radio value="public">公开</el-radio>
                     <el-radio value="private">仅本人和管理员</el-radio>
                   </el-radio-group>
                   <div class="field-hint">公开需求可被所有用户查看；私有需求仅本人和管理员可见。</div>
                 </el-form-item>
+                <el-form-item v-else label="公开范围">
+                  <el-input model-value="公开" disabled />
+                  <div class="field-hint">匿名提交的需求固定公开展示。</div>
+                </el-form-item>
               </div>
             </div>
 
-            <div class="submit-quota">每个账号每天最多提交 5 条需求，同时处理中最多 20 条。</div>
+            <div class="submit-quota">所有非管理员用户合计每小时最多提交 20 条需求。</div>
             <div class="actions">
               <el-button type="primary" size="large" :icon="Promotion" :loading="busy" native-type="submit">提交需求</el-button>
               <el-button size="large" @click="saveDraft">保存草稿</el-button>
@@ -432,7 +459,7 @@
     </footer>
 
     <!-- ============ 需求详情 ============ -->
-    <el-dialog v-model="detailDialog" :title="detailTarget?.title" width="min(92vw, 640px)">
+    <el-dialog v-model="detailDialog" :title="detailTarget ? `REQ-${detailTarget.public_number} · ${detailTarget.title}` : '需求详情'" width="min(92vw, 680px)" @closed="closeDetail">
       <template v-if="detailTarget">
         <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px">
           <span class="tag no-dot" :class="`t-${detailTarget.type}`">{{ typeLabel(detailTarget.type) }}</span>
@@ -462,11 +489,36 @@
           <span>{{ detailTarget.follower_count || 0 }} 人关注</span>
           <a v-if="detailTarget.github_issue_url" :href="detailTarget.github_issue_url" target="_blank" rel="noopener">GitHub #{{ detailTarget.github_issue_number }}</a>
         </div>
+        <div v-if="isManager && detailTarget.submitter_contact" class="contact-box"><strong>提交人联系方式（仅管理员可见）：</strong>{{ detailTarget.submitter_contact }}</div>
+        <div class="timeline">
+          <h3>需求动态</h3>
+          <div v-if="!detailHistory.length" class="field-hint">暂无状态记录</div>
+          <div v-for="event in detailHistory" :key="event.id" class="timeline-item">
+            <span class="timeline-dot"></span>
+            <div><strong>{{ historyLabel(event) }}</strong><p>{{ event.actor_name }} · {{ new Date(event.created_at).toLocaleString() }}<span v-if="event.reason"> · {{ event.reason }}</span></p></div>
+          </div>
+        </div>
       </template>
       <template #footer>
+        <el-button v-if="detailTarget" @click="copyRequirementLink(detailTarget)">复制链接</el-button>
         <el-button v-if="detailTarget && canFollow" @click="follow(detailTarget); detailDialog = false">关注（{{ detailTarget.follower_count || 0 }}）</el-button>
+        <el-button v-if="detailTarget && isManager" @click="detailDialog = false; openEdit(detailTarget)">编辑</el-button>
         <el-button v-if="detailTarget && isManager" type="primary" @click="detailDialog = false; openReview(detailTarget)">审核</el-button>
       </template>
+    </el-dialog>
+
+    <el-dialog v-model="editDialog" title="编辑需求" width="min(92vw, 640px)">
+      <el-form label-position="top">
+        <div class="form-grid"><el-form-item label="类型" required><el-select v-model="editForm.type"><el-option label="新功能" value="feature" /><el-option label="体验优化" value="improvement" /><el-option label="问题修复" value="bug" /></el-select></el-form-item><el-form-item label="影响程度" required><el-select v-model="editForm.severity"><el-option label="低" value="low" /><el-option label="中" value="medium" /><el-option label="高" value="high" /><el-option label="严重" value="critical" /></el-select></el-form-item></div>
+        <el-form-item label="标题" required><el-input v-model="editForm.title" maxlength="160" show-word-limit /><div class="field-hint">4–160 字。</div></el-form-item>
+        <el-form-item label="需求描述" required><el-input v-model="editForm.description" type="textarea" :rows="5" maxlength="8000" show-word-limit /><div class="field-hint">10–8,000 字。</div></el-form-item>
+        <el-form-item label="复现步骤"><el-input v-model="editForm.steps_to_reproduce" type="textarea" :rows="3" maxlength="4000" show-word-limit /></el-form-item>
+        <div class="form-grid"><el-form-item label="当前行为"><el-input v-model="editForm.current_behavior" type="textarea" :rows="3" maxlength="3000" show-word-limit /></el-form-item><el-form-item label="期望行为"><el-input v-model="editForm.expected_behavior" type="textarea" :rows="3" maxlength="3000" show-word-limit /></el-form-item></div>
+        <el-form-item label="日志文字（仅提交人和管理员可见）"><el-input v-model="editForm.log_text" type="textarea" :rows="3" maxlength="20000" show-word-limit /></el-form-item>
+        <div class="form-grid"><el-form-item label="产品版本"><el-input v-model="editForm.product_version" maxlength="50" /></el-form-item><el-form-item label="公开范围"><el-select v-model="editForm.visibility"><el-option label="公开" value="public" /><el-option label="仅提交人和管理员" value="private" /></el-select></el-form-item></div>
+        <el-alert v-if="editTarget?.github_issue_number" type="info" :closable="false">保存后将异步同步 GitHub Issue 的标题、正文、类型和状态标签。</el-alert>
+      </el-form>
+      <template #footer><el-button @click="editDialog = false">取消</el-button><el-button type="primary" :loading="busy" @click="submitEdit">保存</el-button></template>
     </el-dialog>
 
     <!-- ============ 登录 ============ -->
@@ -541,13 +593,13 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
 import {
-  ArrowDown, Bell, Checked, CircleCheckFilled, Collection, Connection, Document, DocumentAdd, EditPen, Flag, Guide,
+  ArrowDown, Bell, Checked, CircleCheckFilled, Collection, Connection, DataAnalysis, Document, DocumentAdd, EditPen, Flag, Guide,
   InfoFilled, Key, MagicStick, Opportunity, Plus, Promotion, Refresh, Search, Service, Switch, Tickets, User, UserFilled, Warning,
 } from '@element-plus/icons-vue'
 import { ElButton, ElIcon, ElMessage, ElMessageBox } from 'element-plus'
 import axios from 'axios'
 import logoUrl from './assets/logo.svg'
-import { api, type AgentToken, type Batch, type Requirement, type User as ApiUser } from './api'
+import { api, type AgentToken, type Batch, type Dashboard, type Requirement, type RequirementHistory, type User as ApiUser } from './api'
 import {
   avatarColor, batchTypeLabel, deliveryLabel, priorityLabel, reviewActionLabels, roleLabel, severityLabel,
   statusLabel, typeLabel,
@@ -582,21 +634,24 @@ const errorMessage = (error: unknown) => {
 
 const emptyRequirementForm = () => ({
   type: 'feature', title: '', description: '', log_text: '', current_behavior: '', expected_behavior: '', steps_to_reproduce: '',
-  severity: 'medium', product_version: '', visibility: 'public', environment: {} as Record<string, unknown>,
+  severity: 'medium', product_version: '', visibility: 'public', submitter_name: '', submitter_contact: '', environment: {} as Record<string, unknown>,
 })
 
-type Tab = 'public' | 'submit' | 'mine' | 'admin' | 'versions' | 'integrations' | 'users'
+type Tab = 'public' | 'dashboard' | 'submit' | 'mine' | 'admin' | 'versions' | 'integrations' | 'users'
 const tab = ref<Tab>('public')
 const user = ref<ApiUser | null>(null)
 const requirements = ref<Requirement[]>([]), myRequirements = ref<Requirement[]>([]), adminRequirements = ref<Requirement[]>([])
 const batches = ref<Batch[]>([]), users = ref<ApiUser[]>([]), candidates = ref<Requirement[]>([])
 const agentTokens = ref<AgentToken[]>([])
-const busy = ref(false), syncingGithub = ref(false), authDialog = ref(false), reviewDialog = ref(false), batchDialog = ref(false), tokenDialog = ref(false)
+const dashboard = ref<Dashboard | null>(null), detailHistory = ref<RequirementHistory[]>([])
+const busy = ref(false), syncingGithub = ref(false), authDialog = ref(false), reviewDialog = ref(false), editDialog = ref(false), batchDialog = ref(false), tokenDialog = ref(false)
 const githubOauthEnabled = ref(false), createdToken = ref('')
 const authMode = ref<'login' | 'register'>('login'), adminStatus = ref('pending_review')
 const sortBy = ref('updated')
 const detailDialog = ref(false), detailTarget = ref<Requirement | null>(null)
 const reviewTarget = ref<Requirement | null>(null)
+const editTarget = ref<Requirement | null>(null)
+const editForm = reactive({ type: 'feature', severity: 'medium', title: '', description: '', steps_to_reproduce: '', current_behavior: '', expected_behavior: '', log_text: '', product_version: '', visibility: 'public' })
 const filters = reactive({ q: '', type: '', status: '' })
 const authForm = reactive({ username: '', email: '', password: '' })
 const requirementForm = reactive(emptyRequirementForm())
@@ -617,6 +672,7 @@ const visibleTabs = computed(() => [
   { key: 'submit' as Tab, label: '提交需求' },
   { key: 'mine' as Tab, label: '我的需求' },
   { key: 'versions' as Tab, label: '版本计划' },
+  ...(isManager.value ? [{ key: 'dashboard' as Tab, label: '总览看板' }] : []),
   ...(isManager.value ? [{ key: 'admin' as Tab, label: '需求审核' }] : []),
   ...(isManager.value ? [{ key: 'integrations' as Tab, label: '集成设置' }] : []),
   ...(user.value?.role === 'owner' ? [{ key: 'users' as Tab, label: '角色管理' }] : []),
@@ -637,7 +693,7 @@ const sortedRequirements = computed(() => {
   else list.sort((a, b) => (b.follower_count || 0) - (a.follower_count || 0))
   return list
 })
-const canFollow = computed(() => !!detailTarget.value)
+const canFollow = computed(() => !!user.value && !!detailTarget.value)
 
 async function loadRequirements() {
   const p = new URLSearchParams()
@@ -648,6 +704,7 @@ async function loadRequirements() {
 }
 async function loadMine() { if (user.value) myRequirements.value = await api.requirements('?mine=true') }
 async function loadAdmin() { if (isManager.value) adminRequirements.value = await api.requirements(adminStatus.value ? `?status=${adminStatus.value}` : '') }
+async function loadDashboard() { if (isManager.value) dashboard.value = await api.dashboard() }
 async function loadBatches() { batches.value = await api.batches(); if (isManager.value) candidates.value = await api.requirements('?status=candidate&limit=100') }
 async function loadUsers() { if (user.value?.role === 'owner') users.value = await api.users() }
 async function loadIntegrations() { if (isManager.value) agentTokens.value = await api.agentTokens() }
@@ -657,6 +714,7 @@ async function switchTab(value: Tab) {
     if (value === 'public') await loadRequirements()
     if (value === 'mine') await loadMine()
     if (value === 'admin') await loadAdmin()
+    if (value === 'dashboard') await loadDashboard()
     if (value === 'versions') await loadBatches()
     if (value === 'users') await loadUsers()
     if (value === 'integrations') await loadIntegrations()
@@ -731,14 +789,15 @@ async function submitRequirement() {
     const created = await api.createRequirement(requirementForm)
     let uploadError: unknown = null
     for (const file of pendingFiles.value) {
-      try { await api.uploadAttachment(created.id, file) } catch (e) { uploadError = e; break }
+      try { await api.uploadAttachment(created.id, file, created.upload_token) } catch (e) { uploadError = e; break }
     }
     Object.assign(requirementForm, emptyRequirementForm())
     pendingFiles.value = []
     if (fileInput.value) fileInput.value.value = ''
     if (uploadError) ElMessage.warning(`需求已提交，但有附件上传失败：${errorMessage(uploadError)}`)
     else ElMessage.success('需求已提交')
-    await switchTab('mine')
+    if (user.value) await switchTab('mine')
+    else { await switchTab('public'); await openDetail(created) }
   } catch (e) { ElMessage.error(errorMessage(e)) } finally { busy.value = false }
 }
 
@@ -777,12 +836,52 @@ function saveDraft() {
   ElMessage.success('草稿已保存，下次进入提交页可继续填写')
 }
 
-function openDetail(item: Requirement) { detailTarget.value = item; detailDialog.value = true }
+async function openDetail(item: Requirement) {
+  try {
+    detailTarget.value = item.public_number ? await api.requirementByNumber(item.public_number) : item
+    detailHistory.value = await api.requirementHistory(item.id)
+    detailDialog.value = true
+    if (item.public_number) history.replaceState({}, '', `/requirements/REQ-${item.public_number}`)
+  } catch (e) { ElMessage.error(errorMessage(e)) }
+}
+function closeDetail() { history.replaceState({}, '', '/'); detailHistory.value = [] }
+function requirementLink(item: Requirement) { return `${window.location.origin}/requirements/REQ-${item.public_number}` }
+async function copyRequirementLink(item: Requirement) { await copyText(requirementLink(item)) }
+function historyLabel(event: RequirementHistory) {
+  if (event.before && event.after) return `状态由“${statusLabel(event.before)}”变为“${statusLabel(event.after)}”`
+  if (event.action === 'requirement.created') return '需求已提交'
+  if (event.action === 'requirement.updated') return '需求内容已更新'
+  if (event.after) return `状态更新为“${statusLabel(event.after)}”`
+  return '需求有新动态'
+}
+
+function openEdit(item: Requirement) {
+  editTarget.value = item
+  Object.assign(editForm, {
+    type: item.type, severity: item.severity, title: item.title, description: item.description,
+    steps_to_reproduce: item.steps_to_reproduce || '', log_text: item.log_text || '',
+    current_behavior: item.current_behavior || '', expected_behavior: item.expected_behavior || '',
+    product_version: item.product_version || '', visibility: item.visibility,
+  })
+  editDialog.value = true
+}
+async function submitEdit() {
+  if (!editTarget.value) return
+  if (editForm.title.trim().length < 4 || editForm.description.trim().length < 10) { ElMessage.error('请按要求填写标题和需求描述'); return }
+  busy.value = true
+  try {
+    const updated = await api.updateRequirement(editTarget.value.id, { ...editForm, title: editForm.title.trim(), description: editForm.description.trim() })
+    editDialog.value = false
+    ElMessage.success(updated.github_issue_number ? '需求已保存，GitHub Issue 将自动同步' : '需求已保存')
+    await refreshManaged()
+  } catch (e) { ElMessage.error(errorMessage(e)) } finally { busy.value = false }
+}
 
 function onRowAction(payload: { item: Requirement; command: string }) {
   const { item, command } = payload
   if (command === 'follow') follow(item)
   else if (command === 'review') openReview(item)
+  else if (command === 'edit') openEdit(item)
   else if (command === 'withdraw') withdraw(item)
   else if (command === 'github-create') createGithubIssue(item)
   else if (command === 'github-link') linkGithubIssue(item)
@@ -926,7 +1025,7 @@ onMounted(async () => {
     history.replaceState({}, '', `${window.location.pathname}${params.size ? `?${params}` : ''}`)
   }
   const requestedTab = params.get('view') as Tab | null
-  if (requestedTab && ['public', 'submit', 'mine', 'admin', 'versions', 'integrations', 'users'].includes(requestedTab)) tab.value = requestedTab
+  if (requestedTab && ['public', 'dashboard', 'submit', 'mine', 'admin', 'versions', 'integrations', 'users'].includes(requestedTab)) tab.value = requestedTab
   const requestedType = params.get('type')
   if (requestedType && ['bug', 'improvement', 'feature'].includes(requestedType)) requirementForm.type = requestedType
   if (tab.value === 'submit') {
@@ -936,12 +1035,17 @@ onMounted(async () => {
     } catch { localStorage.removeItem('rp_draft') }
   }
   if (!user.value) await restoreSession()
-  if ((['admin', 'integrations'].includes(tab.value) && !isManager.value) || (tab.value === 'users' && user.value?.role !== 'owner')) tab.value = 'public'
+  if ((['admin', 'dashboard', 'integrations'].includes(tab.value) && !isManager.value) || (tab.value === 'users' && user.value?.role !== 'owner')) tab.value = 'public'
   await Promise.all([loadRequirements(), loadBatches()])
   if (tab.value === 'mine') await loadMine()
   if (tab.value === 'admin') await loadAdmin()
+  if (tab.value === 'dashboard') await loadDashboard()
   if (tab.value === 'users') await loadUsers()
   if (tab.value === 'integrations') await loadIntegrations()
+  const directNumber = window.location.pathname.match(/^\/requirements\/REQ-(\d+)\/?$/i)
+  if (directNumber) {
+    try { await openDetail(await api.requirementByNumber(Number(directNumber[1]))) } catch (e) { ElMessage.error(errorMessage(e)) }
+  }
 })
 </script>
 

--- a/package/requirement-platform/web/src/App.vue
+++ b/package/requirement-platform/web/src/App.vue
@@ -385,7 +385,7 @@
             <el-table-column label="作用域"><template #default="scope"><span class="meta">{{ scope.row.scopes.join('、') }}</span></template></el-table-column>
             <el-table-column label="最后使用" width="170"><template #default="scope">{{ scope.row.last_used_at ? new Date(scope.row.last_used_at).toLocaleString() : '从未' }}</template></el-table-column>
             <el-table-column label="状态" width="100"><template #default="scope"><span class="tag no-dot plain">{{ scope.row.revoked_at ? '已撤销' : '有效' }}</span></template></el-table-column>
-            <el-table-column label="操作" width="100"><template #default="scope"><el-button v-if="!scope.row.revoked_at" text type="danger" @click="revokeToken(scope.row.id)">撤销</el-button></template></el-table-column>
+            <el-table-column label="操作" width="150"><template #default="scope"><el-button v-if="!scope.row.revoked_at" text type="primary" :icon="Connection" @click="openMcpConnection(scope.row)">接入</el-button><el-button v-if="!scope.row.revoked_at" text type="danger" @click="revokeToken(scope.row.id)">撤销</el-button></template></el-table-column>
           </el-table>
         </article>
         <article class="panel mcp-guide" style="margin-top:16px">
@@ -403,6 +403,10 @@
               <p>编辑用户级 <code>~/.codex/config.toml</code>。Codex 会在连接 MCP 时直接注入请求头，沙盒内的 Agent 无需读取宿主机环境变量。</p>
               <pre class="code-block mcp-code"><code>{{ mcpConfigExample }}</code></pre>
               <el-button size="small" @click="copyText(mcpConfigExample)">复制配置</el-button>
+            </li>
+            <li>
+              <strong>通过 Codex 设置界面接入</strong>
+              <p>URL 填 <code>{{ mcpUrl }}</code>；“Bearer 令牌环境变量”留空；在“标头”中填写 <code>Authorization</code> 和 <code>Bearer 完整令牌</code>；“来自环境变量的标头”留空。不要把 <code>bearer_token_env_var</code> 当作标头名。</p>
             </li>
             <li>
               <strong>重启并验证</strong>
@@ -540,8 +544,32 @@
         <el-form-item label="有效期（天）"><el-input-number v-model="tokenForm.expires_in_days" :min="1" :max="365" /></el-form-item>
         <el-form-item label="授权作用域"><el-checkbox-group v-model="tokenForm.scopes"><el-checkbox v-for="scope in scopeOptions" :key="scope" :value="scope">{{ scope }}</el-checkbox></el-checkbox-group></el-form-item>
       </el-form>
-      <el-alert v-if="createdToken" type="success" :closable="false" title="请立即复制，关闭后无法再次查看"><code class="code-block">{{ createdToken }}</code><el-button style="margin-top:10px" @click="copyText(createdToken)">复制令牌</el-button></el-alert>
+      <el-alert v-if="createdToken" type="success" :closable="false" title="请立即复制，关闭后无法再次查看"><code class="code-block">{{ createdToken }}</code><div class="token-created-actions"><el-button @click="copyText(createdToken)">复制令牌</el-button><el-button type="primary" :icon="Connection" @click="openCreatedTokenConnection">接入</el-button></div></el-alert>
       <template #footer><el-button @click="tokenDialog = false; createdToken = ''">关闭</el-button><el-button v-if="!createdToken" type="primary" :loading="busy" @click="createToken">创建</el-button></template>
+    </el-dialog>
+
+    <el-dialog v-model="mcpConnectionDialog" title="接入 MCP 客户端" width="min(94vw, 680px)" :close-on-click-modal="false">
+      <el-form label-position="top">
+        <el-form-item label="完整令牌" required>
+          <el-input v-model="connectionToken" type="password" show-password placeholder="粘贴以 trp_ 开头的完整令牌" autocomplete="off" />
+          <div class="field-hint">平台只保存令牌哈希。历史令牌需要重新粘贴；令牌仅保留在当前弹窗内。</div>
+        </el-form-item>
+      </el-form>
+      <div class="connection-section">
+        <div class="section-title-row"><div><h3>通用 Streamable HTTP MCP</h3><p class="meta">适用于支持 JSON MCP 配置的客户端。</p></div><el-button :disabled="!connectionToken.trim()" @click="copyText(genericMcpConfig)">复制 JSON</el-button></div>
+        <pre class="code-block mcp-code"><code>{{ genericMcpConfig }}</code></pre>
+      </div>
+      <div class="connection-section">
+        <h3>Codex 设置界面</h3>
+        <dl class="config-fields">
+          <div><dt>URL</dt><dd>{{ mcpUrl }}</dd></div>
+          <div><dt>Bearer 令牌环境变量</dt><dd>留空</dd></div>
+          <div><dt>标头</dt><dd><code>Authorization</code> → <code>Bearer 完整令牌</code></dd></div>
+          <div><dt>来自环境变量的标头</dt><dd>留空</dd></div>
+        </dl>
+      </div>
+      <el-alert type="warning" :closable="false" title="配置包含完整令牌">只复制到可信客户端，不要提交到 Git 或发送给其他人；令牌泄露后请立即撤销。</el-alert>
+      <template #footer><el-button @click="closeMcpConnection">关闭</el-button></template>
     </el-dialog>
 
     <!-- ============ 人工审核 ============ -->
@@ -644,8 +672,8 @@ const requirements = ref<Requirement[]>([]), myRequirements = ref<Requirement[]>
 const batches = ref<Batch[]>([]), users = ref<ApiUser[]>([]), candidates = ref<Requirement[]>([])
 const agentTokens = ref<AgentToken[]>([])
 const dashboard = ref<Dashboard | null>(null), detailHistory = ref<RequirementHistory[]>([])
-const busy = ref(false), syncingGithub = ref(false), authDialog = ref(false), reviewDialog = ref(false), editDialog = ref(false), batchDialog = ref(false), tokenDialog = ref(false)
-const githubOauthEnabled = ref(false), createdToken = ref('')
+const busy = ref(false), syncingGithub = ref(false), authDialog = ref(false), reviewDialog = ref(false), editDialog = ref(false), batchDialog = ref(false), tokenDialog = ref(false), mcpConnectionDialog = ref(false)
+const githubOauthEnabled = ref(false), createdToken = ref(''), createdTokenId = ref(''), connectionToken = ref('')
 const authMode = ref<'login' | 'register'>('login'), adminStatus = ref('pending_review')
 const sortBy = ref('updated')
 const detailDialog = ref(false), detailTarget = ref<Requirement | null>(null)
@@ -662,8 +690,17 @@ const batchForm = reactive({ name: '', version_name: '', goal: '', batch_type: '
 const scopeOptions = ['requirements:read', 'requirements:write', 'requirements:review', 'versions:read', 'versions:write', 'github:write']
 const tokenForm = reactive({ name: '', scopes: ['requirements:read'], expires_in_days: 90 })
 const mcpUrl = `${window.location.origin}/mcp/`
-const mcpConfigExample = computed(() => `[mcp_servers.trailsnap_requirements]\nurl = "${mcpUrl}"\nhttp_headers = { Authorization = "Bearer rp_替换为刚创建的完整令牌" }\ndefault_tools_approval_mode = "writes"`)
+const mcpConfigExample = computed(() => `[mcp_servers.trailsnap_requirements]\nurl = "${mcpUrl}"\nhttp_headers = { Authorization = "Bearer trp_替换为刚创建的完整令牌" }\ndefault_tools_approval_mode = "writes"`)
 const mcpEnvConfigExample = computed(() => `[mcp_servers.trailsnap_requirements]\nurl = "${mcpUrl}"\nbearer_token_env_var = "TRAILSNAP_MCP_TOKEN"\ndefault_tools_approval_mode = "writes"`)
+const genericMcpConfig = computed(() => JSON.stringify({
+  mcpServers: {
+    'trailsnap-feedback': {
+      type: 'http',
+      url: mcpUrl,
+      headers: { Authorization: connectionToken.value.trim() ? `Bearer ${connectionToken.value.trim()}` : 'Bearer <完整令牌>' },
+    },
+  },
+}, null, 2))
 const candidateSelection = reactive<Record<string, string>>({})
 
 const isManager = computed(() => user.value?.role === 'admin' || user.value?.role === 'owner')
@@ -765,11 +802,24 @@ async function createToken() {
   try {
     const result = await api.createAgentToken({ ...tokenForm })
     createdToken.value = result.token
+    createdTokenId.value = result.id
     await loadIntegrations()
   } catch (e) { ElMessage.error(errorMessage(e)) } finally { busy.value = false }
 }
 async function revokeToken(id: string) {
   try { await ElMessageBox.confirm('撤销后 Agent 将立即失去访问权限，确认继续？', '撤销令牌'); await api.revokeAgentToken(id); await loadIntegrations(); ElMessage.success('令牌已撤销') } catch (e) { if (e !== 'cancel') ElMessage.error(errorMessage(e)) }
+}
+function openMcpConnection(token: AgentToken) {
+  connectionToken.value = token.id === createdTokenId.value ? createdToken.value : ''
+  mcpConnectionDialog.value = true
+}
+function openCreatedTokenConnection() {
+  connectionToken.value = createdToken.value
+  mcpConnectionDialog.value = true
+}
+function closeMcpConnection() {
+  mcpConnectionDialog.value = false
+  connectionToken.value = ''
 }
 async function copyText(value: string) { await navigator.clipboard.writeText(value); ElMessage.success('已复制') }
 
@@ -1063,6 +1113,15 @@ onMounted(async () => {
 .mcp-guide h2 { margin: 0 0 6px; font-size: 18px; }
 .guide-steps { margin: 20px 0; padding-left: 24px; display: grid; gap: 18px; }
 .guide-steps li { padding-left: 4px; }
+.token-created-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+.connection-section { margin-bottom: 18px; }
+.connection-section h3 { margin: 0 0 6px; font-size: 15px; }
+.config-fields { margin: 10px 0 0; border: 1px solid var(--rp-border); border-radius: 10px; overflow: hidden; }
+.config-fields > div { display: grid; grid-template-columns: 190px minmax(0, 1fr); border-bottom: 1px solid var(--rp-border); }
+.config-fields > div:last-child { border-bottom: 0; }
+.config-fields dt, .config-fields dd { margin: 0; padding: 10px 12px; font-size: 13px; }
+.config-fields dt { color: var(--rp-text-2); background: #f8fafc; font-weight: 600; }
+.config-fields dd { color: var(--rp-text); overflow-wrap: anywhere; }
 .guide-steps p { margin: 6px 0 10px; color: var(--rp-text-2); line-height: 1.65; font-size: 13.5px; }
 .guide-steps code { font-size: 12.5px; }
 .mcp-code { margin: 10px 0; overflow-x: auto; overflow-wrap: normal; white-space: pre; }
@@ -1073,5 +1132,8 @@ onMounted(async () => {
   .account-row,.section-title-row { align-items:flex-start; flex-wrap:wrap; }
   .mcp-guide .section-title-row { display: grid; }
   .guide-steps { padding-left: 20px; }
+  .config-fields > div { grid-template-columns: 1fr; }
+  .config-fields dt { padding-bottom: 4px; }
+  .config-fields dd { padding-top: 4px; }
 }
 </style>

--- a/package/requirement-platform/web/src/RequirementTable.vue
+++ b/package/requirement-platform/web/src/RequirementTable.vue
@@ -20,7 +20,7 @@
                 <el-icon :size="18"><component :is="typeIcon(item.type)" /></el-icon>
               </span>
               <div style="min-width: 0">
-                <p class="req-title req-title-link" @click="emit('open', item)">{{ item.title }}</p>
+                <p class="req-title req-title-link" @click="emit('open', item)"><span class="req-number">REQ-{{ item.public_number }}</span> {{ item.title }}</p>
                 <p class="req-desc">{{ item.description }}</p>
               </div>
             </div>
@@ -43,6 +43,7 @@
                   <el-dropdown-item command="follow">关注（{{ item.follower_count || 0 }}）</el-dropdown-item>
                   <el-dropdown-item v-if="canWithdraw(item)" command="withdraw">撤回</el-dropdown-item>
                   <el-dropdown-item v-if="manager" command="review">审核</el-dropdown-item>
+                  <el-dropdown-item v-if="manager" command="edit">编辑需求</el-dropdown-item>
                   <el-dropdown-item v-if="manager && !item.github_issue_number" command="github-create">新建 GitHub Issue</el-dropdown-item>
                   <el-dropdown-item v-if="manager && !item.github_issue_number" command="github-link">关联已有 GitHub Issue</el-dropdown-item>
                   <el-dropdown-item v-if="manager && item.github_issue_number && item.github_state !== 'closed'" command="github-close">关闭 GitHub Issue 与需求</el-dropdown-item>
@@ -102,4 +103,5 @@ const canWithdraw = (item: Requirement) =>
 .t-feature { background: #eff6ff; color: #2563eb; }
 .t-improvement { background: #f5f3ff; color: #7c3aed; }
 .t-bug { background: #fff7ed; color: #ea580c; }
+.req-number { color: var(--rp-primary); font-size: 12px; font-weight: 700; white-space: nowrap; }
 </style>

--- a/package/requirement-platform/web/src/api.ts
+++ b/package/requirement-platform/web/src/api.ts
@@ -4,11 +4,12 @@ export type GitHubIdentity = { github_user_id: number; login: string; avatar_url
 export type User = { id: string; username: string; email: string; role: 'viewer' | 'admin' | 'owner'; is_active: boolean; github?: GitHubIdentity }
 export type AgentToken = { id: string; name: string; token_prefix: string; scopes: string[]; expires_at?: string; last_used_at?: string; revoked_at?: string; created_at: string }
 export type Requirement = {
-  id: string; type: string; title: string; description: string; log_text?: string; current_behavior?: string; expected_behavior?: string
+  id: string; public_number?: number; type: string; title: string; description: string; log_text?: string; current_behavior?: string; expected_behavior?: string
   steps_to_reproduce?: string; severity: string; product_version?: string; environment: Record<string, unknown>
   visibility: string; status: string; priority: string; risk_level: string; review_reason?: string
   duplicate_of_id?: string; github_issue_number?: number; github_issue_url?: string; github_state?: string
-  created_by: string; created_by_name?: string; created_at: string; updated_at: string; follower_count: number; triage?: Record<string, unknown>
+  created_by?: string; created_by_name?: string; submitter_name?: string; submitter_contact?: string; upload_token?: string
+  created_at: string; updated_at: string; follower_count: number; triage?: Record<string, unknown>
   deleted_at?: string; deleted_by?: string; delete_reason?: string; source: 'platform' | 'github'
   attachments?: Array<{ id: string; name: string; content_type: string; size_bytes: number; kind: string; download_url: string }>
 }
@@ -17,6 +18,8 @@ export type Batch = {
   id: string; name: string; version_name: string; batch_type: string; goal: string; status: string; target_date?: string
   max_risk_level: string; github_milestone_number?: number; github_milestone_url?: string; items: BatchItem[]
 }
+export type RequirementHistory = { id: string; action: string; actor_name: string; before?: string; after?: string; reason?: string; created_at: string }
+export type Dashboard = { total: number; new_last_7_days: number; pending_review: number; in_progress: number; github_linked: number; anonymous: number; by_status: Record<string, number>; by_type: Record<string, number> }
 
 const client = axios.create({ baseURL: import.meta.env.VITE_REQUIREMENT_API_URL || '/api', timeout: 20000 })
 client.interceptors.request.use(config => {
@@ -40,10 +43,14 @@ export const api = {
   githubUnlink: () => call<{ unlinked: boolean }>('delete', '/auth/github/link'),
   requirements: (params = '') => call<Requirement[]>('get', `/requirements${params}`),
   createRequirement: (data: unknown) => call<Requirement>('post', '/requirements', data),
-  uploadAttachment: (id: string, file: File) => {
+  uploadAttachment: (id: string, file: File, uploadToken?: string) => {
     const data = new FormData(); data.append('file', file)
-    return call<{ id: string; name: string }>('post', `/requirements/${id}/attachments`, data)
+    return client.post(`/requirements/${id}/attachments`, data, {
+      headers: uploadToken ? { 'X-Requirement-Upload-Token': uploadToken } : undefined,
+    }).then(response => response.data.data as { id: string; name: string })
   },
+  requirementByNumber: (number: number) => call<Requirement>('get', `/requirements/number/${number}`),
+  requirementHistory: (id: string) => call<RequirementHistory[]>('get', `/requirements/${id}/history`),
   downloadAttachment: async (requirementId: string, attachmentId: string, name: string) => {
     const response = await client.get(`/requirements/${requirementId}/attachments/${attachmentId}`, { responseType: 'blob' })
     const url = URL.createObjectURL(response.data)
@@ -63,6 +70,7 @@ export const api = {
   unlinkGithubIssue: (id: string) => call<Requirement>('delete', `/requirements/${id}/github/link`),
   closeGithubIssue: (id: string, reason: string) => call<Requirement>('post', `/requirements/${id}/github/close`, { reason }),
   syncGithubIssues: () => call<{ created: number; updated: number; skipped: number; total: number }>('post', '/admin/github/issues/sync'),
+  dashboard: () => call<Dashboard>('get', '/admin/dashboard'),
   batches: () => call<Batch[]>('get', '/versions'),
   createBatch: (data: unknown) => call<Batch>('post', '/versions', data),
   addBatchItem: (batchId: string, requirementId: string) => call<Batch>('post', `/versions/${batchId}/items`, { requirement_id: requirementId }),

--- a/package/requirement-platform/web/src/style.css
+++ b/package/requirement-platform/web/src/style.css
@@ -143,6 +143,19 @@ a { color: inherit; }
 .section-head .el-icon { color: var(--rp-primary); }
 .field-hint { color: var(--rp-text-3); font-size: 12.5px; line-height: 1.5; margin-top: 5px; }
 .submit-quota { color: var(--rp-text-2); font-size: 13px; line-height: 1.5; margin-top: 10px; }
+.dashboard-cards { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 12px; margin-bottom: 16px; }
+.dashboard-card { display: grid; gap: 6px; text-align: center; }
+.dashboard-card strong { color: var(--rp-primary); font-size: 28px; }
+.dashboard-card span { color: var(--rp-text-2); font-size: 13px; }
+.dashboard-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.dashboard-grid h2 { margin: 0 0 14px; font-size: 17px; }
+.distribution-row { display: flex; justify-content: space-between; padding: 9px 0; border-bottom: 1px solid var(--rp-border); }
+.contact-box { margin-top: 14px; padding: 10px 12px; border-radius: 8px; background: #fff7ed; color: #9a3412; font-size: 13px; }
+.timeline { margin-top: 20px; border-top: 1px solid var(--rp-border); padding-top: 14px; }
+.timeline h3 { margin: 0 0 12px; font-size: 15px; }
+.timeline-item { position: relative; display: flex; gap: 10px; padding: 0 0 14px 4px; }
+.timeline-dot { width: 9px; height: 9px; margin-top: 5px; border-radius: 50%; background: var(--rp-primary); flex: none; }
+.timeline-item p { margin: 3px 0 0; color: var(--rp-text-3); font-size: 12px; }
 .native-file { width: 100%; padding: 10px; border: 1px dashed var(--rp-border); border-radius: 10px; background: #f8fafc; color: var(--rp-text-2); }
 .file-list { width: 100%; margin-top: 8px; display: grid; gap: 6px; }
 .file-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 7px 10px; border-radius: 8px; background: #f8fafc; color: var(--rp-text-2); font-size: 13px; }
@@ -215,6 +228,7 @@ a { color: inherit; }
   .brand-sub { display: none; }
   .main { padding: 20px 16px 48px; }
   .page-head-actions { width: 100%; justify-content: space-between; }
+  .dashboard-cards { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 @media (max-width: 720px) {
   .main { padding: 16px 12px 36px; }
@@ -228,13 +242,17 @@ a { color: inherit; }
   .page-head-actions { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 8px; }
   .page-head-actions > .el-select { grid-column: 1 / -1; width: 100% !important; }
   .page-head-actions > .stat-cards { grid-column: 1 / -1; }
-  .page-head-actions > .el-button { width: 100%; margin-left: 0; }
+  .page-head-actions > .el-button { grid-column: 1 / -1; width: 100%; margin-left: 0; }
   .stat-cards { width: 100%; gap: 8px; justify-content: space-between; }
   .stat-card { min-width: 0; flex: 1; }
   .filters { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
   .filters .search { grid-column: 1 / -1; max-width: none; }
   .filters .select, .filters .sort { width: 100%; }
   .actions > .el-button { flex: 1 1 140px; margin-left: 0; min-height: 40px; }
+  .submit-form .actions { display: grid; grid-template-columns: minmax(0, 1fr); }
+  .submit-form .actions > .el-button { width: 100%; max-width: 100%; min-width: 0; }
+  .page-head-actions > .el-button { max-width: 100%; min-width: 0; }
+  .dashboard-cards, .dashboard-grid { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
   .native-file { min-height: 44px; }
   .file-row { align-items: flex-start; flex-wrap: wrap; word-break: break-all; }
   .batch-grid { grid-template-columns: minmax(0, 1fr); }


### PR DESCRIPTION
## 描述\n\n实现需求管理平台的下一组人工管理能力：管理员完整编辑并同步 GitHub Issue 内容；为需求增加 REQ 公共编号、编号搜索、详情直链、复制链接和变更时间线；允许匿名提交并保护联系方式；增加全体非管理员共享的一小时 20 条限流；新增管理员总览看板；修复移动端提交按钮溢出。\n\n这是基于 #230 的堆叠 PR。#230 合并后，本 PR 可将 base 切换为 master。\n\n## 变更类型\n\n- [x] ✨ 新功能 (New Feature)\n- [x] 🐛 修复错误 (Bug Fix)\n- [x] ✅ 测试增加/修改 (Tests)\n\n## 相关 Issue\n\nCloses #231\n\n## 如何测试\n\n- uv run pytest：9 passed\n- npm run build：通过\n- Alembic 从空 SQLite 数据库升级到 head：通过\n- 本地 Docker API、worker、MCP 已重建并迁移到 9c73e1ab420d\n- Playwright 在 375x812 视口验证 document scrollWidth=375，表单提交按钮位于 x=27、宽 321，无横向溢出\n\n## 检查清单\n\n- [x] 我已阅读并遵循项目的贡献指南\n- [x] 我的代码遵循项目的代码风格\n- [x] 我已添加/更新了必要的测试\n- [x] 所有测试均已通过\n- [x] 我已添加数据库迁移\n\nI have read and agree to the CLA