### PR TITLE
feat(requirements): 完善 MCP 全生命周期能力

### DIFF
--- a/package/requirement-platform/README.md
+++ b/package/requirement-platform/README.md
@@ -106,6 +106,15 @@ bearer_token_env_var = "TRAILSNAP_REQUIREMENTS_TOKEN"
 令牌明文只返回一次，数据库仅保存 SHA-256 摘要；可设置有效期并随时撤销。`requirements:review`
 允许关闭和软删除需求，`github:write` 允许变更 GitHub Issue，应只授予受信任的 Agent。
 
+MCP 作用域与能力：
+
+- `requirements:read`：查询需求、附件、历史/编辑/审核记录、分诊报告和后台任务。
+- `requirements:write`：创建和完整编辑需求、通过 Base64 上传附件、关注/取消关注及撤回需求。
+- `requirements:review`：审核、标记重复、关闭、软删除和恢复需求。
+- `versions:read`：查询版本批次、范围快照、单项交付状态和 GitHub Milestone。
+- `versions:write`：创建版本、增删范围条目、锁定范围、流转版本状态及更新交付状态。
+- `github:write`：创建、关联、解除关联和关闭 Issue，导入/同步 Issue，以及同步版本 Milestone。
+
 面向公网时，内置 nginx 会限制单 IP 的登录、注册和 API 访问频率，并限制请求体大小；应用层还会限制每个账号每天的提交数和未关闭需求数。API 与 SQLite 均不暴露宿主机端口，公网只应开放 HTTPS 反向代理入口。
 
 ## 验证

--- a/package/requirement-platform/server/requirement_platform/mcp_server.py
+++ b/package/requirement-platform/server/requirement_platform/mcp_server.py
@@ -1,6 +1,9 @@
 """Authenticated MCP tools for requirement and release management."""
 
+import base64
+import secrets
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -14,10 +17,11 @@ from sqlalchemy import func
 from .config import settings
 from .db import SessionLocal
 from .models import (
-    AgentToken, ReleaseBatch, ReleaseBatchItem, Requirement, RequirementFollower, RequirementRevision, ReviewDecision, User,
+    AgentToken, AuditEvent, BackgroundJob, ReleaseBatch, ReleaseBatchItem, Requirement, RequirementAttachment,
+    RequirementFollower, RequirementRevision, ReviewDecision, TriageReport, User, utcnow,
 )
 from .security import resolve_agent_token
-from .services import GitHubClient, audit, enqueue, requirement_snapshot
+from .services import GitHubClient, STATUS_LABELS, audit, enqueue, requirement_snapshot, sync_batch_milestone
 
 
 class DatabaseTokenVerifier:
