### PR TITLE
feat(requirements): 支持 Markdown 需求详情页

### DIFF
--- a/package/requirement-platform/server/requirement_platform/mcp_server.py
+++ b/package/requirement-platform/server/requirement_platform/mcp_server.py
@@ -2,11 +2,13 @@
 
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlsplit
 
 from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.mcpserver import MCPServer
+from mcp.server.transport_security import TransportSecuritySettings
 from sqlalchemy import func
 
 from .config import settings
@@ -283,4 +285,30 @@ def list_versions() -> list[dict[str, Any]]:
                 for row in db.query(ReleaseBatch).order_by(ReleaseBatch.created_at.desc()).all()]
 
 
-mcp_http_app = mcp.streamable_http_app(streamable_http_path="/", stateless_http=True, json_response=True)
+def _transport_security_settings() -> TransportSecuritySettings:
+    """Trust the configured public endpoints while retaining DNS rebinding protection."""
+    allowed_hosts = {"127.0.0.1:*", "localhost:*", "[::1]:*"}
+    allowed_origins = {"http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"}
+
+    for endpoint in (settings.mcp_public_url, settings.web_url):
+        parsed = urlsplit(endpoint)
+        if not parsed.scheme or not parsed.hostname:
+            continue
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        allowed_hosts.update({host, f"{host}:*"})
+        allowed_origins.add(f"{parsed.scheme}://{parsed.netloc}")
+
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=sorted(allowed_hosts),
+        allowed_origins=sorted(allowed_origins),
+    )
+
+
+mcp_http_app = mcp.streamable_http_app(
+    streamable_http_path="/",
+    stateless_http=True,
+    json_response=True,
+    host="0.0.0.0",
+    transport_security=_transport_security_settings(),
+)

--- a/package/requirement-platform/server/tests/test_platform_flow.py
+++ b/package/requirement-platform/server/tests/test_platform_flow.py
@@ -9,6 +9,8 @@ os.environ["RP_DATABASE_URL"] = f"sqlite:///{Path(TEST_DIR.name) / 'requirements
 os.environ["RP_JWT_SECRET"] = "test-secret-that-is-long-enough-for-tests"
 os.environ["RP_GITHUB_TOKEN"] = ""
 os.environ["RP_UPLOAD_DIR"] = str(Path(TEST_DIR.name) / "uploads")
+os.environ["RP_WEB_URL"] = "https://feedback.trailsnap.cn"
+os.environ["RP_MCP_PUBLIC_URL"] = "https://feedback.trailsnap.cn/mcp/"
 
 from fastapi.testclient import TestClient  # noqa: E402
 
@@ -229,7 +231,12 @@ def test_manager_github_soft_delete_agent_token_and_mcp(monkeypatch):
         mcp_token = token_response.json()["data"]["token"]
 
     with TestClient(mcp_http_app) as mcp_client:
