### PR TITLE
fix(mobile): 手机 App 天地图瓦片大面积 403，代理改用浏览器 UA

### DIFF
--- a/package/server/app/api/system.py
+++ b/package/server/app/api/system.py
@@ -63,7 +63,12 @@ async def proxy_tianditu_resource(host: str, path: str, request: Request):
     timeout = aiohttp.ClientTimeout(total=30, connect=8)
     headers = {
         "Accept": request.headers.get("accept", "*/*"),
-        "User-Agent": "TrailSnap-Map-Proxy/1.0",
+        # Tianditu rejects browser-type keys unless the caller looks like a
+        # browser: a synthetic "TrailSnap-Map-Proxy/1.0" UA gets 403 301012
+        # ("权限类型错误") on tiles and geocoding.  Forward the WebView's real
+        # UA and fall back to a modern mobile browser string when absent.
+        "User-Agent": request.headers.get("user-agent")
+        or "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126 Mobile Safari/537.36",
     }
     # Tianditu browser keys can be restricted by an allowed web origin.  From
     # Tianditu's perspective the self-hosted gateway is now the caller, so use
@@ -81,13 +86,18 @@ async def proxy_tianditu_resource(host: str, path: str, request: Request):
                     charset = response.charset or "utf-8"
                     body = _rewrite_tianditu_text(body.decode(charset, errors="replace")).encode("utf-8")
                     content_type = content_type.split(";", 1)[0] + "; charset=utf-8"
+                # Only success responses are cacheable: an upstream 403/502
+                # would otherwise poison the WebView cache for a full day.
+                cache_control = (
+                    "public, max-age=86400" if response.status == 200 else "no-store"
+                )
                 return Response(
                     content=body,
                     status_code=response.status,
                     media_type=None,
                     headers={
                         "Content-Type": content_type,
-                        "Cache-Control": "public, max-age=86400",
+                        "Cache-Control": cache_control,
                         "X-Content-Type-Options": "nosniff",
                     },
                 )

--- a/package/server/tests/unit/test_system_api.py
+++ b/package/server/tests/unit/test_system_api.py
@@ -258,3 +258,97 @@ def test_map_proxy_uses_public_server_origin_for_browser_key():
 
     assert system_api._public_request_origin(request) == "https://photos.example.com"
 
+
+# ------------------------ /map-proxy UA + caching -------------------------
+# 天地图对「浏览器端」Key 按 User-Agent 校验：非浏览器 UA 一律 403 301012
+# （"Key权限类型为:浏览器端，请使用浏览器访问"）。代理必须转发 WebView 的
+# 真实 UA，缺失时兜底为移动浏览器 UA，绝不能再发合成标识。
+
+
+def _proxy_request(headers=None):
+    return Request({
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("localhost", 8000),
+        "path": "/api/system/map-proxy/t0.tianditu.gov.cn/DataServer",
+        "query_string": b"T=vec_w&x=1&y=2&l=3&tk=test",
+        "headers": headers or [(b"host", b"localhost:8000")],
+    })
+
+
+def _fake_upstream(status=200, content_type="image/png", body=b"tile-bytes"):
+    response = SimpleNamespace(
+        status=status,
+        headers={"Content-Type": content_type},
+        charset=None,
+        read=AsyncMock(return_value=body),
+    )
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=response)
+    context.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.get = MagicMock(return_value=context)
+    return session
+
+
+class AsyncMock(MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
+def test_map_proxy_forwards_client_user_agent_to_tianditu():
+    """WebView 的真实 UA 必须透传；天地图按 UA 拒绝非浏览器客户端。"""
+    request = _proxy_request([
+        (b"host", b"localhost:8000"),
+        (b"user-agent", b"Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36"),
+    ])
+    session = _fake_upstream()
+
+    with patch.object(system_api.aiohttp, "ClientSession", MagicMock(return_value=session)):
+        asyncio.run(system_api.proxy_tianditu_resource("t0.tianditu.gov.cn", "DataServer", request))
+
+    sent_headers = session.get.call_args.kwargs["headers"]
+    assert sent_headers["User-Agent"] == "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36"
+
+
+def test_map_proxy_falls_back_to_browser_user_agent_when_missing():
+    """无 UA（如部分内网探活）时用浏览器 UA 兜底，而不是合成标识。"""
+    session = _fake_upstream()
+
+    with patch.object(system_api.aiohttp, "ClientSession", MagicMock(return_value=session)):
+        asyncio.run(
+            system_api.proxy_tianditu_resource("t0.tianditu.gov.cn", "DataServer", _proxy_request())
+        )
+
+    sent_headers = session.get.call_args.kwargs["headers"]
+    assert sent_headers["User-Agent"].startswith("Mozilla/5.0")
+    assert "TrailSnap-Map-Proxy" not in sent_headers["User-Agent"]
+
+
+def test_map_proxy_does_not_cache_error_responses():
+    """上游 403/5xx 若被缓存，会在 WebView 里毒缓存一天，必须 no-store。"""
+    session = _fake_upstream(status=403, content_type="application/json", body=b'{"code":301012}')
+
+    with patch.object(system_api.aiohttp, "ClientSession", MagicMock(return_value=session)):
+        response = asyncio.run(
+            system_api.proxy_tianditu_resource("t0.tianditu.gov.cn", "DataServer", _proxy_request())
+        )
+
+    assert response.status_code == 403
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_map_proxy_caches_successful_responses():
+    session = _fake_upstream(status=200)
+
+    with patch.object(system_api.aiohttp, "ClientSession", MagicMock(return_value=session)):
+        response = asyncio.run(
+            system_api.proxy_tianditu_resource("t0.tianditu.gov.cn", "DataServer", _proxy_request())
+        )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "public, max-age=86400"
+

--- a/package/website/src/views/album/location/AddSceneDialog.vue
+++ b/package/website/src/views/album/location/AddSceneDialog.vue
@@ -91,7 +91,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, watch, nextTick, computed } from 'vue'
-import { loadMapScript } from '@/utils/mapLoader'
+import { getTiandituTileTemplate, loadMapScript } from '@/utils/mapLoader'
 import { locationService } from '@/api/location'
 import { ElMessage } from 'element-plus'
 import type { SceneCreate, Scene } from '@/types/location'