@@ -43,7 +47,7 @@ class DatabaseTokenVerifier:
 mcp = MCPServer(
     name="trailsnap-requirements",
     title="TrailSnap 需求管理",
-    version="0.2.0",
+    version="0.3.0",
     instructions=(
         "用于查询和管理 TrailSnap 需求与版本。任何写入、审核、删除和 GitHub 操作都必须遵循令牌作用域；"
         "删除为可恢复的软删除。执行 review_requirement 前先读取需求详情，理由必须具体。"
@@ -79,15 +83,46 @@ def _requirement_dict(row: Requirement) -> dict[str, Any]:
     return {
         "id": row.id, "public_number": row.public_number, "reference": f"REQ-{row.public_number}",
         "type": row.type, "title": row.title, "description": row.description,
-        "current_behavior": row.current_behavior, "expected_behavior": row.expected_behavior,
-        "steps_to_reproduce": row.steps_to_reproduce, "severity": row.severity,
-        "product_version": row.product_version, "visibility": row.visibility, "status": row.status,
+        "log_text": row.log_text, "current_behavior": row.current_behavior, "expected_behavior": row.expected_behavior,
+        "steps_to_reproduce": row.steps_to_reproduce, "severity": row.severity, "product_version": row.product_version,
+        "environment": row.environment, "visibility": row.visibility, "status": row.status,
         "priority": row.priority, "risk_level": row.risk_level, "review_reason": row.review_reason,
+        "duplicate_of_id": row.duplicate_of_id,
         "github_issue_number": row.github_issue_number, "github_issue_url": row.github_issue_url,
-        "github_state": row.github_state, "created_by": row.created_by,
+        "github_state": row.github_state, "source": row.source, "created_by": row.created_by,
         "created_at": row.created_at.isoformat(), "updated_at": row.updated_at.isoformat(),
         "deleted_at": row.deleted_at.isoformat() if row.deleted_at else None,
     }
+
+
+def _batch_dict(row: ReleaseBatch, db) -> dict[str, Any]:
+    items = db.query(ReleaseBatchItem).filter(ReleaseBatchItem.batch_id == row.id).order_by(
+        ReleaseBatchItem.priority_order, ReleaseBatchItem.created_at
+    ).all()
+    return {
+        "id": row.id, "name": row.name, "version_name": row.version_name, "batch_type": row.batch_type,
+        "goal": row.goal, "status": row.status, "target_date": row.target_date, "max_risk_level": row.max_risk_level,
+        "scope_summary": row.scope_summary, "github_milestone_number": row.github_milestone_number,
+        "github_milestone_url": row.github_milestone_url, "locked_at": row.locked_at.isoformat() if row.locked_at else None,
+        "created_at": row.created_at.isoformat(), "updated_at": row.updated_at.isoformat(),
+        "items": [{"id": item.id, "requirement_id": item.requirement_id, "priority_order": item.priority_order,
+                   "delivery_status": item.delivery_status, "requirement_snapshot": item.requirement_snapshot} for item in items],
+    }
+
+
+def _requirement_or_error(db, requirement_id: str, *, include_deleted: bool = False) -> Requirement:
+    query = db.query(Requirement).filter(Requirement.id == requirement_id)
+    if not include_deleted:
+        query = query.filter(Requirement.deleted_at.is_(None))
+    row = query.first()
+    if not row:
+        raise ValueError("需求不存在")
+    return row
+
+
+def _enqueue_requirement_github_sync(db, row: Requirement) -> None:
+    if row.github_issue_number or (row.visibility == "public" and row.status == "candidate"):
+        enqueue(db, "github_issue", row.id, f"github_issue:{row.id}:{row.status}:{secrets.token_hex(6)}")
 
 
 @mcp.tool()
@@ -121,17 +156,23 @@ def get_requirement(requirement_id: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-def create_requirement(type: str, title: str, description: str, severity: str = "medium", visibility: str = "public", expected_behavior: str | None = None) -> dict[str, Any]:
+def create_requirement(type: str, title: str, description: str, severity: str = "medium", visibility: str = "public",
+                       log_text: str | None = None, current_behavior: str | None = None,
+                       expected_behavior: str | None = None, steps_to_reproduce: str | None = None,
+                       product_version: str | None = None, environment: dict[str, Any] | None = None) -> dict[str, Any]:
     """以令牌所属管理员身份创建需求。"""
     _, actor = _identity("requirements:write")
     if type not in {"bug", "improvement", "feature"} or severity not in {"low", "medium", "high", "critical"}:
         raise ValueError("需求类型或影响程度无效")
-    if visibility not in {"public", "private"} or len(title.strip()) < 4 or len(description.strip()) < 10:
+    if (visibility not in {"public", "private"} or not 4 <= len(title.strip()) <= 160
+            or not 10 <= len(description.strip()) <= 8000):
         raise ValueError("需求内容或公开范围无效")
     with SessionLocal() as db:
         public_number = (db.query(func.max(Requirement.public_number)).scalar() or 0) + 1
         row = Requirement(public_number=public_number, type=type, title=title.strip(), description=description.strip(), severity=severity,
-                          visibility=visibility, expected_behavior=expected_behavior, created_by=actor.id)
+                          visibility=visibility, log_text=log_text, current_behavior=current_behavior,
+                          expected_behavior=expected_behavior, steps_to_reproduce=steps_to_reproduce,
+                          product_version=product_version, environment=environment or {}, created_by=actor.id)
         db.add(row)
         db.flush()
         db.add(RequirementFollower(requirement_id=row.id, user_id=actor.id))
@@ -143,26 +184,30 @@ def create_requirement(type: str, title: str, description: str, severity: str = 
 
 
 @mcp.tool()
-def update_requirement(requirement_id: str, title: str | None = None, description: str | None = None,
-                       expected_behavior: str | None = None, severity: str | None = None,
-                       visibility: str | None = None) -> dict[str, Any]:
+def update_requirement(requirement_id: str, type: str | None = None, title: str | None = None, description: str | None = None,
+                       log_text: str | None = None, current_behavior: str | None = None, expected_behavior: str | None = None,
+                       steps_to_reproduce: str | None = None, severity: str | None = None, product_version: str | None = None,
+                       environment: dict[str, Any] | None = None, visibility: str | None = None) -> dict[str, Any]:
     """更新需求正文；未传入的字段保持不变。"""
     _, actor = _identity("requirements:write")
+    if type and type not in {"bug", "improvement", "feature"}:
+        raise ValueError("需求类型无效")
     if severity and severity not in {"low", "medium", "high", "critical"}:
         raise ValueError("影响程度无效")
     if visibility and visibility not in {"public", "private"}:
         raise ValueError("公开范围无效")
     with SessionLocal() as db:
-        row = db.query(Requirement).filter(Requirement.id == requirement_id, Requirement.deleted_at.is_(None)).first()
-        if not row:
-            raise ValueError("需求不存在")
+        row = _requirement_or_error(db, requirement_id)
         db.add(RequirementRevision(requirement_id=row.id, editor_id=actor.id, snapshot=requirement_snapshot(row), reason="mcp updated"))
-        values = {"title": title, "description": description, "expected_behavior": expected_behavior,
-                  "severity": severity, "visibility": visibility}
+        values = {"type": type, "title": title, "description": description, "log_text": log_text,
+                  "current_behavior": current_behavior, "expected_behavior": expected_behavior,
+                  "steps_to_reproduce": steps_to_reproduce, "severity": severity, "product_version": product_version,
+                  "environment": environment, "visibility": visibility}
         for field, value in values.items():
             if value is not None:
                 setattr(row, field, value.strip() if isinstance(value, str) else value)
         row.version += 1
+        _enqueue_requirement_github_sync(db, row)
         enqueue(db, "triage", row.id, f"triage:{row.id}:v{row.version}")
         audit(db, actor.id, "requirement.updated", "requirement", row.id, source="mcp", version=row.version)
         db.commit()
@@ -170,20 +215,32 @@ def update_requirement(requirement_id: str, title: str | None = None, descriptio
 
 
 @mcp.tool()
-def review_requirement(requirement_id: str, action: str, reason: str, priority: str = "normal", risk_level: str = "medium") -> dict[str, Any]:
+def review_requirement(requirement_id: str, action: str, reason: str, priority: str = "normal", risk_level: str = "medium",
+                       duplicate_of_id: str | None = None) -> dict[str, Any]:
     """人工授权的 Agent 审核需求并修改其状态。"""
     _, actor = _identity("requirements:review")
     statuses = {"candidate": "candidate", "needs_information": "needs_information", "rejected": "rejected",
-                "deferred": "deferred", "close": "closed"}
+                "deferred": "deferred", "duplicate": "duplicate", "close": "closed"}
     if action not in statuses or len(reason.strip()) < 2:
         raise ValueError("审核动作或理由无效")
+    if priority not in {"low", "normal", "high", "urgent"} or risk_level not in {"low", "medium", "high", "critical"}:
+        raise ValueError("优先级或风险等级无效")
     with SessionLocal() as db:
-        row = db.query(Requirement).filter(Requirement.id == requirement_id, Requirement.deleted_at.is_(None)).first()
-        if not row:
-            raise ValueError("需求不存在")
+        row = _requirement_or_error(db, requirement_id)
+        if action == "duplicate":
+            target = _requirement_or_error(db, duplicate_of_id or "")
+            if target.id == row.id:
+                raise ValueError("重复需求不能指向自身")
+            row.duplicate_of_id = target.id
+            for follower in db.query(RequirementFollower).filter(RequirementFollower.requirement_id == row.id).all():
+                if not db.query(RequirementFollower).filter(RequirementFollower.requirement_id == target.id,
+                                                           RequirementFollower.user_id == follower.user_id).first():
+                    db.add(RequirementFollower(requirement_id=target.id, user_id=follower.user_id))
         row.status, row.review_reason, row.priority, row.risk_level = statuses[action], reason.strip(), priority, risk_level
+        _enqueue_requirement_github_sync(db, row)
         db.add(ReviewDecision(requirement_id=row.id, reviewer_id=actor.id, action=action, reason=reason,
-                              metadata_json={"source": "mcp", "priority": priority, "risk_level": risk_level}))
+                              metadata_json={"source": "mcp", "priority": priority, "risk_level": risk_level,
+                                             "duplicate_of_id": duplicate_of_id}))
         audit(db, actor.id, f"requirement.{action}", "requirement", row.id, source="mcp", reason=reason)
         db.commit()
         return _requirement_dict(row)
@@ -277,12 +334,379 @@ def close_github_issue(requirement_id: str, reason: str) -> dict[str, Any]:
 
 @mcp.tool()
 def list_versions() -> list[dict[str, Any]]:
-    """列出版本批次及状态。"""
+    """列出版本批次、范围条目、交付状态和 GitHub Milestone。"""
     _identity("versions:read")
     with SessionLocal() as db:
-        return [{"id": row.id, "name": row.name, "version_name": row.version_name, "goal": row.goal,
-                 "status": row.status, "target_date": row.target_date, "locked_at": row.locked_at.isoformat() if row.locked_at else None}
-                for row in db.query(ReleaseBatch).order_by(ReleaseBatch.created_at.desc()).all()]
+        return [_batch_dict(row, db) for row in db.query(ReleaseBatch).order_by(ReleaseBatch.created_at.desc()).all()]
+
+
+@mcp.tool()
+def get_version(batch_id: str) -> dict[str, Any]:
+    """读取一个版本批次的完整范围、交付状态和 Milestone 信息。"""
+    _identity("versions:read")
+    with SessionLocal() as db:
+        row = db.query(ReleaseBatch).filter(ReleaseBatch.id == batch_id).first()
+        if not row:
+            raise ValueError("版本批次不存在")
+        return _batch_dict(row, db)
+
+
+@mcp.tool()
+def create_version(name: str, version_name: str, goal: str, batch_type: str = "feature", target_date: str | None = None,
+                   max_risk_level: str = "high") -> dict[str, Any]:
+    """创建版本批次。"""
+    _, actor = _identity("versions:write")
+    if batch_type not in {"fix", "feature", "major", "hotfix"} or max_risk_level not in {"low", "medium", "high", "critical"}:
+        raise ValueError("版本类型或最大风险等级无效")
+    with SessionLocal() as db:
+        if db.query(ReleaseBatch).filter(ReleaseBatch.version_name == version_name).first():
+            raise ValueError("版本号已存在")
+        row = ReleaseBatch(name=name.strip(), version_name=version_name.strip(), goal=goal.strip(), batch_type=batch_type,
+                           target_date=target_date, max_risk_level=max_risk_level, created_by=actor.id)
+        db.add(row)
+        db.flush()
+        audit(db, actor.id, "release_batch.created", "release_batch", row.id, source="mcp", version_name=row.version_name)
+        db.commit()
+        return _batch_dict(row, db)
+
+
+@mcp.tool()
+def add_version_requirement(batch_id: str, requirement_id: str, priority_order: int = 0) -> dict[str, Any]:
+    """把候选需求加入未锁定的版本范围。"""
+    _, actor = _identity("versions:write")
+    with SessionLocal() as db:
+        batch = db.query(ReleaseBatch).filter(ReleaseBatch.id == batch_id).first()
+        requirement = _requirement_or_error(db, requirement_id)
+        if not batch:
+            raise ValueError("版本批次不存在")
+        if batch.status not in {"planning", "candidate_selection"}:
+            raise ValueError("版本范围已锁定")
+        if requirement.status not in {"candidate", "scheduled"}:
+            raise ValueError("只能加入候选需求")
+        ranks = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+        if ranks.get(requirement.risk_level, 4) > ranks.get(batch.max_risk_level, 3):
+            raise ValueError("需求风险超过版本上限")
+        if db.query(ReleaseBatchItem).filter(ReleaseBatchItem.batch_id == batch.id,
+                                             ReleaseBatchItem.requirement_id == requirement.id).first():
+            raise ValueError("需求已在该版本中")
+        db.add(ReleaseBatchItem(batch_id=batch.id, requirement_id=requirement.id, priority_order=max(priority_order, 0),
+                                requirement_snapshot=requirement_snapshot(requirement)))
+        batch.status = "candidate_selection"
+        audit(db, actor.id, "release_batch.item_added", "release_batch", batch.id, source="mcp", requirement_id=requirement.id)
+        db.commit()
+        return _batch_dict(batch, db)
+
+
+@mcp.tool()
+def remove_version_requirement(batch_id: str, item_id: str) -> dict[str, Any]:
+    """从未锁定版本中移除一个范围条目。"""
+    _, actor = _identity("versions:write")
+    with SessionLocal() as db:
+        batch = db.query(ReleaseBatch).filter(ReleaseBatch.id == batch_id).first()
+        item = db.query(ReleaseBatchItem).filter(ReleaseBatchItem.id == item_id, ReleaseBatchItem.batch_id == batch_id).first()
+        if not batch or not item:
+            raise ValueError("版本条目不存在")
+        if batch.status not in {"planning", "candidate_selection"}:
+            raise ValueError("版本范围已锁定")
+        audit(db, actor.id, "release_batch.item_removed", "release_batch", batch.id, source="mcp", requirement_id=item.requirement_id)
+        db.delete(item)
+        db.commit()
+        return {"removed": True, "item_id": item_id}
+
+
+@mcp.tool()
+def lock_version(batch_id: str) -> dict[str, Any]:
+    """锁定版本范围，并把条目需求置为已排期。"""
+    _, actor = _identity("versions:write")
+    with SessionLocal() as db:
+        batch = db.query(ReleaseBatch).filter(ReleaseBatch.id == batch_id).first()
+        items = db.query(ReleaseBatchItem).filter(ReleaseBatchItem.batch_id == batch_id).all()
+        if not batch or not items:
+            raise ValueError("版本不存在或没有需求")
+        if batch.status not in {"planning", "candidate_selection"}:
+            raise ValueError("版本范围已锁定")
+        batch.status, batch.locked_at = "scope_locked", utcnow()
+        for item in items:
+            requirement = _requirement_or_error(db, item.requirement_id)
+            item.requirement_snapshot = requirement_snapshot(requirement)
+            before, requirement.status = requirement.status, "scheduled"
+            _enqueue_requirement_github_sync(db, requirement)
+            audit(db, actor.id, "requirement.status_changed", "requirement", requirement.id, source="mcp", before=before, after="scheduled")
+        enqueue(db, "github_milestone", batch.id, f"github_milestone:{batch.id}")
+        audit(db, actor.id, "release_batch.locked", "release_batch", batch.id, source="mcp", count=len(items))
+        db.commit()
+        return _batch_dict(batch, db)
+
+
+@mcp.tool()
+def update_version_status(batch_id: str, status: str, reason: str) -> dict[str, Any]:
+    """推进、暂停、阻塞、发布或完成版本；完成/取消仅所有者令牌可执行。"""
+    _, actor = _identity("versions:write")
+    transitions = {"planning": {"cancelled"}, "candidate_selection": {"cancelled"},
+                   "scope_locked": {"developing", "blocked", "paused", "cancelled"},
+                   "developing": {"testing", "blocked", "paused", "cancelled"},
+                   "testing": {"developing", "release_ready", "blocked", "paused", "cancelled"},
+                   "release_ready": {"testing", "published", "blocked", "paused", "cancelled"},
+                   "published": {"completed"}, "blocked": {"developing", "testing", "release_ready", "paused", "cancelled"},
+                   "paused": {"developing", "testing", "release_ready", "blocked", "cancelled"}}
+    with SessionLocal() as db:
+        batch = db.query(ReleaseBatch).filter(ReleaseBatch.id == batch_id).first()
+        if not batch or status not in transitions.get(batch.status, set()):
+            raise ValueError("无效的版本状态流转")
+        if status in {"completed", "cancelled"} and actor.role != "owner":
+            raise PermissionError("只有所有者可以完成或取消版本")
+        items = db.query(ReleaseBatchItem).filter(ReleaseBatchItem.batch_id == batch.id).all()
+        if status == "published" and any(item.delivery_status not in {"completed", "removed"} for item in items):
+            raise ValueError("所有需求完成后才能发布")
+        before, batch.status = batch.status, status
+        requirement_status = {"developing": "developing", "testing": "testing", "release_ready": "release_ready",
+                              "published": "released", "completed": "released"}.get(status)
+        if requirement_status:
+            for item in items:
+                if requirement_status != "released" or item.delivery_status == "completed":
+                    requirement = _requirement_or_error(db, item.requirement_id)
+                    old, requirement.status = requirement.status, requirement_status
+                    _enqueue_requirement_github_sync(db, requirement)
+                    audit(db, actor.id, "requirement.status_changed", "requirement", requirement.id, source="mcp", before=old, after=requirement_status, reason=reason)
+        audit(db, actor.id, "release_batch.status_changed", "release_batch", batch.id, source="mcp", before=before, after=status, reason=reason)
+        db.commit()
+        return _batch_dict(batch, db)
+
+
+@mcp.tool()
+def update_version_delivery_status(batch_id: str, item_id: str, status: str) -> dict[str, Any]:
+    """更新已锁定版本中一个需求的交付状态。"""
+    _, actor = _identity("versions:write")
+    allowed = {"not_started", "developing", "pr_open", "testing", "completed", "blocked", "removed"}
+    with SessionLocal() as db:
+        batch = db.query(ReleaseBatch).filter(ReleaseBatch.id == batch_id).first()
+        item = db.query(ReleaseBatchItem).filter(ReleaseBatchItem.id == item_id, ReleaseBatchItem.batch_id == batch_id).first()
+        if not batch or not item or status not in allowed:
+            raise ValueError("版本条目或交付状态无效")
+        if batch.status in {"planning", "candidate_selection", "published", "completed", "cancelled"}:
+            raise ValueError("当前版本状态不能修改交付进度")
+        item.delivery_status = status
+        mapping = {"developing": "developing", "pr_open": "developing", "testing": "testing", "completed": "release_ready"}
+        if status in mapping:
+            requirement = _requirement_or_error(db, item.requirement_id)
+            requirement.status = mapping[status]
+            _enqueue_requirement_github_sync(db, requirement)
+        audit(db, actor.id, "release_batch.delivery_status", "release_batch", batch.id, source="mcp", item_id=item.id, status=status)
+        db.commit()
+        return {"id": item.id, "delivery_status": item.delivery_status}
+
+
+@mcp.tool()
+def upload_requirement_attachment(requirement_id: str, filename: str, content_base64: str,
+                                  content_type: str = "application/octet-stream") -> dict[str, Any]:
+    """为需求上传附件。内容必须是 Base64；单文件最大 5MB，最多 5 个附件。"""
+    _, actor = _identity("requirements:write")
+    safe_name = Path(filename).name[:255]
+    suffix = Path(safe_name).suffix.lower()
+    allowed = {".png", ".jpg", ".jpeg", ".webp", ".txt", ".log", ".json", ".pdf"}
+    if not safe_name or suffix not in allowed:
+        raise ValueError("附件类型不支持")
+    try:
+        content = base64.b64decode(content_base64, validate=True)
+    except ValueError as exc:
+        raise ValueError("content_base64 不是有效 Base64") from exc
+    if not content or len(content) > settings.max_attachment_bytes:
+        raise ValueError("附件为空或超过大小限制")
+    with SessionLocal() as db:
+        row = _requirement_or_error(db, requirement_id)
+        count = db.query(func.count(RequirementAttachment.id)).filter(RequirementAttachment.requirement_id == row.id).scalar() or 0
+        if count >= settings.max_attachments_per_requirement:
+            raise ValueError("附件数量已达到上限")
+        upload_dir = Path(settings.upload_dir).resolve()
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        stored_name = f"mcp-{secrets.token_hex(16)}{suffix}"
+        target = upload_dir / stored_name
+        target.write_bytes(content)
+        item = RequirementAttachment(requirement_id=row.id, uploaded_by=actor.id, original_name=safe_name, stored_name=stored_name,
+                                     content_type=content_type[:100], size_bytes=len(content), kind="image" if suffix in {".png", ".jpg", ".jpeg", ".webp"} else "file")
+        try:
+            db.add(item)
+            db.flush()
+            audit(db, actor.id, "requirement.attachment_uploaded", "requirement", row.id, source="mcp", attachment_id=item.id, name=safe_name)
+            db.commit()
+        except Exception:
+            db.rollback()
+            target.unlink(missing_ok=True)
+            raise
+        return {"id": item.id, "name": item.original_name, "content_type": item.content_type, "size_bytes": item.size_bytes, "kind": item.kind}
+
+
+@mcp.tool()
+def list_requirement_attachments(requirement_id: str) -> list[dict[str, Any]]:
+    """列出需求附件元数据。"""
+    _identity("requirements:read")
+    with SessionLocal() as db:
+        _requirement_or_error(db, requirement_id)
+        return [{"id": item.id, "name": item.original_name, "content_type": item.content_type, "size_bytes": item.size_bytes,
+                 "kind": item.kind, "created_at": item.created_at.isoformat()} for item in db.query(RequirementAttachment).filter(
+                 RequirementAttachment.requirement_id == requirement_id).order_by(RequirementAttachment.created_at).all()]
+
+
+@mcp.tool()
+def download_requirement_attachment(requirement_id: str, attachment_id: str) -> dict[str, Any]:
+    """下载需求附件，返回 Base64 内容和元数据。"""
+    _identity("requirements:read")
+    with SessionLocal() as db:
+        _requirement_or_error(db, requirement_id)
+        item = db.query(RequirementAttachment).filter(RequirementAttachment.id == attachment_id,
+                                                       RequirementAttachment.requirement_id == requirement_id).first()
+        if not item:
+            raise ValueError("附件不存在")
+        path = Path(settings.upload_dir).resolve() / item.stored_name
+        if not path.is_file():
+            raise ValueError("附件文件不存在")
+        return {"id": item.id, "name": item.original_name, "content_type": item.content_type,
+                "content_base64": base64.b64encode(path.read_bytes()).decode("ascii")}
+
+
+@mcp.tool()
+def get_requirement_records(requirement_id: str) -> dict[str, Any]:
+    """读取需求的审计历史、编辑版本和审核记录。"""
+    _identity("requirements:read")
+    with SessionLocal() as db:
+        _requirement_or_error(db, requirement_id)
+        events = db.query(AuditEvent).filter(AuditEvent.object_type == "requirement", AuditEvent.object_id == requirement_id).order_by(AuditEvent.created_at).all()
+        revisions = db.query(RequirementRevision).filter(RequirementRevision.requirement_id == requirement_id).order_by(RequirementRevision.created_at).all()
+        reviews = db.query(ReviewDecision).filter(ReviewDecision.requirement_id == requirement_id).order_by(ReviewDecision.created_at).all()
+        return {"history": [{"id": x.id, "action": x.action, "details": x.details, "created_at": x.created_at.isoformat()} for x in events],
+                "revisions": [{"id": x.id, "editor_id": x.editor_id, "snapshot": x.snapshot, "reason": x.reason, "created_at": x.created_at.isoformat()} for x in revisions],
+                "reviews": [{"id": x.id, "reviewer_id": x.reviewer_id, "action": x.action, "reason": x.reason, "metadata": x.metadata_json, "created_at": x.created_at.isoformat()} for x in reviews]}
+
+
+@mcp.tool()
+def get_requirement_triage(requirement_id: str) -> list[dict[str, Any]]:
+    """读取需求的 AI/规则分诊报告。"""
+    _identity("requirements:read")
+    with SessionLocal() as db:
+        _requirement_or_error(db, requirement_id)
+        return [{"id": x.id, "requirement_version": x.requirement_version, "provider": x.provider, "model": x.model,
+                 "report": x.report, "confidence": x.confidence, "created_at": x.created_at.isoformat()} for x in db.query(TriageReport).filter(
+                 TriageReport.requirement_id == requirement_id).order_by(TriageReport.created_at.desc()).all()]
+
+
+@mcp.tool()
+def list_background_jobs(requirement_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    """查询后台分诊、GitHub 同步和 Milestone 任务状态。"""
+    _identity("requirements:read")
+    with SessionLocal() as db:
+        query = db.query(BackgroundJob)
+        if requirement_id:
+            query = query.filter(BackgroundJob.object_id == requirement_id)
+        return [{"id": x.id, "job_type": x.job_type, "object_id": x.object_id, "status": x.status, "attempts": x.attempts,
+                 "last_error": x.last_error, "created_at": x.created_at.isoformat()} for x in query.order_by(BackgroundJob.created_at.desc()).limit(min(max(limit, 1), 100)).all()]
+
+
+@mcp.tool()
+def set_requirement_following(requirement_id: str, following: bool) -> dict[str, Any]:
+    """以令牌所属账号关注或取消关注需求。"""
+    _, actor = _identity("requirements:write")
+    with SessionLocal() as db:
+        _requirement_or_error(db, requirement_id)
+        row = db.query(RequirementFollower).filter(RequirementFollower.requirement_id == requirement_id,
+                                                   RequirementFollower.user_id == actor.id).first()
+        if following and not row:
+            db.add(RequirementFollower(requirement_id=requirement_id, user_id=actor.id))
+        elif not following and row:
+            db.delete(row)
+        db.commit()
+        return {"requirement_id": requirement_id, "following": following}
+
+
+@mcp.tool()
+def withdraw_requirement(requirement_id: str, reason: str = "Agent 请求撤回") -> dict[str, Any]:
+    """撤回令牌所属账号创建的、尚未排期的需求。"""
+    _, actor = _identity("requirements:write")
+    with SessionLocal() as db:
+        row = _requirement_or_error(db, requirement_id)
+        if row.created_by != actor.id:
+            raise PermissionError("只能撤回令牌所属账号创建的需求")
+        if row.status in {"scheduled", "developing", "testing", "release_ready", "released"}:
+            raise ValueError("已排期需求不能撤回")
+        before, row.status = row.status, "withdrawn"
+        audit(db, actor.id, "requirement.withdrawn", "requirement", row.id, source="mcp", before=before, after="withdrawn", reason=reason)
+        db.commit()
+        return _requirement_dict(row)
+
+
+@mcp.tool()
+def unlink_github_issue(requirement_id: str) -> dict[str, Any]:
+    """解除需求与 GitHub Issue 的关联，不会删除远端 Issue。"""
+    _, actor = _identity("github:write")
+    with SessionLocal() as db:
+        row = _requirement_or_error(db, requirement_id)
+        if not row.github_issue_number:
+            raise ValueError("需求尚未关联 GitHub Issue")
+        number = row.github_issue_number
+        row.github_issue_number, row.github_issue_url, row.github_state = None, None, None
+        audit(db, actor.id, "github.issue.unlinked", "requirement", row.id, source="mcp", issue_number=number)
+        db.commit()
+        return _requirement_dict(row)
+
+
+@mcp.tool()
+def list_github_issues() -> list[dict[str, Any]]:
+    """读取仓库中最近更新的 GitHub Issues（排除 Pull Request）。"""
+    _identity("github:write")
+    return [{"number": issue.get("number"), "title": issue.get("title"), "state": issue.get("state"),
+             "url": issue.get("html_url"), "labels": [x.get("name") for x in issue.get("labels", [])]} for issue in GitHubClient().list_issues()]
+
+
+@mcp.tool()
+def sync_github_issues() -> dict[str, int]:
+    """从 GitHub 导入新 Issue，并更新此前由 GitHub 导入的需求。"""
+    _, actor = _identity("github:write")
+    issues = GitHubClient().list_issues()
+    statuses = {name.lower(): status for status, (name, _color, _description) in STATUS_LABELS.items()}
+    created = updated = skipped = 0
+    with SessionLocal() as db:
+        for issue in issues:
+            number = issue.get("number")
+            if not number:
+                skipped += 1
+                continue
+            labels = [x.get("name", "") if isinstance(x, dict) else str(x) for x in issue.get("labels", [])]
+            status = next((statuses[name.lower()] for name in labels if name.lower() in statuses), None) or ("closed" if issue.get("state") == "closed" else "submitted")
+            kind = "bug" if any(name.lower() == "bug" for name in labels) else ("feature" if any(name.lower() in {"enhancement", "feature"} for name in labels) else "improvement")
+            row = db.query(Requirement).filter(Requirement.github_issue_number == number).first()
+            if row:
+                row.github_issue_url, row.github_state = issue.get("html_url"), issue.get("state")
+                if row.source == "github":
+                    row.title = (issue.get("title") or f"GitHub Issue #{number}")[:160]
+                    row.description = ((issue.get("body") or "GitHub Issue 未提供正文").strip() or "GitHub Issue 未提供正文")[:8000]
+                    row.type, row.status = kind, status
+                updated += 1
+                continue
+            row = Requirement(public_number=(db.query(func.max(Requirement.public_number)).scalar() or 0) + 1, type=kind,
+                              title=(issue.get("title") or f"GitHub Issue #{number}")[:160],
+                              description=((issue.get("body") or "GitHub Issue 未提供正文").strip() or "GitHub Issue 未提供正文")[:8000],
+                              severity="medium", visibility="public", status=status, source="github", created_by=actor.id,
+                              github_issue_number=number, github_issue_url=issue.get("html_url"), github_state=issue.get("state"))
+            db.add(row)
+            db.flush()
+            db.add(RequirementFollower(requirement_id=row.id, user_id=actor.id))
+            if status == "submitted":
+                enqueue(db, "triage", row.id, f"triage:{row.id}:v{row.version}")
+            created += 1
+        audit(db, actor.id, "github.issues.synchronized", "github_repository", settings.github_repo, source="mcp", created=created, updated=updated, skipped=skipped, total=len(issues))
+        db.commit()
+    return {"created": created, "updated": updated, "skipped": skipped, "total": len(issues)}
+
+
+@mcp.tool()
+def sync_github_milestone(batch_id: str) -> dict[str, Any]:
+    """立即创建/同步版本的 GitHub Milestone，并关联范围内的 Issues。"""
+    _identity("github:write")
+    with SessionLocal() as db:
+        if not db.query(ReleaseBatch).filter(ReleaseBatch.id == batch_id).first():
+            raise ValueError("版本批次不存在")
+        sync_batch_milestone(db, batch_id)
+        batch = db.query(ReleaseBatch).filter(ReleaseBatch.id == batch_id).first()
+        return _batch_dict(batch, db)
 
 
 def _transport_security_settings() -> TransportSecuritySettings:

--- a/package/requirement-platform/server/tests/test_platform_flow.py
+++ b/package/requirement-platform/server/tests/test_platform_flow.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import tempfile
 import atexit
@@ -16,6 +17,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 from requirement_platform.db import SessionLocal, engine  # noqa: E402
 from requirement_platform.main import app  # noqa: E402
+from requirement_platform import mcp_server  # noqa: E402
 from requirement_platform.mcp_server import mcp_http_app  # noqa: E402
 from requirement_platform.models import BackgroundJob, TriageReport  # noqa: E402
 from requirement_platform.services import GitHubClient, analyze_requirement  # noqa: E402
@@ -244,13 +246,43 @@ def test_manager_github_soft_delete_agent_token_and_mcp(monkeypatch):
         assert initialized.status_code == 200, initialized.text
         tools = mcp_client.post("/", headers=headers, json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
         assert tools.status_code == 200, tools.text
-        assert "list_requirements" in {item["name"] for item in tools.json()["result"]["tools"]}
+        tool_names = {item["name"] for item in tools.json()["result"]["tools"]}
+        assert {"list_requirements", "create_version", "upload_requirement_attachment", "get_requirement_records",
+                "sync_github_issues", "sync_github_milestone"} <= tool_names
         rejected = mcp_client.post(
             "/",
             headers={**headers, "Host": "attacker.example"},
             json={"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {}},
         )
         assert rejected.status_code == 421
+
+
+def test_mcp_requirement_version_attachment_and_records_flow(monkeypatch):
+    """The MCP surface covers the same local requirement/version lifecycle as the REST API."""
+    with TestClient(app) as client:
+        owner = client.post("/api/auth/login", json={"identifier": "owner@example.com", "password": "password123"}).json()["data"]
+        actor_id = owner["user"]["id"]
+    actor = type("Actor", (), {"id": actor_id, "role": "owner"})()
+    monkeypatch.setattr(mcp_server, "_identity", lambda _scope: (None, actor))
+
+    created = mcp_server.create_requirement(**{
+            "type": "bug", "title": "MCP 完整字段测试", "description": "验证 MCP 可写入完整需求字段和后续版本流程。",
+            "log_text": "trace", "current_behavior": "当前失败", "expected_behavior": "预期成功",
+            "steps_to_reproduce": "1. 调用", "product_version": "v0.1", "environment": {"os": "test"},
+        })
+    requirement_id = created["id"]
+    mcp_server.upload_requirement_attachment(requirement_id, "trace.log", base64.b64encode(b"trace").decode())
+    attachment_id = mcp_server.list_requirement_attachments(requirement_id)[0]["id"]
+    assert mcp_server.download_requirement_attachment(requirement_id, attachment_id)["content_base64"] == base64.b64encode(b"trace").decode()
+    mcp_server.review_requirement(requirement_id, "candidate", "可纳入测试版本")
+    batch = mcp_server.create_version("MCP 测试版本", "mcp-test-1", "验证版本写入")
+    version = mcp_server.add_version_requirement(batch["id"], requirement_id)
+    item_id = version["items"][0]["id"]
+    mcp_server.lock_version(batch["id"])
+    mcp_server.update_version_delivery_status(batch["id"], item_id, "developing")
+    mcp_server.update_version_status(batch["id"], "developing", "开始开发")
+    assert mcp_server.get_version(batch["id"])["items"][0]["delivery_status"] == "developing"
+    assert "history" in mcp_server.get_requirement_records(requirement_id)
 
 
 def test_attachment_limits_and_private_access():

--- a/package/requirement-platform/web/nginx.conf
+++ b/package/requirement-platform/web/nginx.conf
@@ -71,7 +71,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_buffering off;
     proxy_read_timeout 300s;
-    client_max_body_size 1m;
+    # 5MB attachment payloads expand to about 6.7MB when transported as Base64 JSON.
+    client_max_body_size 8m;
   }
 
   location / {


### PR DESCRIPTION
## 描述

补齐需求管理平台 MCP 的需求、版本、附件和 GitHub 全生命周期能力，并将 MCP 服务版本升级到 0.3.0。

主要变更：
- 新增版本详情、创建、范围增删、锁定、状态流转和交付状态工具
- 新增附件 Base64 上传、列表与下载工具
- 新增需求历史、编辑版本、审核记录、分诊报告和后台任务查询
- 新增关注/取消关注、撤回和重复需求关联
- 扩充需求创建与更新字段
- 新增 GitHub Issue 列表/同步/解除关联和 Milestone 同步
- 版本查询返回范围快照、交付状态与 Milestone 信息
- 调整 MCP 代理请求体上限以支持 5MB 附件

## 变更类型

- [ ] 🐛 修复错误 (Bug Fix)
- [x] ✨ 新功能 (New Feature)
- [x] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [x] ✅ 测试增加/修改 (Tests)
- [x] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue

Closes #236

对应需求平台记录：REQ-94

## 如何测试

- `cd package/requirement-platform/server && uv run pytest`：10 passed
- `cd package/requirement-platform/web && npm run build`：通过
- `docker compose -f package/requirement-platform/docker-compose.yml config --quiet`：通过

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [x] 我已更新了相关文档