-        headers = {"Authorization": f"Bearer {mcp_token}", "Accept": "application/json, text/event-stream", "Host": "127.0.0.1:8000"}
+        headers = {
+            "Authorization": f"Bearer {mcp_token}",
+            "Accept": "application/json, text/event-stream",
+            "Host": "feedback.trailsnap.cn",
+            "Origin": "https://feedback.trailsnap.cn",
+        }
         initialized = mcp_client.post("/", headers=headers, json={
             "jsonrpc": "2.0", "id": 1, "method": "initialize",
             "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "pytest", "version": "1"}},
@@ -238,6 +245,12 @@ def test_manager_github_soft_delete_agent_token_and_mcp(monkeypatch):
         tools = mcp_client.post("/", headers=headers, json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
         assert tools.status_code == 200, tools.text
         assert "list_requirements" in {item["name"] for item in tools.json()["result"]["tools"]}
+        rejected = mcp_client.post(
+            "/",
+            headers={**headers, "Host": "attacker.example"},
+            json={"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {}},
+        )
+        assert rejected.status_code == 421
 
 
 def test_attachment_limits_and_private_access():

--- a/package/requirement-platform/web/package-lock.json
+++ b/package/requirement-platform/web/package-lock.json
@@ -11,9 +11,11 @@
         "@element-plus/icons-vue": "^2.3.2",
         "axios": "^1.18.0",
         "element-plus": "^2.11.9",
+        "markdown-it": "^15.0.1",
         "vue": "^3.5.13"
       },
       "devDependencies": {
+        "@types/markdown-it": "^14.2.0",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/tsconfig": "^0.8.1",
         "typescript": "^5.9.3",
@@ -962,6 +964,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
@@ -976,6 +985,24 @@
       "dependencies": {
         "@types/lodash": "*"
       }
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
@@ -1362,6 +1389,22 @@
       "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.1.tgz",
+      "integrity": "sha512-nM4mHF/KM1v59ZNKX7zfusQz5wUAxR511YG8Vo6TyiV4aqhu++rbJW4v04xsWhpSsHFj66flT8P7znVpyO20xQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "PSF-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1893,6 +1936,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -1932,6 +1994,45 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.1.tgz",
+      "integrity": "sha512-9/7gE95FNPkfUWrjJIoHZza2iLmuJlPD0UNMxPi7bxUrbCR525YZY0r+zyfes0dZI5ZZ/uNIXUJca0pJvtw41g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1940,6 +2041,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "6.0.0",
@@ -2099,6 +2206,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rollup": {
@@ -2264,6 +2380,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.3",

--- a/package/requirement-platform/web/package.json
+++ b/package/requirement-platform/web/package.json
@@ -12,9 +12,11 @@
     "@element-plus/icons-vue": "^2.3.2",
     "axios": "^1.18.0",
     "element-plus": "^2.11.9",
+    "markdown-it": "^15.0.1",
     "vue": "^3.5.13"
   },
   "devDependencies": {
+    "@types/markdown-it": "^14.2.0",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/tsconfig": "^0.8.1",
     "typescript": "^5.9.3",

--- a/package/requirement-platform/web/src/App.vue
+++ b/package/requirement-platform/web/src/App.vue
@@ -38,8 +38,27 @@
     </header>
 
     <main class="main">
+      <!-- ============ 需求详情页 ============ -->
+      <section v-if="detailRouteNumber">
+        <div v-if="detailLoading" class="panel empty">正在加载 REQ-{{ detailRouteNumber }}…</div>
+        <RequirementDetail
+          v-else-if="detailTarget"
+          :requirement="detailTarget"
+          :history="detailHistory"
+          :manager="isManager"
+          :can-follow="canFollow"
+          @back="closeDetail"
+          @copy-link="copyRequirementLink(detailTarget)"
+          @follow="followDetail"
+          @edit="openEdit(detailTarget)"
+          @review="openReview(detailTarget)"
+          @download="downloadAttachment(detailTarget, $event)"
+        />
+        <div v-else class="panel empty">需求不存在或你没有查看权限。</div>
+      </section>
+
       <!-- ============ 公开需求 ============ -->
-      <section v-if="tab === 'public'">
+      <section v-else-if="tab === 'public'">
         <div class="page-head">
           <div class="page-head-left">
             <div class="page-head-icon"><el-icon :size="26"><Document /></el-icon></div>
@@ -462,55 +481,6 @@
       </div>
     </footer>
 
-    <!-- ============ 需求详情 ============ -->
-    <el-dialog v-model="detailDialog" :title="detailTarget ? `REQ-${detailTarget.public_number} · ${detailTarget.title}` : '需求详情'" width="min(92vw, 680px)" @closed="closeDetail">
-      <template v-if="detailTarget">
-        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px">
-          <span class="tag no-dot" :class="`t-${detailTarget.type}`">{{ typeLabel(detailTarget.type) }}</span>
-          <span class="tag" :class="`s-${detailTarget.status}`">{{ statusLabel(detailTarget.status) }}</span>
-          <span class="tag no-dot" :class="`p-${detailTarget.priority}`">优先级：{{ priorityLabel(detailTarget.priority) }}</span>
-          <span class="tag no-dot" :class="`sev-${detailTarget.severity}`">影响：{{ severityLabel(detailTarget.severity) }}</span>
-        </div>
-        <p class="description" style="margin:0 0 14px">{{ detailTarget.description }}</p>
-        <div v-if="detailTarget.current_behavior" class="meta" style="margin-bottom:6px"><strong>当前行为：</strong>{{ detailTarget.current_behavior }}</div>
-        <div v-if="detailTarget.expected_behavior" class="meta" style="margin-bottom:14px"><strong>期望行为：</strong>{{ detailTarget.expected_behavior }}</div>
-        <div v-if="detailTarget.triage" class="triage-box">
-          <div class="triage-head"><el-icon><MagicStick /></el-icon>AI 分析建议</div>
-          <p>{{ String(detailTarget.triage.summary || detailTarget.triage.recommendation || '分析已完成') }}</p>
-        </div>
-        <div v-if="detailTarget.review_reason" class="meta" style="margin-top:12px"><strong>审核说明：</strong>{{ detailTarget.review_reason }}</div>
-        <div v-if="detailTarget.log_text" class="triage-box" style="margin-top:12px"><strong>日志（仅本人和管理员可见）</strong><pre class="log-text">{{ detailTarget.log_text }}</pre></div>
-        <div v-if="detailTarget.attachments?.length" style="margin-top:12px">
-          <strong>附件（仅本人和管理员可见）</strong>
-          <div v-for="attachment in detailTarget.attachments" :key="attachment.id" class="file-row">
-            <span>{{ attachment.name }}（{{ formatBytes(attachment.size_bytes) }}）</span>
-            <el-button link type="primary" @click="downloadAttachment(detailTarget, attachment)">下载</el-button>
-          </div>
-        </div>
-        <div class="meta" style="margin-top:14px">
-          <span>提交人：{{ detailTarget.created_by_name || '用户' }}</span>
-          <span>提交于 {{ new Date(detailTarget.created_at).toLocaleString() }}</span>
-          <span>{{ detailTarget.follower_count || 0 }} 人关注</span>
-          <a v-if="detailTarget.github_issue_url" :href="detailTarget.github_issue_url" target="_blank" rel="noopener">GitHub #{{ detailTarget.github_issue_number }}</a>
-        </div>
-        <div v-if="isManager && detailTarget.submitter_contact" class="contact-box"><strong>提交人联系方式（仅管理员可见）：</strong>{{ detailTarget.submitter_contact }}</div>
-        <div class="timeline">
-          <h3>需求动态</h3>
-          <div v-if="!detailHistory.length" class="field-hint">暂无状态记录</div>
-          <div v-for="event in detailHistory" :key="event.id" class="timeline-item">
-            <span class="timeline-dot"></span>
-            <div><strong>{{ historyLabel(event) }}</strong><p>{{ event.actor_name }} · {{ new Date(event.created_at).toLocaleString() }}<span v-if="event.reason"> · {{ event.reason }}</span></p></div>
-          </div>
-        </div>
-      </template>
-      <template #footer>
-        <el-button v-if="detailTarget" @click="copyRequirementLink(detailTarget)">复制链接</el-button>
-        <el-button v-if="detailTarget && canFollow" @click="follow(detailTarget); detailDialog = false">关注（{{ detailTarget.follower_count || 0 }}）</el-button>
-        <el-button v-if="detailTarget && isManager" @click="detailDialog = false; openEdit(detailTarget)">编辑</el-button>
-        <el-button v-if="detailTarget && isManager" type="primary" @click="detailDialog = false; openReview(detailTarget)">审核</el-button>
-      </template>
-    </el-dialog>
-
     <el-dialog v-model="editDialog" title="编辑需求" width="min(92vw, 640px)">
       <el-form label-position="top">
         <div class="form-grid"><el-form-item label="类型" required><el-select v-model="editForm.type"><el-option label="新功能" value="feature" /><el-option label="体验优化" value="improvement" /><el-option label="问题修复" value="bug" /></el-select></el-form-item><el-form-item label="影响程度" required><el-select v-model="editForm.severity"><el-option label="低" value="low" /><el-option label="中" value="medium" /><el-option label="高" value="high" /><el-option label="严重" value="critical" /></el-select></el-form-item></div>
@@ -619,20 +589,21 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import {
   ArrowDown, Bell, Checked, CircleCheckFilled, Collection, Connection, DataAnalysis, Document, DocumentAdd, EditPen, Flag, Guide,
-  InfoFilled, Key, MagicStick, Opportunity, Plus, Promotion, Refresh, Search, Service, Switch, Tickets, User, UserFilled, Warning,
+  InfoFilled, Key, Opportunity, Plus, Promotion, Refresh, Search, Service, Switch, Tickets, User, UserFilled, Warning,
 } from '@element-plus/icons-vue'
 import { ElButton, ElIcon, ElMessage, ElMessageBox } from 'element-plus'
 import axios from 'axios'
 import logoUrl from './assets/logo.svg'
 import { api, type AgentToken, type Batch, type Dashboard, type Requirement, type RequirementHistory, type User as ApiUser } from './api'
 import {
-  avatarColor, batchTypeLabel, deliveryLabel, priorityLabel, reviewActionLabels, roleLabel, severityLabel,
+  avatarColor, batchTypeLabel, deliveryLabel, reviewActionLabels, roleLabel,
   statusLabel, typeLabel,
 } from './labels'
 import RequirementTable from './RequirementTable.vue'
+import RequirementDetail from './RequirementDetail.vue'
 
 const statusOptions = ['pending_review', 'candidate', 'scheduled', 'developing', 'testing', 'release_ready', 'released', 'deferred', 'rejected']
 const reviewStatuses = ['submitted', 'triaging', 'pending_review', 'needs_information', 'candidate', 'deferred', 'rejected', 'duplicate']
@@ -676,7 +647,8 @@ const busy = ref(false), syncingGithub = ref(false), authDialog = ref(false), re
 const githubOauthEnabled = ref(false), createdToken = ref(''), createdTokenId = ref(''), connectionToken = ref('')
 const authMode = ref<'login' | 'register'>('login'), adminStatus = ref('pending_review')
 const sortBy = ref('updated')
-const detailDialog = ref(false), detailTarget = ref<Requirement | null>(null)
+const detailRouteNumber = ref<number | null>(routeRequirementNumber())
+const detailLoading = ref(false), detailTarget = ref<Requirement | null>(null)
 const reviewTarget = ref<Requirement | null>(null)
 const editTarget = ref<Requirement | null>(null)
 const editForm = reactive({ type: 'feature', severity: 'medium', title: '', description: '', steps_to_reproduce: '', current_behavior: '', expected_behavior: '', log_text: '', product_version: '', visibility: 'public' })
@@ -746,6 +718,12 @@ async function loadBatches() { batches.value = await api.batches(); if (isManage
 async function loadUsers() { if (user.value?.role === 'owner') users.value = await api.users() }
 async function loadIntegrations() { if (isManager.value) agentTokens.value = await api.agentTokens() }
 async function switchTab(value: Tab) {
+  if (detailRouteNumber.value) {
+    detailRouteNumber.value = null
+    detailTarget.value = null
+    detailHistory.value = []
+    history.pushState({}, '', '/')
+  }
   tab.value = value
   try {
     if (value === 'public') await loadRequirements()
@@ -886,23 +864,54 @@ function saveDraft() {
   ElMessage.success('草稿已保存，下次进入提交页可继续填写')
 }
 
-async function openDetail(item: Requirement) {
-  try {
-    detailTarget.value = item.public_number ? await api.requirementByNumber(item.public_number) : item
-    detailHistory.value = await api.requirementHistory(item.id)
-    detailDialog.value = true
-    if (item.public_number) history.replaceState({}, '', `/requirements/REQ-${item.public_number}`)
-  } catch (e) { ElMessage.error(errorMessage(e)) }
+function routeRequirementNumber() {
+  const match = window.location.pathname.match(/^\/requirements\/REQ-(\d+)\/?$/i)
+  return match ? Number(match[1]) : null
 }
-function closeDetail() { history.replaceState({}, '', '/'); detailHistory.value = [] }
+async function loadDetail(number: number) {
+  detailLoading.value = true
+  try {
+    const requirement = await api.requirementByNumber(number)
+    detailTarget.value = requirement
+    detailHistory.value = await api.requirementHistory(requirement.id)
+  } catch (e) {
+    detailTarget.value = null
+    detailHistory.value = []
+    ElMessage.error(errorMessage(e))
+  } finally { detailLoading.value = false }
+}
+async function openDetail(item: Requirement) {
+  if (!item.public_number) return
+  detailRouteNumber.value = item.public_number
+  history.pushState({}, '', `/requirements/REQ-${item.public_number}`)
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+  await loadDetail(item.public_number)
+}
+function closeDetail() {
+  detailRouteNumber.value = null
+  detailTarget.value = null
+  detailHistory.value = []
+  history.pushState({}, '', '/')
+}
 function requirementLink(item: Requirement) { return `${window.location.origin}/requirements/REQ-${item.public_number}` }
 async function copyRequirementLink(item: Requirement) { await copyText(requirementLink(item)) }
-function historyLabel(event: RequirementHistory) {
-  if (event.before && event.after) return `状态由“${statusLabel(event.before)}”变为“${statusLabel(event.after)}”`
-  if (event.action === 'requirement.created') return '需求已提交'
-  if (event.action === 'requirement.updated') return '需求内容已更新'
-  if (event.after) return `状态更新为“${statusLabel(event.after)}”`
-  return '需求有新动态'
+async function followDetail() {
+  if (!detailTarget.value) return
+  if (!user.value) { authDialog.value = true; return }
+  try {
+    await api.followRequirement(detailTarget.value.id)
+    ElMessage.success('关注状态已更新')
+    if (detailRouteNumber.value) await loadDetail(detailRouteNumber.value)
+  } catch (e) { ElMessage.error(errorMessage(e)) }
+}
+function handlePopState() {
+  const number = routeRequirementNumber()
+  detailRouteNumber.value = number
+  if (number) void loadDetail(number)
+  else {
+    detailTarget.value = null
+    detailHistory.value = []
+  }
 }
 
 function openEdit(item: Requirement) {
@@ -924,6 +933,7 @@ async function submitEdit() {
     editDialog.value = false
     ElMessage.success(updated.github_issue_number ? '需求已保存，GitHub Issue 将自动同步' : '需求已保存')
     await refreshManaged()
+    if (detailRouteNumber.value) await loadDetail(detailRouteNumber.value)
   } catch (e) { ElMessage.error(errorMessage(e)) } finally { busy.value = false }
 }
 
@@ -994,6 +1004,7 @@ async function submitReview() {
     ElMessage.success('审核结果已保存')
     await loadAdmin()
     await loadRequirements()
+    if (detailRouteNumber.value) await loadDetail(detailRouteNumber.value)
   } catch (e) { ElMessage.error(errorMessage(e)) } finally { busy.value = false }
 }
 
@@ -1061,6 +1072,7 @@ function logout() {
 }
 
 onMounted(async () => {
+  window.addEventListener('popstate', handlePopState)
   const params = new URLSearchParams(window.location.search)
   try { githubOauthEnabled.value = (await api.authStatus()).github_oauth_enabled } catch { githubOauthEnabled.value = false }
   const githubError = params.get('github_error')
@@ -1101,11 +1113,9 @@ onMounted(async () => {
   if (tab.value === 'dashboard') await loadDashboard()
   if (tab.value === 'users') await loadUsers()
   if (tab.value === 'integrations') await loadIntegrations()
-  const directNumber = window.location.pathname.match(/^\/requirements\/REQ-(\d+)\/?$/i)
-  if (directNumber) {
-    try { await openDetail(await api.requirementByNumber(Number(directNumber[1]))) } catch (e) { ElMessage.error(errorMessage(e)) }
-  }
+  if (detailRouteNumber.value) await loadDetail(detailRouteNumber.value)
 })
+onBeforeUnmount(() => window.removeEventListener('popstate', handlePopState))
 </script>
 
 <style scoped>

--- a/package/requirement-platform/web/src/RequirementDetail.vue
+++ b/package/requirement-platform/web/src/RequirementDetail.vue
@@ -1,0 +1,226 @@
+<template>
+  <div class="detail-page">
+    <button class="detail-back" type="button" @click="emit('back')">
+      <el-icon><ArrowLeft /></el-icon>返回需求列表
+    </button>
+
+    <header class="detail-header">
+      <div>
+        <h1>{{ requirement.title }} <span>REQ-{{ requirement.public_number }}</span></h1>
+        <p>
+          {{ requirement.created_by_name || '用户' }} 于 {{ formatDateTime(requirement.created_at) }} 提交
+          · {{ requirement.follower_count || 0 }} 人关注
+        </p>
+      </div>
+      <el-button :icon="Link" @click="emit('copyLink')">复制链接</el-button>
+    </header>
+
+    <div class="detail-layout">
+      <div class="detail-main">
+        <article class="panel issue-content">
+          <div class="issue-author">
+            <span class="avatar" :style="{ ...avatarColor(requirement.created_by_name || '用户') }">
+              {{ (requirement.created_by_name || '用户').slice(0, 1) }}
+            </span>
+            <strong>{{ requirement.created_by_name || '用户' }}</strong>
+            <span>描述了这个需求</span>
+          </div>
+
+          <div class="markdown-body" v-html="renderMarkdown(requirement.description)"></div>
+
+          <section v-if="requirement.steps_to_reproduce" class="issue-section">
+            <h2>复现步骤</h2>
+            <div class="markdown-body" v-html="renderMarkdown(requirement.steps_to_reproduce)"></div>
+          </section>
+          <section v-if="requirement.current_behavior" class="issue-section">
+            <h2>当前行为</h2>
+            <div class="markdown-body" v-html="renderMarkdown(requirement.current_behavior)"></div>
+          </section>
+          <section v-if="requirement.expected_behavior" class="issue-section">
+            <h2>期望行为</h2>
+            <div class="markdown-body" v-html="renderMarkdown(requirement.expected_behavior)"></div>
+          </section>
+
+          <div v-if="requirement.triage" class="triage-box">
+            <div class="triage-head"><el-icon><MagicStick /></el-icon>AI 分析建议</div>
+            <div class="markdown-body compact" v-html="renderMarkdown(triageText)"></div>
+          </div>
+          <div v-if="requirement.review_reason" class="review-note">
+            <strong>审核说明</strong>
+            <div class="markdown-body compact" v-html="renderMarkdown(requirement.review_reason)"></div>
+          </div>
+          <div v-if="requirement.log_text" class="log-panel">
+            <strong>日志（仅本人和管理员可见）</strong>
+            <pre class="log-text">{{ requirement.log_text }}</pre>
+          </div>
+          <div v-if="requirement.attachments?.length" class="attachments">
+            <strong>附件（仅本人和管理员可见）</strong>
+            <div v-for="attachment in requirement.attachments" :key="attachment.id" class="file-row">
+              <span>{{ attachment.name }}（{{ formatBytes(attachment.size_bytes) }}）</span>
+              <el-button link type="primary" @click="emit('download', attachment)">下载</el-button>
+            </div>
+          </div>
+          <div v-if="manager && requirement.submitter_contact" class="contact-box">
+            <strong>提交人联系方式（仅管理员可见）：</strong>{{ requirement.submitter_contact }}
+          </div>
+        </article>
+      </div>
+
+      <aside class="detail-sidebar">
+        <article class="panel detail-status">
+          <div class="detail-tags">
+            <span class="tag" :class="`s-${requirement.status}`">{{ statusLabel(requirement.status) }}</span>
+            <span class="tag no-dot" :class="`t-${requirement.type}`">{{ typeLabel(requirement.type) }}</span>
+            <span class="tag no-dot" :class="`p-${requirement.priority}`">{{ priorityLabel(requirement.priority) }}</span>
+            <span class="tag no-dot" :class="`sev-${requirement.severity}`">影响：{{ severityLabel(requirement.severity) }}</span>
+          </div>
+          <dl>
+            <div><dt>产品版本</dt><dd>{{ requirement.product_version || '未填写' }}</dd></div>
+            <div><dt>来源</dt><dd>{{ requirement.source === 'github' ? 'GitHub' : '需求平台' }}</dd></div>
+            <div><dt>最后更新</dt><dd>{{ formatDateTime(requirement.updated_at) }}</dd></div>
+          </dl>
+          <a v-if="requirement.github_issue_url" class="github-link" :href="requirement.github_issue_url" target="_blank" rel="noopener noreferrer">
+            查看 GitHub Issue #{{ requirement.github_issue_number }}
+          </a>
+          <div class="detail-actions">
+            <el-button v-if="canFollow" @click="emit('follow')">关注（{{ requirement.follower_count || 0 }}）</el-button>
+            <el-button v-if="manager" @click="emit('edit')">编辑</el-button>
+            <el-button v-if="manager" type="primary" @click="emit('review')">审核</el-button>
+          </div>
+        </article>
+
+        <article class="panel detail-timeline">
+          <h2>状态变化</h2>
+          <div v-if="!history.length" class="field-hint">暂无状态记录</div>
+          <div v-for="event in history" :key="event.id" class="timeline-item">
+            <span class="timeline-dot"></span>
+            <div>
+              <strong>{{ historyLabel(event) }}</strong>
+              <p>{{ event.actor_name }} · {{ formatDateTime(event.created_at) }}</p>
+              <p v-if="event.reason" class="timeline-reason">{{ event.reason }}</p>
+            </div>
+          </div>
+        </article>
+      </aside>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ArrowLeft, Link, MagicStick } from '@element-plus/icons-vue'
+import { ElButton, ElIcon } from 'element-plus'
+import MarkdownIt from 'markdown-it'
+import type { Requirement, RequirementHistory } from './api'
+import { avatarColor, priorityLabel, severityLabel, statusLabel, typeLabel } from './labels'
+
+type Attachment = NonNullable<Requirement['attachments']>[number]
+
+const props = defineProps<{
+  requirement: Requirement
+  history: RequirementHistory[]
+  manager: boolean
+  canFollow: boolean
+}>()
+const emit = defineEmits<{
+  back: []
+  copyLink: []
+  follow: []
+  edit: []
+  review: []
+  download: [attachment: Attachment]
+}>()
+
+const markdown = new MarkdownIt({ html: false, linkify: true, breaks: true })
+markdown.renderer.rules.link_open = (tokens, index, options, _env, self) => {
+  const token = tokens[index]
+  if (!token) return ''
+  token.attrSet('target', '_blank')
+  token.attrSet('rel', 'noopener noreferrer')
+  return self.renderToken(tokens, index, options)
+}
+
+const triageText = computed(() => String(
+  props.requirement.triage?.summary || props.requirement.triage?.recommendation || '分析已完成',
+))
+const renderMarkdown = (value?: string) => markdown.render(value || '')
+const formatDateTime = (value: string) => new Date(value).toLocaleString()
+const formatBytes = (size: number) => size < 1024 * 1024 ? `${Math.ceil(size / 1024)}KB` : `${(size / 1024 / 1024).toFixed(1)}MB`
+const historyLabel = (event: RequirementHistory) => {
+  if (event.before && event.after) return `状态由“${statusLabel(event.before)}”变为“${statusLabel(event.after)}”`
+  if (event.action === 'requirement.created') return '需求已提交'
+  if (event.action === 'requirement.updated') return '需求内容已更新'
+  if (event.after) return `状态更新为“${statusLabel(event.after)}”`
+  return '需求有新动态'
+}
+</script>
+
+<style scoped>
+.detail-back { display: inline-flex; align-items: center; gap: 6px; margin: 0 0 18px; padding: 7px 0; border: 0; background: transparent; color: var(--rp-text-2); cursor: pointer; }
+.detail-back:hover { color: var(--rp-primary); }
+.detail-back:focus-visible { outline: 2px solid var(--rp-primary); outline-offset: 3px; border-radius: 4px; }
+.detail-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; margin-bottom: 20px; }
+.detail-header h1 { margin: 0 0 8px; font-size: 28px; line-height: 1.3; overflow-wrap: anywhere; }
+.detail-header h1 span { color: var(--rp-text-3); font-weight: 400; }
+.detail-header p { margin: 0; color: var(--rp-text-3); font-size: 13px; }
+.detail-layout { display: grid; grid-template-columns: minmax(0, 1fr) 310px; gap: 20px; align-items: start; }
+.detail-main, .detail-sidebar { min-width: 0; }
+.issue-content { padding: 0; overflow: hidden; }
+.issue-author { display: flex; align-items: center; gap: 8px; padding: 12px 18px; border-bottom: 1px solid var(--rp-border); background: #f8fafc; color: var(--rp-text-3); font-size: 13px; }
+.issue-author .avatar { width: 28px; height: 28px; font-size: 12px; }
+.issue-author strong { color: var(--rp-text); }
+.issue-content > .markdown-body { padding: 20px; }
+.issue-section { margin: 0 20px; padding: 18px 0; border-top: 1px solid var(--rp-border); }
+.issue-section h2 { margin: 0 0 10px; font-size: 16px; }
+.triage-box, .review-note, .log-panel, .attachments, .contact-box { margin: 0 20px 18px; }
+.review-note { padding: 12px 14px; border-radius: 10px; background: #f8fafc; border: 1px solid var(--rp-border); }
+.review-note > strong { font-size: 13px; }
+.log-panel, .attachments { padding-top: 16px; border-top: 1px solid var(--rp-border); }
+.detail-sidebar { position: sticky; top: 84px; }
+.detail-status, .detail-timeline { padding: 16px; }
+.detail-tags { display: flex; flex-wrap: wrap; gap: 8px; padding-bottom: 14px; border-bottom: 1px solid var(--rp-border); }
+.detail-status dl { margin: 0; }
+.detail-status dl > div { display: flex; justify-content: space-between; gap: 12px; padding: 10px 0; border-bottom: 1px solid var(--rp-border); font-size: 13px; }
+.detail-status dt { color: var(--rp-text-3); }
+.detail-status dd { margin: 0; color: var(--rp-text-2); text-align: right; }
+.github-link { display: inline-flex; margin-top: 12px; color: var(--rp-primary); font-size: 13px; text-decoration: none; }
+.github-link:hover { text-decoration: underline; }
+.detail-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 14px; }
+.detail-actions .el-button { margin-left: 0; }
+.detail-actions .el-button:first-child:last-child, .detail-actions .el-button:nth-last-child(3):first-child { grid-column: 1 / -1; }
+.detail-timeline h2 { margin: 0 0 16px; font-size: 16px; }
+.timeline-item { position: relative; display: flex; gap: 10px; padding: 0 0 16px; }
+.timeline-item:not(:last-child)::before { content: ''; position: absolute; left: 4px; top: 13px; bottom: 0; width: 1px; background: var(--rp-border); }
+.timeline-dot { position: relative; z-index: 1; width: 9px; height: 9px; margin-top: 5px; border-radius: 50%; background: var(--rp-primary); flex: none; }
+.timeline-item strong { font-size: 13px; line-height: 1.45; }
+.timeline-item p { margin: 3px 0 0; color: var(--rp-text-3); font-size: 12px; line-height: 1.45; }
+.timeline-item .timeline-reason { color: var(--rp-text-2); }
+.markdown-body { min-width: 0; color: var(--rp-text-2); font-size: 14px; line-height: 1.75; overflow-wrap: anywhere; }
+.markdown-body.compact { font-size: 13px; }
+.markdown-body :deep(:first-child) { margin-top: 0; }
+.markdown-body :deep(:last-child) { margin-bottom: 0; }
+.markdown-body :deep(h1), .markdown-body :deep(h2), .markdown-body :deep(h3) { color: var(--rp-text); line-height: 1.4; }
+.markdown-body :deep(h1) { font-size: 22px; padding-bottom: 8px; border-bottom: 1px solid var(--rp-border); }
+.markdown-body :deep(h2) { font-size: 18px; padding-bottom: 6px; border-bottom: 1px solid var(--rp-border); }
+.markdown-body :deep(h3) { font-size: 16px; }
+.markdown-body :deep(a) { color: var(--rp-primary); }
+.markdown-body :deep(blockquote) { margin: 12px 0; padding: 1px 14px; border-left: 4px solid var(--rp-border); color: var(--rp-text-3); }
+.markdown-body :deep(code) { padding: 2px 5px; border-radius: 5px; background: #f1f5f9; color: #be123c; font-size: 12.5px; }
+.markdown-body :deep(pre) { max-width: 100%; padding: 14px; border-radius: 9px; background: #0f172a; color: #e2e8f0; overflow-x: auto; }
+.markdown-body :deep(pre code) { padding: 0; background: transparent; color: inherit; }
+.markdown-body :deep(img) { max-width: 100%; height: auto; border-radius: 8px; }
+.markdown-body :deep(table) { display: block; max-width: 100%; border-collapse: collapse; overflow-x: auto; }
+.markdown-body :deep(th), .markdown-body :deep(td) { padding: 7px 10px; border: 1px solid var(--rp-border); }
+
+@media (max-width: 860px) {
+  .detail-layout { grid-template-columns: 1fr; }
+  .detail-sidebar { position: static; }
+}
+@media (max-width: 520px) {
+  .detail-header { display: grid; }
+  .detail-header h1 { font-size: 22px; }
+  .detail-header .el-button { width: 100%; }
+  .issue-content > .markdown-body { padding: 16px; }
+  .issue-section, .triage-box, .review-note, .log-panel, .attachments, .contact-box { margin-left: 16px; margin-right: 16px; }
+}
+</style>


### PR DESCRIPTION
## 描述

- 使用关闭原始 HTML 的 Markdown 渲染器展示需求正文、复现步骤、行为说明和审核说明。
- 将需求详情从弹窗改为独立的 \/requirements/REQ-编号\ 页面。
- 右侧集中展示状态、元数据和完整状态变化时间线，窄屏自动改为单栏。
- 支持直接链接、复制链接以及浏览器前进/后退。
- 修复 Cloudflare/反向代理公网域名访问 MCP 时的 421 Host 校验，并保留 DNS 重绑定防护。

## 变更类型
- [x] 🐛 修复错误 (Bug Fix)
- [x] ✨ 新功能 (New Feature)
- [x] ✅ 测试增加/修改 (Tests)

## 相关 Issue
Closes #234

## 如何测试
- \cd package/requirement-platform/server && uv run pytest -q\：9 passed
- \cd package/requirement-platform/web && npm run build\：通过
- Playwright 真实浏览器验证 Markdown 渲染、独立地址、前进/后退与 390px 移动端布局。

## 检查清单
- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [ ] 我已更新了相关文档（本次无需新增部署配置）