### PR TITLE
fix(requirements): 统一 GitHub 状态同步与审计

### DIFF
--- a/package/requirement-platform/server/requirement_platform/main.py
+++ b/package/requirement-platform/server/requirement_platform/main.py
@@ -60,7 +60,9 @@ from .schemas import (
 from .security import (
     authenticate, create_agent_token_value, create_token, current_user, hash_password, manager, optional_user, owner,
 )
-from .services import GitHubClient, STATUS_LABELS, audit, enqueue, requirement_snapshot, verify_webhook
+from .services import (
+    GitHubClient, audit, enqueue, requirement_snapshot, requirement_status_from_github, verify_webhook,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -112,6 +114,26 @@ def requirement_data(row: Requirement, db: Session, *, include_private: bool = F
 def enqueue_github_sync(db: Session, row: Requirement) -> None:
     if row.github_issue_number or (row.visibility == "public" and row.status == "candidate"):
         enqueue(db, "github_issue", row.id, f"github_issue:{row.id}:{row.status}:{secrets.token_hex(6)}")
+
+
+def apply_github_status(
+    db: Session, row: Requirement, issue: dict, *, action: str | None = None,
+    changed_label: str | None = None, actor_id: str | None = None, actor_name: str = "GitHub",
+    source: str = "github",
+) -> bool:
+    """Apply one GitHub-originated transition and retain an attributable audit record."""
+    before = row.status
+    after = requirement_status_from_github(issue, current_status=before, action=action, changed_label=changed_label)
+    row.github_state = issue.get("state", row.github_state)
+    if after == before:
+        return False
+    row.status = after
+    audit(
+        db, actor_id, "requirement.status_changed", "requirement", row.id,
+        before=before, after=after, reason=f"GitHub 状态同步：{action or 'manual_sync'}",
+        source=source, actor_name=actor_name, github_action=action,
+    )
+    return True
 
 
 def next_requirement_number(db: Session) -> int:
@@ -636,12 +658,12 @@ def requirement_history(requirement_id: str, user: User | None = Depends(optiona
     ).order_by(AuditEvent.created_at).all()
     result = []
     for event in events:
-        actor_name = db.query(User.username).filter(User.id == event.actor_id).scalar() if event.actor_id else None
         details = event.details or {}
+        actor_name = db.query(User.username).filter(User.id == event.actor_id).scalar() if event.actor_id else None
         result.append({
-            "id": event.id, "action": event.action, "actor_name": actor_name or "系统",
+            "id": event.id, "action": event.action, "actor_name": details.get("actor_name") or actor_name or "系统",
             "before": details.get("before"), "after": details.get("after") or details.get("status"),
-            "reason": details.get("reason"), "created_at": event.created_at.isoformat(),
+            "reason": details.get("reason"), "source": details.get("source"), "created_at": event.created_at.isoformat(),
         })
     return ok(result)
 
@@ -830,6 +852,7 @@ def create_requirement_github_issue(requirement_id: str, actor: User = Depends(m
     except (RuntimeError, httpx.HTTPError) as exc:
         raise HTTPException(status_code=502, detail=f"GitHub issue creation failed: {exc}") from exc
     row.github_issue_number, row.github_issue_url, row.github_state = data["number"], data["html_url"], data["state"]
+    enqueue_github_sync(db, row)
     audit(db, actor.id, "github.issue.created", "requirement", row.id, issue_number=data["number"])
     db.commit()
     return ok(requirement_data(row, db, include_private=True))
@@ -841,7 +864,6 @@ def import_github_issues(actor: User = Depends(manager), db: Session = Depends(g
         issues = GitHubClient().list_issues()
     except (RuntimeError, httpx.HTTPError) as exc:
         raise HTTPException(status_code=502, detail=f"GitHub Issue 同步失败：{exc}") from exc
-    status_by_label = {label_name.lower(): status for status, (label_name, _color, _desc) in STATUS_LABELS.items()}
     created = updated = skipped = 0
     for issue in issues:
         number = issue.get("number")
@@ -849,33 +871,35 @@ def import_github_issues(actor: User = Depends(manager), db: Session = Depends(g
             skipped += 1
             continue
         label_names = [label.get("name", "") if isinstance(label, dict) else str(label) for label in issue.get("labels", [])]
-        managed_status = next((status_by_label[name.lower()] for name in label_names if name.lower() in status_by_label), None)
-        issue_status = managed_status or ("closed" if issue.get("state") == "closed" else "submitted")
         kind = "bug" if any(name.lower() == "bug" for name in label_names) else (
             "feature" if any(name.lower() in {"enhancement", "feature"} for name in label_names) else "improvement"
         )
         row = db.query(Requirement).filter(Requirement.github_issue_number == number).first()
         if row:
             row.github_issue_url = issue.get("html_url")
-            row.github_state = issue.get("state")
             if row.source == "github":
                 row.title = (issue.get("title") or f"GitHub Issue #{number}")[:160]
                 row.description = ((issue.get("body") or "GitHub Issue 未提供正文").strip() or "GitHub Issue 未提供正文")[:8000]
                 row.type = kind
-                row.status = issue_status
+            apply_github_status(
+                db, row, issue, actor_id=actor.id, actor_name=actor.username, source="github_manual_sync",
+            )
             updated += 1
             continue
         row = Requirement(
             public_number=next_requirement_number(db),
             type=kind, title=(issue.get("title") or f"GitHub Issue #{number}")[:160],
             description=((issue.get("body") or "GitHub Issue 未提供正文").strip() or "GitHub Issue 未提供正文")[:8000],
-            severity="medium", visibility="public", status=issue_status, source="github", created_by=actor.id,
+            severity="medium", visibility="public", status="submitted", source="github", created_by=actor.id,
             github_issue_number=number, github_issue_url=issue.get("html_url"), github_state=issue.get("state"),
         )
         db.add(row)
         db.flush()
         db.add(RequirementFollower(requirement_id=row.id, user_id=actor.id))
-        if issue_status == "submitted":
+        apply_github_status(
+            db, row, issue, actor_id=actor.id, actor_name=actor.username, source="github_manual_sync",
+        )
+        if row.status == "submitted":
             enqueue(db, "triage", row.id, f"triage:{row.id}:v{row.version}")
         audit(db, actor.id, "github.issue.imported", "requirement", row.id, issue_number=number)
         created += 1
@@ -898,6 +922,7 @@ def link_requirement_github_issue(requirement_id: str, payload: GitHubIssueLinkI
     except (RuntimeError, httpx.HTTPError) as exc:
         raise HTTPException(status_code=502, detail=f"GitHub issue lookup failed: {exc}") from exc
     row.github_issue_number, row.github_issue_url, row.github_state = data["number"], data["html_url"], data["state"]
+    apply_github_status(db, row, data, actor_id=actor.id, actor_name=actor.username, source="github_link")
     enqueue_github_sync(db, row)
     audit(db, actor.id, "github.issue.linked", "requirement", row.id, issue_number=data["number"])
     db.commit()
@@ -921,14 +946,11 @@ def close_requirement_github_issue(requirement_id: str, payload: ReasonInput, ac
     row = db.query(Requirement).filter(Requirement.id == requirement_id, Requirement.deleted_at.is_(None)).first()
     if not row or not row.github_issue_number:
         raise HTTPException(status_code=404, detail="Linked GitHub issue not found")
-    try:
-        data = GitHubClient().update_issue_state(row.github_issue_number, "closed")
-    except (RuntimeError, httpx.HTTPError) as exc:
-        raise HTTPException(status_code=502, detail=f"GitHub issue close failed: {exc}") from exc
-    row.github_state, row.status, row.review_reason = data["state"], "closed", payload.reason
+    before = row.status
+    row.status, row.review_reason = "closed", payload.reason
     enqueue_github_sync(db, row)
-    audit(db, actor.id, "github.issue.closed", "requirement", row.id,
-          issue_number=row.github_issue_number, reason=payload.reason)
+    audit(db, actor.id, "requirement.closed", "requirement", row.id, before=before, after="closed",
+          issue_number=row.github_issue_number, reason=payload.reason, source="platform")
     db.commit()
     return ok(requirement_data(row, db, include_private=True))
 
@@ -1167,7 +1189,21 @@ async def github_webhook(
         issue = payload.get("issue") or {}
         row = db.query(Requirement).filter(Requirement.github_issue_number == issue.get("number")).first()
         if row:
-            row.github_state = issue.get("state")
+            sender = payload.get("sender") or {}
+            identity = db.query(GitHubIdentity).filter(GitHubIdentity.github_user_id == sender.get("id")).first()
+            action = payload.get("action")
+            changed_label = (payload.get("label") or {}).get("name")
+            if action in {"closed", "reopened", "labeled", "unlabeled"}:
+                changed = apply_github_status(
+                    db, row, issue, action=action, changed_label=changed_label,
+                    actor_id=identity.user_id if identity else None,
+                    actor_name=f"GitHub @{sender.get('login', 'unknown')}", source="github_webhook",
+                )
+            else:
+                row.github_state = issue.get("state", row.github_state)
+                changed = False
+            if changed:
+                enqueue(db, "github_issue", row.id, f"github_issue:{row.id}:webhook:{delivery_id}")
     event.processed = True
     db.commit()
     return ok({"accepted": True})

--- a/package/requirement-platform/server/requirement_platform/mcp_server.py
+++ b/package/requirement-platform/server/requirement_platform/mcp_server.py
@@ -21,7 +21,9 @@ from .models import (
     RequirementFollower, RequirementRevision, ReviewDecision, TriageReport, User, utcnow,
 )
 from .security import resolve_agent_token
-from .services import GitHubClient, STATUS_LABELS, audit, enqueue, requirement_snapshot, sync_batch_milestone
+from .services import (
+    GitHubClient, audit, enqueue, requirement_snapshot, requirement_status_from_github, sync_batch_milestone,
+)
 
 
 class DatabaseTokenVerifier:
@@ -123,6 +125,19 @@ def _requirement_or_error(db, requirement_id: str, *, include_deleted: bool = Fa
 def _enqueue_requirement_github_sync(db, row: Requirement) -> None:
     if row.github_issue_number or (row.visibility == "public" and row.status == "candidate"):
         enqueue(db, "github_issue", row.id, f"github_issue:{row.id}:{row.status}:{secrets.token_hex(6)}")
+
+
+def _apply_github_status(db, row: Requirement, issue: dict[str, Any], actor: User) -> bool:
+    before = row.status
+    after = requirement_status_from_github(issue, current_status=before)
+    row.github_state = issue.get("state", row.github_state)
+    if after == before:
+        return False
+    row.status = after
+    audit(db, actor.id, "requirement.status_changed", "requirement", row.id,
+          before=before, after=after, reason="GitHub 状态同步：manual_sync",
+          source="github_manual_sync", actor_name=actor.username)
+    return True
 
 
 @mcp.tool()
@@ -236,12 +251,14 @@ def review_requirement(requirement_id: str, action: str, reason: str, priority: 
                 if not db.query(RequirementFollower).filter(RequirementFollower.requirement_id == target.id,
                                                            RequirementFollower.user_id == follower.user_id).first():
                     db.add(RequirementFollower(requirement_id=target.id, user_id=follower.user_id))
+        before = row.status
         row.status, row.review_reason, row.priority, row.risk_level = statuses[action], reason.strip(), priority, risk_level
         _enqueue_requirement_github_sync(db, row)
         db.add(ReviewDecision(requirement_id=row.id, reviewer_id=actor.id, action=action, reason=reason,
                               metadata_json={"source": "mcp", "priority": priority, "risk_level": risk_level,
                                              "duplicate_of_id": duplicate_of_id}))
-        audit(db, actor.id, f"requirement.{action}", "requirement", row.id, source="mcp", reason=reason)
+        audit(db, actor.id, f"requirement.{action}", "requirement", row.id, source="mcp", reason=reason,
+              before=before, after=row.status)
         db.commit()
         return _requirement_dict(row)
 
@@ -293,6 +310,7 @@ def create_github_issue(requirement_id: str) -> dict[str, Any]:
             return _requirement_dict(row)
         data = GitHubClient().create_issue(row)
         row.github_issue_number, row.github_issue_url, row.github_state = data["number"], data["html_url"], data["state"]
+        _enqueue_requirement_github_sync(db, row)
         audit(db, actor.id, "github.issue.created", "requirement", row.id, source="mcp", issue_number=data["number"])
         db.commit()
         return _requirement_dict(row)
@@ -311,6 +329,8 @@ def link_github_issue(requirement_id: str, issue_number: int) -> dict[str, Any]:
             raise ValueError("该 Issue 已关联其他需求")
         data = GitHubClient().get_issue(issue_number)
         row.github_issue_number, row.github_issue_url, row.github_state = data["number"], data["html_url"], data["state"]
+        _apply_github_status(db, row, data, actor)
+        _enqueue_requirement_github_sync(db, row)
         audit(db, actor.id, "github.issue.linked", "requirement", row.id, source="mcp", issue_number=issue_number)
         db.commit()
         return _requirement_dict(row)
@@ -318,16 +338,17 @@ def link_github_issue(requirement_id: str, issue_number: int) -> dict[str, Any]:
 
 @mcp.tool()
 def close_github_issue(requirement_id: str, reason: str) -> dict[str, Any]:
-    """关闭已关联的 GitHub Issue，并同步关闭平台需求。"""
+    """关闭平台需求，并由后台任务同步关闭已关联的 GitHub Issue。"""
     _, actor = _identity("github:write")
     with SessionLocal() as db:
         row = db.query(Requirement).filter(Requirement.id == requirement_id, Requirement.deleted_at.is_(None)).first()
         if not row or not row.github_issue_number:
             raise ValueError("需求不存在或尚未关联 Issue")
-        data = GitHubClient().update_issue_state(row.github_issue_number, "closed")
-        row.github_state, row.status, row.review_reason = data["state"], "closed", reason.strip()
-        audit(db, actor.id, "github.issue.closed", "requirement", row.id, source="mcp",
-              issue_number=row.github_issue_number, reason=reason)
+        before = row.status
+        row.status, row.review_reason = "closed", reason.strip()
+        _enqueue_requirement_github_sync(db, row)
+        audit(db, actor.id, "requirement.closed", "requirement", row.id, source="mcp",
+              before=before, after="closed", issue_number=row.github_issue_number, reason=reason)
         db.commit()
         return _requirement_dict(row)
 
@@ -489,8 +510,11 @@ def update_version_delivery_status(batch_id: str, item_id: str, status: str) -> 
         mapping = {"developing": "developing", "pr_open": "developing", "testing": "testing", "completed": "release_ready"}
         if status in mapping:
             requirement = _requirement_or_error(db, item.requirement_id)
+            before = requirement.status
             requirement.status = mapping[status]
             _enqueue_requirement_github_sync(db, requirement)
+            audit(db, actor.id, "requirement.status_changed", "requirement", requirement.id, source="mcp",
+                  before=before, after=requirement.status, reason=f"版本交付状态：{status}")
         audit(db, actor.id, "release_batch.delivery_status", "release_batch", batch.id, source="mcp", item_id=item.id, status=status)
         db.commit()
         return {"id": item.id, "delivery_status": item.delivery_status}
@@ -658,10 +682,9 @@ def list_github_issues() -> list[dict[str, Any]]:
 
 @mcp.tool()
 def sync_github_issues() -> dict[str, int]:
-    """从 GitHub 导入新 Issue，并更新此前由 GitHub 导入的需求。"""
+    """从 GitHub 导入/更新 Issue，并按统一映射记录平台状态变化。"""
     _, actor = _identity("github:write")
     issues = GitHubClient().list_issues()
-    statuses = {name.lower(): status for status, (name, _color, _description) in STATUS_LABELS.items()}
     created = updated = skipped = 0
     with SessionLocal() as db:
         for issue in issues:
@@ -670,26 +693,27 @@ def sync_github_issues() -> dict[str, int]:
                 skipped += 1
                 continue
             labels = [x.get("name", "") if isinstance(x, dict) else str(x) for x in issue.get("labels", [])]
-            status = next((statuses[name.lower()] for name in labels if name.lower() in statuses), None) or ("closed" if issue.get("state") == "closed" else "submitted")
             kind = "bug" if any(name.lower() == "bug" for name in labels) else ("feature" if any(name.lower() in {"enhancement", "feature"} for name in labels) else "improvement")
             row = db.query(Requirement).filter(Requirement.github_issue_number == number).first()
             if row:
-                row.github_issue_url, row.github_state = issue.get("html_url"), issue.get("state")
+                row.github_issue_url = issue.get("html_url")
                 if row.source == "github":
                     row.title = (issue.get("title") or f"GitHub Issue #{number}")[:160]
                     row.description = ((issue.get("body") or "GitHub Issue 未提供正文").strip() or "GitHub Issue 未提供正文")[:8000]
-                    row.type, row.status = kind, status
+                    row.type = kind
+                _apply_github_status(db, row, issue, actor)
                 updated += 1
                 continue
             row = Requirement(public_number=(db.query(func.max(Requirement.public_number)).scalar() or 0) + 1, type=kind,
                               title=(issue.get("title") or f"GitHub Issue #{number}")[:160],
                               description=((issue.get("body") or "GitHub Issue 未提供正文").strip() or "GitHub Issue 未提供正文")[:8000],
-                              severity="medium", visibility="public", status=status, source="github", created_by=actor.id,
+                              severity="medium", visibility="public", status="submitted", source="github", created_by=actor.id,
                               github_issue_number=number, github_issue_url=issue.get("html_url"), github_state=issue.get("state"))
             db.add(row)
             db.flush()
             db.add(RequirementFollower(requirement_id=row.id, user_id=actor.id))
-            if status == "submitted":
+            _apply_github_status(db, row, issue, actor)
+            if row.status == "submitted":
                 enqueue(db, "triage", row.id, f"triage:{row.id}:v{row.version}")
             created += 1
         audit(db, actor.id, "github.issues.synchronized", "github_repository", settings.github_repo, source="mcp", created=created, updated=updated, skipped=skipped, total=len(issues))

--- a/package/requirement-platform/server/requirement_platform/services.py
+++ b/package/requirement-platform/server/requirement_platform/services.py
@@ -178,6 +178,44 @@ STATUS_LABELS = {
     "closed": ("status: closed", "6a737d", "已关闭"),
 }
 
+# Both systems may initiate a transition, but they share one mapping: platform
+# statuses are projected to GitHub labels/state, while explicit GitHub state or
+# managed-label changes are translated back to a platform status.
+GITHUB_CLOSED_REQUIREMENT_STATUSES = {"released", "rejected", "duplicate", "withdrawn", "closed"}
+
+
+def github_state_for_requirement(status: str) -> str:
+    return "closed" if status in GITHUB_CLOSED_REQUIREMENT_STATUSES else "open"
+
+
+def requirement_status_from_github(issue: dict[str, Any], current_status: str = "submitted",
+                                   action: str | None = None, changed_label: str | None = None) -> str:
+    """Translate an explicit GitHub change without guessing from unrelated edits."""
+    status_by_label = {label.lower(): status for status, (label, _color, _description) in STATUS_LABELS.items()}
+    labels = {
+        (item.get("name", "") if isinstance(item, dict) else str(item)).lower()
+        for item in issue.get("labels", [])
+    }
+    matched = {status_by_label[label] for label in labels if label in status_by_label}
+    # A webhook emitted by our outbound synchronization already contains the
+    # platform's label and matching native state. Treat it as an echo.
+    if matched == {current_status} and issue.get("state") == github_state_for_requirement(current_status):
+        return current_status
+    if action == "closed":
+        return "closed"
+    if action == "reopened":
+        return "pending_review"
+    if action == "labeled" and changed_label and changed_label.lower() in status_by_label:
+        return status_by_label[changed_label.lower()]
+    if len(matched) == 1:
+        label_status = matched.pop()
+        if issue.get("state") != github_state_for_requirement(label_status):
+            return "closed" if issue.get("state") == "closed" else "pending_review"
+        return label_status
+    if issue.get("state") == "closed":
+        return "closed"
+    return current_status
+
 
 class GitHubClient:
     def __init__(self):
@@ -275,7 +313,8 @@ class GitHubClient:
         ]
         retained.append(self.ensure_status_label(status))
         return self._request(
-            "PATCH", f"/repos/{settings.github_repo}/issues/{issue_number}", json={"labels": retained}
+            "PATCH", f"/repos/{settings.github_repo}/issues/{issue_number}",
+            json={"labels": retained, "state": github_state_for_requirement(status)},
         )
 
     def sync_issue(self, requirement: Requirement) -> dict[str, Any]:
@@ -299,7 +338,12 @@ class GitHubClient:
         )
         return self._request(
             "PATCH", f"/repos/{settings.github_repo}/issues/{requirement.github_issue_number}",
-            json={"title": requirement.title, "body": body, "labels": retained},
+            json={
+                "title": requirement.title,
+                "body": body,
+                "labels": retained,
+                "state": github_state_for_requirement(requirement.status),
+            },
         )
 
     def create_milestone(self, batch: ReleaseBatch) -> dict[str, Any]:
@@ -333,6 +377,10 @@ def sync_requirement_issue(db: Session, requirement_id: str) -> None:
     requirement.github_issue_number = data["number"]
     requirement.github_issue_url = data["html_url"]
     requirement.github_state = data["state"]
+    desired_state = github_state_for_requirement(requirement.status)
+    if requirement.github_state != desired_state:
+        data = client.update_issue_state(requirement.github_issue_number, desired_state)
+        requirement.github_state = data["state"]
     audit(db, None, "github.issue.created", "requirement", requirement.id, issue_number=data["number"])
     db.commit()
 

--- a/package/requirement-platform/server/tests/test_platform_flow.py
+++ b/package/requirement-platform/server/tests/test_platform_flow.py
@@ -19,8 +19,8 @@ from requirement_platform.db import SessionLocal, engine  # noqa: E402
 from requirement_platform.main import app  # noqa: E402
 from requirement_platform import mcp_server  # noqa: E402
 from requirement_platform.mcp_server import mcp_http_app  # noqa: E402
-from requirement_platform.models import BackgroundJob, TriageReport  # noqa: E402
-from requirement_platform.services import GitHubClient, analyze_requirement  # noqa: E402
+from requirement_platform.models import BackgroundJob, GitHubIdentity, Requirement, TriageReport  # noqa: E402
+from requirement_platform.services import GitHubClient, analyze_requirement, requirement_status_from_github  # noqa: E402
 
 
 def cleanup_database_handles():
@@ -351,6 +351,7 @@ def test_github_status_sync_preserves_unmanaged_labels(monkeypatch):
     GitHubClient().sync_status_label(42, "testing")
     patch_request = next(item for item in requests if item[0] == "PATCH")
     assert patch_request[2]["json"]["labels"] == ["bug", "status: testing"]
+    assert patch_request[2]["json"]["state"] == "open"
 
 
 def test_github_full_issue_sync_updates_content_and_preserves_custom_labels(monkeypatch):
@@ -377,6 +378,65 @@ def test_github_full_issue_sync_updates_content_and_preserves_custom_labels(monk
     assert payload["title"] == "新的标题"
     assert "新的描述" in payload["body"]
     assert payload["labels"] == ["documentation", "enhancement", "status: testing"]
+    assert payload["state"] == "open"
+
+
+def test_github_status_mapping_distinguishes_sync_echo_from_user_transition():
+    assert requirement_status_from_github(
+        {"state": "closed", "labels": [{"name": "status: released"}]}, "released", action="closed"
+    ) == "released"
+    assert requirement_status_from_github(
+        {"state": "open", "labels": [{"name": "status: candidate"}]}, "candidate", action="reopened"
+    ) == "candidate"
+    assert requirement_status_from_github(
+        {"state": "closed", "labels": [{"name": "status: candidate"}]}, "candidate", action="closed"
+    ) == "closed"
+    assert requirement_status_from_github(
+        {"state": "open", "labels": [{"name": "status: closed"}]}, "closed", action="reopened"
+    ) == "pending_review"
+
+
+def test_github_webhook_updates_platform_status_with_actor_and_history(monkeypatch):
+    with TestClient(app) as client:
+        owner = client.post(
+            "/api/auth/login", json={"identifier": "owner@example.com", "password": "password123"}
+        ).json()["data"]
+        created = client.post(
+            "/api/requirements", headers=auth(owner["token"]),
+            json={"type": "feature", "title": "Webhook 状态同步测试", "description": "验证 GitHub 状态变化进入平台时间线。"},
+        ).json()["data"]
+        db = SessionLocal()
+        try:
+            row = db.query(Requirement).filter(Requirement.id == created["id"]).one()
+            row.github_issue_number = 99993
+            row.github_issue_url = "https://github.com/LC044/TrailSnap/issues/99993"
+            row.github_state = "open"
+            db.add(GitHubIdentity(user_id=owner["user"]["id"], github_user_id=123456789, login="octocat"))
+            db.commit()
+        finally:
+            db.close()
+
+        monkeypatch.setattr("requirement_platform.main.verify_webhook", lambda _body, _signature: True)
+        headers = {"X-Hub-Signature-256": "sha256=test", "X-GitHub-Event": "issues"}
+        closed = client.post("/api/hooks/github", headers={**headers, "X-GitHub-Delivery": "delivery-close"}, json={
+            "action": "closed", "issue": {"number": 99993, "state": "closed", "labels": [{"name": "status: candidate"}]},
+            "sender": {"id": 123456789, "login": "octocat"},
+        })
+        assert closed.status_code == 200, closed.text
+        detail = client.get(f"/api/requirements/{created['id']}").json()["data"]
+        assert detail["status"] == "closed"
+        history = client.get(f"/api/requirements/{created['id']}/history").json()["data"]
+        event = history[-1]
+        assert (event["before"], event["after"], event["actor_name"], event["source"]) == (
+            "submitted", "closed", "GitHub @octocat", "github_webhook",
+        )
+
+        reopened = client.post("/api/hooks/github", headers={**headers, "X-GitHub-Delivery": "delivery-reopen"}, json={
+            "action": "reopened", "issue": {"number": 99993, "state": "open", "labels": [{"name": "status: closed"}]},
+            "sender": {"id": 123456789, "login": "octocat"},
+        })
+        assert reopened.status_code == 200, reopened.text
+        assert client.get(f"/api/requirements/{created['id']}").json()["data"]["status"] == "pending_review"
 
 
 def test_anonymous_number_history_dashboard_and_manager_edit():


### PR DESCRIPTION
## 描述

统一需求平台与 GitHub Issue 的双向状态映射和状态审计，修复通过 GitHub/MCP 关闭需求时详情时间线缺少关闭记录的问题。

主要变更：
- 平台状态后台同步到 GitHub 的 `status:*` 标签及 `open/closed`
- GitHub 关闭、重开和受管状态标签变更可通过 Webhook 更新平台
- 状态变化统一记录前后状态、来源、理由和可识别的 GitHub 操作人
- GitHub 账号已绑定时关联到平台用户，同时保留 `GitHub @用户名` 展示
- 识别平台出站同步产生的 Webhook 回声，防止状态循环覆盖
- REST/MCP 关闭操作改为先修改平台，再由后台关闭 GitHub Issue
- GitHub 手动同步和既有 Issue 关联使用同一状态映射

## 变更类型

- [x] 🐛 修复错误 (Bug Fix)
- [ ] ✨ 新功能 (New Feature)
- [ ] 📝 文档更新 (Documentation)
- [ ] 🎨 代码风格调整 (Style)
- [x] ♻️ 代码重构 (Refactor)
- [ ] ⚡️ 性能优化 (Performance)
- [x] ✅ 测试增加/修改 (Tests)
- [ ] 🔧 构建/工具链修改 (Build/Chore)

## 相关 Issue

Closes #238

对应需求平台记录：REQ-95

## 如何测试

- `cd package/requirement-platform/server && uv run pytest`
- 结果：12 passed

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [x] 我已更新了相关文档