@@ -171,7 +171,7 @@ const resetForm = () => {
 }
 
 const initMap = async () => {
-  await loadMapScript()
+  const apiKey = await loadMapScript()
   nextTick(() => {
     // Always create new map instance to ensure proper rendering in dialog
     // Clean up old map if needed (though local variable usually suffices)
@@ -179,8 +179,18 @@ const initMap = async () => {
     if (container) {
         container.innerHTML = '' // clear previous map
     }
-    
-    map = new T.Map('add-scene-map')
+
+    // 手机 App / Web 生产环境走服务器代理瓦片；默认图层会在 App 上直连
+    // 天地图，被原生网络边界拦截导致底图空白。
+    const vecTileUrl = getTiandituTileTemplate('vec_w', apiKey)
+    const cvaTileUrl = getTiandituTileTemplate('cva_w', apiKey)
+    map = vecTileUrl && cvaTileUrl
+      ? new T.Map('add-scene-map', { layers: [] })
+      : new T.Map('add-scene-map')
+    if (vecTileUrl && cvaTileUrl) {
+      map.addOverLay(new T.TileLayer(vecTileUrl, { minZoom: 1, maxZoom: 18 }))
+      map.addOverLay(new T.TileLayer(cvaTileUrl, { minZoom: 1, maxZoom: 18 }))
+    }
     // 如果有坐标，移动到该坐标
     if (form.latitude && form.longitude) {
       map.centerAndZoom(new T.LngLat(form.longitude, form.latitude), 14)


### PR DESCRIPTION
## 描述

手机 App 连接自托管服务后，位置地图天地图瓦片大面积加载失败、整片空白（REQ-98）。

**根因（已实验复现）**：v0.14.0 起（#179 / #180）App 的瓦片改走 FastAPI `/api/system/map-proxy/` 代理，该代理硬编码 `User-Agent: TrailSnap-Map-Proxy/1.0`。天地图对浏览器端类型的 Key 按 UA 校验，非浏览器 UA 一律返回 `403 code=301012`（"Key权限类型为:浏览器端，请使用浏览器访问"），因此 App 的瓦片与逆地理编码全部失败。Web 端走 nginx `/tianditu-tiles/` 透传浏览器自身 UA，不受影响——与用户反馈"仅 App 端异常"吻合。

实测 UA 矩阵（真实 key）：`TrailSnap-Map-Proxy/1.0` / `okhttp` / `curl` / `Dalvik` / `python-urllib` → 403；`Mozilla/5.0 …` → 200。

**修复**：
- 代理转发 WebView 真实 User-Agent，缺失时兜底现代移动浏览器 UA
- 上游非 200 响应改 `Cache-Control: no-store`，避免 403 在 WebView 里毒缓存 24 小时（原实现所有响应统一 `max-age=86400`）
- `AddSceneDialog.vue` 地图补接 `getTiandituTileTemplate` 代理瓦片模板——原先用 SDK 默认图层，App 上会直连天地图被原生网络边界拦截，弹窗底图同样空白
- 新增 4 个单测锁定 UA 转发与错误响应缓存策略

## 变更类型

- [x] 🐛 修复错误 (Bug Fix)
- [x] ✅ 测试增加/修改 (Tests)

## 相关 Issue

关联需求：[REQ-98](https://feedback.trailsnap.cn/requirements/REQ-98)

Closes #246

## 如何测试

1. 单测：`uv run python -m pytest tests/unit/test_system_api.py -v` → 17 passed（含新增 4 例）
2. 真实上游端到端验证（本地已执行）：
   - 瓦片经修复后代理（WebView UA）：HTTP 200, image/png, `cache-control: public, max-age=86400`
   - 无 UA 请求（兜底浏览器 UA）：HTTP 200
   - 逆地理编码经代理：HTTP 200 且返回 `formatted_address`
   - 无效 key：HTTP 403 且 `cache-control: no-store`（不缓存）
3. 前端 `vue-tsc --noEmit`：错误数与 master 基线一致（26 → 26，均为存量问题，无新增）

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [ ] 我已更新了相关文档（无文档需更新：代理行为对用户透明）