### PR TITLE
feat(requirements): MCP 支持通用需求状态流转

### DIFF
--- a/package/requirement-platform/README.md
+++ b/package/requirement-platform/README.md
@@ -111,7 +111,7 @@ MCP 作用域与能力：
 
 - `requirements:read`：查询需求、附件、历史/编辑/审核记录、分诊报告和后台任务。
 - `requirements:write`：创建和完整编辑需求、通过 Base64 上传附件、关注/取消关注及撤回需求。
-- `requirements:review`：审核、标记重复、关闭、软删除和恢复需求。
+- `requirements:review`：审核、修改为任一平台已定义状态、标记重复、关闭、软删除和恢复需求。
 - `versions:read`：查询版本批次、范围快照、单项交付状态和 GitHub Milestone。
 - `versions:write`：创建版本、增删范围条目、锁定范围、流转版本状态及更新交付状态。
 - `github:write`：创建、关联、解除关联和关闭 Issue，导入/同步 Issue，以及同步版本 Milestone。

--- a/package/requirement-platform/server/requirement_platform/main.py
+++ b/package/requirement-platform/server/requirement_platform/main.py
@@ -53,6 +53,7 @@ from .schemas import (
     ReasonInput,
     RequirementCreate,
     RequirementRead,
+    RequirementStatusInput,
     RequirementUpdate,
     ReviewInput,
     RoleUpdate,
@@ -797,6 +798,28 @@ def review_requirement(requirement_id: str, payload: ReviewInput, actor: User = 
     enqueue_github_sync(db, row)
     audit(db, actor.id, f"requirement.{payload.action}", "requirement", row.id,
           before=before, after=row.status, reason=payload.reason)
+    db.commit()
+    return ok(requirement_data(row, db, include_private=True))
+
+
+@app.patch("/api/requirements/{requirement_id}/status")
+def update_requirement_status(
+    requirement_id: str,
+    payload: RequirementStatusInput,
+    actor: User = Depends(manager),
+    db: Session = Depends(get_db),
+):
+    row = db.query(Requirement).filter(Requirement.id == requirement_id, Requirement.deleted_at.is_(None)).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Requirement not found")
+    before = row.status
+    row.status = payload.status
+    row.review_reason = payload.reason
+    enqueue_github_sync(db, row)
+    audit(
+        db, actor.id, "requirement.status_changed", "requirement", row.id,
+        before=before, after=row.status, reason=payload.reason,
+    )
     db.commit()
     return ok(requirement_data(row, db, include_private=True))
 

--- a/package/requirement-platform/server/requirement_platform/mcp_server.py
+++ b/package/requirement-platform/server/requirement_platform/mcp_server.py
@@ -22,7 +22,8 @@ from .models import (
 )
 from .security import resolve_agent_token
 from .services import (
-    GitHubClient, audit, enqueue, requirement_snapshot, requirement_status_from_github, sync_batch_milestone,
+    GitHubClient, STATUS_LABELS, audit, enqueue, requirement_snapshot, requirement_status_from_github,
+    sync_batch_milestone,
 )
 
 
@@ -49,7 +50,7 @@ class DatabaseTokenVerifier:
 mcp = MCPServer(
     name="trailsnap-requirements",
     title="TrailSnap 需求管理",
-    version="0.3.0",
+    version="0.4.0",
     instructions=(
         "用于查询和管理 TrailSnap 需求与版本。任何写入、审核、删除和 GitHub 操作都必须遵循令牌作用域；"
         "删除为可恢复的软删除。执行 review_requirement 前先读取需求详情，理由必须具体。"
@@ -260,6 +261,28 @@ def review_requirement(requirement_id: str, action: str, reason: str, priority: 
                                              "duplicate_of_id": duplicate_of_id}))
         audit(db, actor.id, f"requirement.{action}", "requirement", row.id, source="mcp", reason=reason,
               before=before, after=row.status)
+        db.commit()
+        return _requirement_dict(row)
+
+
+@mcp.tool()
+def update_requirement_status(requirement_id: str, status: str, reason: str) -> dict[str, Any]:
+    """将需求设置为任一平台已定义状态；必须提供具体原因。"""
+    _, actor = _identity("requirements:review")
+    if status not in STATUS_LABELS:
+        raise ValueError(f"无效的需求状态：{status}")
+    if len(reason.strip()) < 2:
+        raise ValueError("状态变更理由至少需要 2 个字符")
+    with SessionLocal() as db:
+        row = _requirement_or_error(db, requirement_id)
+        before = row.status
+        row.status = status
+        row.review_reason = reason.strip()
+        _enqueue_requirement_github_sync(db, row)
+        audit(
+            db, actor.id, "requirement.status_changed", "requirement", row.id,
+            source="mcp", before=before, after=row.status, reason=reason.strip(),
+        )
         db.commit()
         return _requirement_dict(row)
 

--- a/package/requirement-platform/server/requirement_platform/schemas.py
+++ b/package/requirement-platform/server/requirement_platform/schemas.py
@@ -95,6 +95,15 @@ class ReviewInput(BaseModel):
     duplicate_of_id: str | None = None
 
 
+class RequirementStatusInput(BaseModel):
+    status: Literal[
+        "submitted", "triaging", "pending_review", "needs_information", "candidate", "scheduled",
+        "developing", "testing", "release_ready", "released", "deferred", "rejected", "duplicate",
+        "withdrawn", "closed",
+    ]
+    reason: str = Field(min_length=2, max_length=2000)
+
+
 class DeliveryStatusInput(BaseModel):
     status: Literal["not_started", "developing", "pr_open", "testing", "completed", "blocked", "removed"]
 

--- a/package/requirement-platform/server/tests/test_platform_flow.py
+++ b/package/requirement-platform/server/tests/test_platform_flow.py
@@ -4,6 +4,8 @@ import tempfile
 import atexit
 from pathlib import Path
 
+import pytest
+
 
 TEST_DIR = tempfile.TemporaryDirectory()
 os.environ["RP_DATABASE_URL"] = f"sqlite:///{Path(TEST_DIR.name) / 'requirements.db'}"
@@ -82,6 +84,21 @@ def test_complete_manual_requirement_and_batch_flow():
         assert reviewed.status_code == 200, reviewed.text
         assert reviewed.json()["data"]["status"] == "candidate"
 
+        developing = client.patch(
+            f"/api/requirements/{requirement['id']}/status",
+            headers=auth(owner["token"]),
+            json={"status": "developing", "reason": "开始独立开发"},
+        )
+        assert developing.status_code == 200, developing.text
+        assert developing.json()["data"]["status"] == "developing"
+
+        reset_candidate = client.patch(
+            f"/api/requirements/{requirement['id']}/status",
+            headers=auth(owner["token"]),
+            json={"status": "candidate", "reason": "继续验证版本排期流程"},
+        )
+        assert reset_candidate.status_code == 200, reset_candidate.text
+
         batch = client.post(
             "/api/versions",
             headers=auth(owner["token"]),
@@ -153,6 +170,12 @@ def test_viewer_cannot_review_and_private_requirement_is_hidden():
             json={"action": "candidate", "reason": "越权审核"},
         )
         assert denied.status_code == 403
+        denied_status = client.patch(
+            f"/api/requirements/{created['id']}/status",
+            headers=auth(viewer["token"]),
+            json={"status": "developing", "reason": "越权修改状态"},
+        )
+        assert denied_status.status_code == 403
 
         owner = client.post(
             "/api/auth/login", json={"identifier": "owner@example.com", "password": "password123"}
@@ -249,7 +272,7 @@ def test_manager_github_soft_delete_agent_token_and_mcp(monkeypatch):
         tools = mcp_client.post("/", headers=headers, json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
         assert tools.status_code == 200, tools.text
         tool_names = {item["name"] for item in tools.json()["result"]["tools"]}
-        assert {"list_requirements", "create_version", "upload_requirement_attachment", "get_requirement_records",
+        assert {"list_requirements", "update_requirement_status", "create_version", "upload_requirement_attachment", "get_requirement_records",
                 "sync_github_issues", "sync_github_milestone"} <= tool_names
         rejected = mcp_client.post(
             "/",
@@ -280,6 +303,12 @@ def test_mcp_requirement_version_attachment_and_records_flow(monkeypatch):
     attachment_id = mcp_server.list_requirement_attachments(requirement_id)[0]["id"]
     assert mcp_server.download_requirement_attachment(requirement_id, attachment_id)["content_base64"] == base64.b64encode(b"trace").decode()
     mcp_server.review_requirement(requirement_reference, "candidate", "可纳入测试版本")
+    changed = mcp_server.update_requirement_status(requirement_reference, "developing", "开始独立开发")
+    assert changed["status"] == "developing"
+    assert changed["review_reason"] == "开始独立开发"
+    with pytest.raises(ValueError, match="无效的需求状态"):
+        mcp_server.update_requirement_status(requirement_reference, "unknown", "测试未知状态")
+    mcp_server.update_requirement_status(requirement_reference, "candidate", "继续验证版本排期流程")
     batch = mcp_server.create_version("MCP 测试版本", "mcp-test-1", "验证版本写入")
     version = mcp_server.add_version_requirement(batch["id"], requirement_id)
     item_id = version["items"][0]["id"]

--- a/package/requirement-platform/server/tests/test_platform_flow.py
+++ b/package/requirement-platform/server/tests/test_platform_flow.py
@@ -84,21 +84,6 @@ def test_complete_manual_requirement_and_batch_flow():
         assert reviewed.status_code == 200, reviewed.text
         assert reviewed.json()["data"]["status"] == "candidate"
 
-        developing = client.patch(
-            f"/api/requirements/{requirement['id']}/status",
-            headers=auth(owner["token"]),
-            json={"status": "developing", "reason": "开始独立开发"},
-        )
-        assert developing.status_code == 200, developing.text
-        assert developing.json()["data"]["status"] == "developing"
-
-        reset_candidate = client.patch(
-            f"/api/requirements/{requirement['id']}/status",
-            headers=auth(owner["token"]),
-            json={"status": "candidate", "reason": "继续验证版本排期流程"},
-        )
-        assert reset_candidate.status_code == 200, reset_candidate.text
-
         batch = client.post(
             "/api/versions",
             headers=auth(owner["token"]),
@@ -186,6 +171,19 @@ def test_viewer_cannot_review_and_private_requirement_is_hidden():
             json={"action": "candidate", "reason": "保留私密信息", "priority": "normal", "risk_level": "medium"},
         )
         assert reviewed.status_code == 200
+        developing = client.patch(
+            f"/api/requirements/{created['id']}/status",
+            headers=auth(owner["token"]),
+            json={"status": "developing", "reason": "开始独立开发"},
+        )
+        assert developing.status_code == 200, developing.text
+        assert developing.json()["data"]["status"] == "developing"
+        reset_candidate = client.patch(
+            f"/api/requirements/{created['id']}/status",
+            headers=auth(owner["token"]),
+            json={"status": "candidate", "reason": "继续验证版本排期流程"},
+        )
+        assert reset_candidate.status_code == 200, reset_candidate.text
         batch = client.post(
             "/api/versions",
             headers=auth(owner["token"]),


### PR DESCRIPTION
## 描述

新增通用需求状态修改能力：受信任的管理员或 Agent 可以把单个需求设置为任一平台已定义状态，不再必须通过版本批次间接进入 `developing`。未知状态会被拒绝，变更保留原因、审计记录和 GitHub 同步。

同时新增同语义的管理端 REST API，并补充 MCP 工具发现、状态修改、未知状态和权限测试。

## 变更类型

- [x] ✨ 新功能 (New Feature)
- [x] 📝 文档更新 (Documentation)
- [x] ✅ 测试增加/修改 (Tests)

## 相关 Issue

关联需求：[REQ-100](https://feedback.trailsnap.cn/REQ-100)

Closes #249

## 如何测试

本地按仓库提交规则未额外执行测试；由本 PR 的 GitHub Actions 验证需求平台服务端测试与前端构建。

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [x] 我已更新了相关文档
