### PR TITLE
fix(mobile): 打通原生层临时放行与连接页 401 处理

### DIFF
--- a/doc/mobile_offline_network.md
+++ b/doc/mobile_offline_network.md
@@ -16,6 +16,10 @@ TrailSnap 手机 App 的运行原则是：安装包包含前端代码、字体�
 
 尚未保存 Server 地址时，连接页需要探测 mDNS/LAN 服务或测试用户手动输入的公网自部署地址，因此网络白名单尚未收紧。地址保存后策略立即变为精确同源；清除 App 数据会重新进入首次连接状态。
 
+## 切换 Server 的临时放行
+
+连接页对候选地址是"先测试、后保存"：测试请求发出时已保存的还是旧地址，原生层与浏览器层都会把新源当作外部请求。为此 `withTemporaryServerAccess()`（浏览器层）和 `NativeNetworkPolicy` 插件（Android 原生层，`OfflineOnlyWebViewClient`）在同一时刻临时放行候选 origin：测试请求发出前注册，带 30 秒过期兜底，测试结束（成功或失败）即撤销。两层必须同时放行，缺一层时表现为 `Failed to fetch`（Android 原生层返回无 CORS 头的 403）。旧版 App（< v0.14.1）浏览器层也没有放行，报"已阻止外部网络请求"。
+
 ## 上架构建注意事项
 
 当前 Android 自托管分发包包含 `REQUEST_INSTALL_PACKAGES`，用于用户确认后的 APK 自更新。Google Play 等商店通常会严格审核这项权限；正式商店渠道应建立单独 flavor，移除该权限和 App 内安装入口，交由应用商店更新。该渠道差异不改变 App 业务流量只访问自部署 Server 的原则。

--- a/package/website/android/app/src/main/java/cn/trailsnap/app/MainActivity.java
+++ b/package/website/android/app/src/main/java/cn/trailsnap/app/MainActivity.java
@@ -11,6 +11,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(GalleryBackupPlugin.class);
         registerPlugin(LanDiscoveryPlugin.class);
         registerPlugin(AppUpdaterPlugin.class);
+        registerPlugin(NativeNetworkPolicyPlugin.class);
         super.onCreate(savedInstanceState);
         bridge.setWebViewClient(new OfflineOnlyWebViewClient(bridge, this));
         handleGalleryBackupAction(getIntent());

--- a/package/website/android/app/src/main/java/cn/trailsnap/app/NativeNetworkPolicyPlugin.java
+++ b/package/website/android/app/src/main/java/cn/trailsnap/app/NativeNetworkPolicyPlugin.java
@@ -1,0 +1,65 @@
+package cn.trailsnap.app;
+
+import android.webkit.WebViewClient;
+
+import com.getcapacitor.Bridge;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * Bridge between the JS-layer network guard (nativeNetworkPolicy.ts) and the
+ * native WebView boundary (OfflineOnlyWebViewClient).
+ *
+ * The connection screen tests a candidate server BEFORE saving it. The native
+ * boundary only allows the already-saved origin, so without this bridge every
+ * health check to a new server would be answered with a CORS-less 403 and the
+ * JS fetch would fail with "Failed to fetch". The JS layer mirrors this with
+ * withTemporaryServerAccess(); both sides must allow the same origin for the
+ * test request to pass.
+ */
+@CapacitorPlugin(name = "NativeNetworkPolicy")
+public class NativeNetworkPolicyPlugin extends Plugin {
+    private static final long DEFAULT_TTL_MS = 30_000L;
+
+    @PluginMethod
+    public void allowTemporaryOrigin(PluginCall call) {
+        String origin = call.getString("origin");
+        if (origin == null || origin.isEmpty()) {
+            call.reject("origin is required");
+            return;
+        }
+        Long ttlMs = call.getLong("ttlMs");
+        long ttl = ttlMs == null ? DEFAULT_TTL_MS : ttlMs;
+
+        OfflineOnlyWebViewClient client = webViewClient();
+        if (client == null) {
+            // Older runtime without the native boundary: nothing to allow.
+            call.resolve();
+            return;
+        }
+        client.allowTemporaryOrigin(origin, ttl);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void revokeTemporaryOrigin(PluginCall call) {
+        String origin = call.getString("origin");
+        if (origin == null || origin.isEmpty()) {
+            call.reject("origin is required");
+            return;
+        }
+        OfflineOnlyWebViewClient client = webViewClient();
+        if (client != null) client.revokeTemporaryOrigin(origin);
+        call.resolve();
+    }
+
+    private OfflineOnlyWebViewClient webViewClient() {
+        Bridge bridge = getBridge();
+        if (bridge == null) return null;
+        WebViewClient client = bridge.getWebViewClient();
+        return client instanceof OfflineOnlyWebViewClient ? (OfflineOnlyWebViewClient) client : null;
+    }
+}

--- a/package/website/android/app/src/main/java/cn/trailsnap/app/OfflineOnlyWebViewClient.java
+++ b/package/website/android/app/src/main/java/cn/trailsnap/app/OfflineOnlyWebViewClient.java
@@ -11,6 +11,7 @@ import com.getcapacitor.BridgeWebViewClient;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Native network boundary for the packaged App.
@@ -19,6 +20,11 @@ import java.nio.charset.StandardCharsets;
  * only for that exact origin.  Before onboarding, private/LAN hosts are allowed
  * so discovery and connection testing can work.  App assets remain available
  * from Capacitor's localhost origin.
+ *
+ * Switching servers is a two-step flow (test first, then save).  While the JS
+ * layer verifies a candidate origin, it registers that origin via
+ * {@link #allowTemporaryOrigin(String, long)}; the JS-side guard in
+ * nativeNetworkPolicy.ts must stay in sync with this class.
  */
 public final class OfflineOnlyWebViewClient extends BridgeWebViewClient {
     private static final String PREFERENCES_GROUP = "CapacitorStorage";
@@ -26,9 +32,26 @@ public final class OfflineOnlyWebViewClient extends BridgeWebViewClient {
 
     private final Context context;
 
+    /** Candidate origins pending verification, with wall-clock expiry stamps. */
+    private final TemporaryOriginRegistry temporaryOrigins = new TemporaryOriginRegistry();
+
     public OfflineOnlyWebViewClient(Bridge bridge, Context context) {
         super(bridge);
         this.context = context.getApplicationContext();
+    }
+
+    /**
+     * Allow one candidate server origin while the JS layer runs its health
+     * check.  The WebView client reads this set from a different thread than
+     * the plugin bridge, hence the concurrent map plus expiry stamps.
+     */
+    public void allowTemporaryOrigin(String origin, long ttlMs) {
+        temporaryOrigins.allow(origin, ttlMs);
+    }
+
+    /** Drop a candidate origin once verification finished (success or failure). */
+    public void revokeTemporaryOrigin(String origin) {
+        temporaryOrigins.revoke(origin);
     }
 
     @Override
@@ -57,6 +80,8 @@ public final class OfflineOnlyWebViewClient extends BridgeWebViewClient {
         String host = lower(uri.getHost());
         if (host.equals("localhost") || host.equals("127.0.0.1") || host.equals("::1")) return true;
 
+        if (isTemporarilyAllowed(scheme, host, uri)) return true;
+
         String configured = context
             .getSharedPreferences(PREFERENCES_GROUP, Context.MODE_PRIVATE)
             .getString(SERVER_URL_KEY, "");
@@ -69,11 +94,138 @@ public final class OfflineOnlyWebViewClient extends BridgeWebViewClient {
             && effectivePort(uri) == effectivePort(server);
     }
 
+    private boolean isTemporarilyAllowed(String scheme, String host, Uri uri) {
+        return temporaryOrigins.contains(originKey(scheme, host, effectivePort(uri)));
+    }
+
+    /**
+     * Candidate origins pending verification.  Keys are formatted exactly like
+     * the JS {@code URL.origin} (default ports omitted, IPv6 bracketed) so the
+     * JS guard and this native guard agree on what "same origin" means.
+     */
+    static final class TemporaryOriginRegistry {
+        private final ConcurrentHashMap<String, Long> origins = new ConcurrentHashMap<>();
+
+        /** @return whether the origin was accepted (http/https with a host). */
+        boolean allow(String value, long ttlMs) {
+            String key = normalize(value);
+            if (key == null) return false;
+            long ttl = Math.max(1_000L, Math.min(ttlMs, 120_000L));
+            long now = System.currentTimeMillis();
+            purgeExpired(now);
+            origins.put(key, now + ttl);
+            return true;
+        }
+
+        void revoke(String value) {
+            String key = normalize(value);
+            if (key != null) origins.remove(key);
+        }
+
+        boolean contains(String originKey) {
+            if (origins.isEmpty()) return false;
+            Long expiry = origins.get(originKey);
+            if (expiry == null) return false;
+            if (expiry < System.currentTimeMillis()) {
+                origins.remove(originKey);
+                return false;
+            }
+            return true;
+        }
+
+        boolean isEmpty() {
+            return origins.isEmpty();
+        }
+
+        private void purgeExpired(long now) {
+            for (String key : origins.keySet()) {
+                Long expiry = origins.get(key);
+                if (expiry != null && expiry < now) origins.remove(key);
+            }
+        }
+
+        /**
+         * Parse an http(s) origin string without android.net.Uri so unit tests
+         * can run on the JVM (framework classes are stubs there).
+         * @return the URL.origin-style key, or null when not http(s).
+         */
+        private static String normalize(String value) {
+            if (value == null) return null;
+            String candidate = value.trim();
+            String scheme;
+            String rest;
+            int schemeEnd = candidate.indexOf("://");
+            if (schemeEnd < 0) return null;
+            scheme = lower(candidate.substring(0, schemeEnd));
+            rest = candidate.substring(schemeEnd + 3);
+            if (!scheme.equals("http") && !scheme.equals("https")) return null;
+
+            // Strip any path/query/fragment: the authority ends at the first
+            // '/', '?' or '#'.
+            int authorityEnd = rest.length();
+            for (int i = 0; i < rest.length(); i++) {
+                char c = rest.charAt(i);
+                if (c == '/' || c == '?' || c == '#') {
+                    authorityEnd = i;
+                    break;
+                }
+            }
+            String authority = rest.substring(0, authorityEnd);
+
+            // Split host and port. IPv6 literals are bracketed in an origin
+            // string; the closing bracket may be followed by ':port'.
+            String hostPart;
+            String portPart = null;
+            int closeBracket = authority.indexOf(']');
+            int colon = authority.lastIndexOf(':');
+            if (closeBracket >= 0) {
+                hostPart = authority.substring(0, closeBracket + 1);
+                if (closeBracket + 1 < authority.length() && authority.charAt(closeBracket + 1) == ':') {
+                    portPart = authority.substring(closeBracket + 2);
+                }
+            } else if (colon >= 0) {
+                hostPart = authority.substring(0, colon);
+                portPart = authority.substring(colon + 1);
+            } else {
+                hostPart = authority;
+            }
+            String host = lower(stripBrackets(hostPart));
+            if (host.isEmpty()) return null;
+
+            int port;
+            if (portPart == null || portPart.isEmpty()) {
+                port = "https".equals(scheme) ? 443 : 80;
+            } else {
+                try {
+                    port = Integer.parseInt(portPart);
+                } catch (NumberFormatException ignored) {
+                    return null;
+                }
+            }
+            return originKey(scheme, host, port);
+        }
+    }
+
+    /** Format scheme/host/port the way the JS URL.origin does. */
+    private static String originKey(String scheme, String host, int port) {
+        boolean defaultPort = ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443);
+        String hostPart = host.contains(":") ? "[" + host + "]" : host;
+        return scheme + "://" + hostPart + (defaultPort ? "" : ":" + port);
+    }
+
+    private static String stripBrackets(String hostPart) {
+        if (hostPart.startsWith("[") && hostPart.endsWith("]") && hostPart.length() >= 2) {
+            return hostPart.substring(1, hostPart.length() - 1);
+        }
+        return hostPart;
+    }
+
     private static int effectivePort(Uri uri) {
         if (uri.getPort() >= 0) return uri.getPort();
         return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
     }
 
+    /** Hosts the JS connection screen may probe before any server is saved. */
     private static boolean isPrivateLanHost(String host) {
         if (host.endsWith(".local")) return true;
         if (host.startsWith("10.") || host.startsWith("192.168.")) return true;

--- a/package/website/android/app/src/test/java/cn/trailsnap/app/OfflineOnlyWebViewClientTest.java
+++ b/package/website/android/app/src/test/java/cn/trailsnap/app/OfflineOnlyWebViewClientTest.java
@@ -1,0 +1,85 @@
+package cn.trailsnap.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * The temporary-origin mechanism exists so the connection screen can health
+ * check a NEW server while the native boundary still pins the saved one.
+ * Its key formats must match the JS URL.origin produced by
+ * nativeNetworkPolicy.ts, otherwise the test request is answered with a
+ * CORS-less 403 ("Failed to fetch").
+ *
+ * These tests run on the JVM (no Robolectric), so they exercise the pure
+ * origin-string layer: registration -> key normalization -> lookup/revoke.
+ */
+public class OfflineOnlyWebViewClientTest {
+    private final OfflineOnlyWebViewClient.TemporaryOriginRegistry registry =
+        new OfflineOnlyWebViewClient.TemporaryOriginRegistry();
+
+    @Test
+    public void registeredOriginMatchesRequestUrls() {
+        registry.allow("http://192.168.1.20:3180", 30_000);
+        // Request URL -> origin uses the same formatting as URL.origin.
+        assertTrue(registry.contains(formatRequestOrigin("http", "192.168.1.20", 3180)));
+        assertFalse(registry.contains(formatRequestOrigin("http", "192.168.1.21", 3180)));
+        assertFalse(registry.contains(formatRequestOrigin("http", "192.168.1.20", 3181)));
+        assertFalse(registry.contains(formatRequestOrigin("https", "192.168.1.20", 3180)));
+    }
+
+    @Test
+    public void defaultPortsAreOmittedLikeJsUrlOrigin() {
+        registry.allow("http://192.168.1.20", 30_000);
+        assertTrue(registry.contains(formatRequestOrigin("http", "192.168.1.20", 80)));
+        assertFalse(registry.contains(formatRequestOrigin("http", "192.168.1.20", 8080)));
+    }
+
+    @Test
+    public void ipv6LiteralsAreBracketedLikeJsUrlOrigin() {
+        registry.allow("http://[fe80::a1]:3180", 30_000);
+        assertTrue(registry.contains(formatRequestOrigin("http", "fe80::a1", 3180)));
+    }
+
+    @Test
+    public void revokeRemovesOnlyTheTargetOrigin() {
+        registry.allow("http://192.168.1.20:3180", 30_000);
+        registry.allow("http://192.168.1.30:3180", 30_000);
+        registry.revoke("http://192.168.1.20:3180");
+        assertFalse(registry.contains(formatRequestOrigin("http", "192.168.1.20", 3180)));
+        assertTrue(registry.contains(formatRequestOrigin("http", "192.168.1.30", 3180)));
+    }
+
+    @Test
+    public void expiredOriginsStopMatching() {
+        registry.allow("http://192.168.1.20:3180", 1);
+        try {
+            Thread.sleep(1_200);
+        } catch (InterruptedException ignored) {
+        }
+        assertFalse(registry.contains(formatRequestOrigin("http", "192.168.1.20", 3180)));
+    }
+
+    @Test
+    public void nonHttpOriginsAreRejectedFromRegistration() {
+        assertFalse(registry.allow("file:///etc/hosts", 30_000));
+        assertFalse(registry.allow("javascript:alert(1)", 30_000));
+        assertFalse(registry.allow("not a url", 30_000));
+        assertTrue(registry.isEmpty());
+    }
+
+    @Test
+    public void schemeAndHostAreCaseInsensitive() {
+        registry.allow("HTTP://Example.COM:3180", 30_000);
+        assertTrue(registry.contains(formatRequestOrigin("http", "example.com", 3180)));
+    }
+
+    /** Mirrors what isTemporarilyAllowed builds for an intercepted request. */
+    private static String formatRequestOrigin(String scheme, String host, int port) {
+        boolean defaultPort = ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443);
+        String hostPart = host.contains(":") ? "[" + host + "]" : host;
+        return scheme + "://" + hostPart + (defaultPort ? "" : ":" + port);
+    }
+}

--- a/package/website/src/config/nativeNetworkPolicy.ts
+++ b/package/website/src/config/nativeNetworkPolicy.ts
@@ -1,8 +1,15 @@
-import { Capacitor } from '@capacitor/core'
+import { Capacitor, registerPlugin } from '@capacitor/core'
 
 let installed = false
 let getConfiguredServerUrl: () => string = () => ''
 const temporaryServerOrigins = new Map<string, number>()
+
+interface NativeNetworkPolicyPlugin {
+  allowTemporaryOrigin(options: { origin: string; ttlMs: number }): Promise<void>
+  revokeTemporaryOrigin(options: { origin: string }): Promise<void>
+}
+
+const NativeNetworkPolicy = registerPlugin<NativeNetworkPolicyPlugin>('NativeNetworkPolicy')
 
 function requestOrigin(value: string | URL): string {
   const url = new URL(value.toString(), window.location.href)
@@ -11,19 +18,44 @@ function requestOrigin(value: string | URL): string {
   return url.origin
 }
 
+/**
+ * Mirror a candidate origin into the native WebView boundary
+ * (OfflineOnlyWebViewClient). Android intercepts requests below the JS layer;
+ * without this sync the same-origin rule there rejects the health check with
+ * a CORS-less 403, which surfaces as "Failed to fetch". Older Apps and
+ * browser/e2e runtimes have no native plugin — the call rejects there and is
+ * fine to ignore.
+ */
+async function syncTemporaryOriginToNative(origin: string, allowed: boolean): Promise<void> {
+  if (!Capacitor.isNativePlatform()) return
+  try {
+    if (allowed) await NativeNetworkPolicy.allowTemporaryOrigin({ origin, ttlMs: 30_000 })
+    else await NativeNetworkPolicy.revokeTemporaryOrigin({ origin })
+  } catch {
+    // Plugin missing (web runtime or pre-plugin build) — JS guard still applies.
+  }
+}
+
 /** Temporarily allow one candidate Server while its health endpoint is verified. */
 export async function withTemporaryServerAccess<T>(
   serverUrl: string,
   operation: () => Promise<T>,
 ): Promise<T> {
   const origin = requestOrigin(serverUrl)
+  const first = !temporaryServerOrigins.has(origin)
   temporaryServerOrigins.set(origin, (temporaryServerOrigins.get(origin) || 0) + 1)
+  // The native boundary must be open before the first request goes out; the
+  // revoke below must only run after the last concurrent operation finished.
+  if (first) await syncTemporaryOriginToNative(origin, true)
   try {
     return await operation()
   } finally {
     const remaining = (temporaryServerOrigins.get(origin) || 1) - 1
     if (remaining > 0) temporaryServerOrigins.set(origin, remaining)
-    else temporaryServerOrigins.delete(origin)
+    else {
+      temporaryServerOrigins.delete(origin)
+      if (first) void syncTemporaryOriginToNative(origin, false)
+    }
   }
 }
 

--- a/package/website/src/utils/request.ts
+++ b/package/website/src/utils/request.ts
@@ -95,8 +95,17 @@ service.interceptors.response.use(
       }
       switch (error.response.status) {
         case 401: {
-          const currentPath = router.currentRoute.value.path;
-          const publicPages = ['/login', '/register', '/forgot-password'];
+          // window.location rather than router.currentRoute: a background
+          // request (nav items, auth status) can 401 while the initial
+          // navigation is still resolving, when currentRoute is still "/" —
+          // using it here misclassifies a public page as protected and bounces
+          // the user to /login mid-onboarding.
+          const currentPath = window.location.pathname;
+          // Same allow-list as the router guard: /server-settings is where the
+          // user goes to switch servers before logging in. A stale token there
+          // must be cleared silently — redirecting to /login would bounce them
+          // back ("登录已过期" while trying to reach the login flow).
+          const publicPages = ['/login', '/register', '/forgot-password', '/server-settings'];
           const userStore = useUserStore();
 
           const originalRequest = error.config as (InternalAxiosRequestConfig & { _desktopSessionRetried?: boolean }) | undefined;

--- a/package/website/tests/e2e/specs/login/mobile-server-login.spec.ts
+++ b/package/website/tests/e2e/specs/login/mobile-server-login.spec.ts
@@ -194,4 +194,50 @@ test.describe('手机 App 服务器断连 @p0', () => {
     await expect.poll(() => page.evaluate(() => localStorage.getItem('user_token')))
       .toBe('expired-offline-session')
   })
+
+  test('连接页收到 401 时静默清除过期登录态，不踢回登录页', async ({ page }) => {
+    await page.addInitScript(() => {
+      ;(window as typeof window & { CapacitorCustomPlatform?: { name: string } }).CapacitorCustomPlatform = {
+        name: 'android',
+      }
+      localStorage.setItem('trailsnap:server-url', 'http://192.168.1.10:3180')
+      localStorage.setItem('user_token', 'expired-token-before-server-switch')
+    })
+    // 后台请求（nav items 等）带过期 token 吃到 401，但连接页必须可用——
+    // 用户正是为了登录才来切换服务器，踢回 /login 会形成死循环。
+    await page.route('http://192.168.1.10:3180/**', route => route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: 'Not authenticated' }),
+    }))
+
+    await page.goto('/server-settings', { waitUntil: 'domcontentloaded' })
+
+    await expect(page).toHaveURL(url => url.pathname === '/server-settings')
+    await expect(page.getByRole('button', { name: '测试并保存' })).toBeVisible()
+    // 过期 token 已被静默清除，而不是触发"登录已过期"跳转。
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('user_token'))).toBeNull()
+  })
+
+  test('受保护页面收到 401 仍会退出并跳转登录页', async ({ page }) => {
+    await page.addInitScript(() => {
+      ;(window as typeof window & { CapacitorCustomPlatform?: { name: string } }).CapacitorCustomPlatform = {
+        name: 'android',
+      }
+      localStorage.setItem('trailsnap:server-url', 'http://192.168.1.10:3180')
+      localStorage.setItem('user_token', 'expired-token-on-protected-page')
+      localStorage.setItem('user_info', JSON.stringify({ id: 1, username: 'e2e-admin' }))
+    })
+    await page.route('http://192.168.1.10:3180/**', route => route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: 'Not authenticated' }),
+    }))
+
+    await page.goto('/photos', { waitUntil: 'domcontentloaded' })
+
+    // 正常的过期处理：清 token 并回到登录页。
+    await expect(page).toHaveURL(url => url.pathname === '/login', { timeout: 10_000 })
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('user_token'))).toBeNull()
+  })
 })


### PR DESCRIPTION
## 描述

REQ-8（v0.14.1）修复扫码切换服务器时只修了 JS 层网络策略，遗漏了 Android 原生 WebView 边界（`OfflineOnlyWebViewClient`），造成两个用户可见的 bug：

**1. 切换服务器报"无法连接 TrailSnap 服务：Failed to fetch"**

- 已配置服务器 A 的 App，在"连接 TrailSnap"页扫码**或手动输入**服务器 B，点"测试并保存"报 `Failed to fetch`
- 登录页直接填 B 可以正常登录（登录页是先保存再请求，保存动作把原生白名单切到了 B）
- 输入 A 能连（匹配已存 origin）

根因：连接页是"先测试、后保存"流程，健康检查发出时原生层白名单仍是 A → 返回无 CORS 头的合成 403 → WebView 跨域 fetch 抛 `TypeError: Failed to fetch`。上次的 `withTemporaryServerAccess` 只放行了 JS 层。

**2. 登录页点"扫码或自动查找 TrailSnap"被弹"登录已过期，请重新登录"形成死循环**

根因两个叠加：`request.ts` 401 白名单漏了 `/server-settings`（路由守卫白名单里有）；竞态——全局后台请求 401 返回时初始导航可能未完成，`router.currentRoute.value.path` 仍是 `/`，公共页被误判为受保护页踢回 /login。

### 修复

- 新增 `NativeNetworkPolicyPlugin`（Capacitor 插件），`OfflineOnlyWebViewClient` 增加 `TemporaryOriginRegistry`（30s TTL 兜底 + 过期清理，线程安全）；JS 层 `withTemporaryServerAccess` 在发健康检查前把候选 origin 同步注册进原生白名单，结束后撤销。origin 键格式与 JS `URL.origin` 严格对齐（默认端口省略、IPv6 加方括号——`Uri.getHost()` 不带括号，专门做了转换）
- `/server-settings` 加入 `request.ts` 401 白名单（静默清 token，不跳转不弹窗）；`currentPath` 改用 `window.location.pathname` 消除导航时序竞态
- 受保护页面（如 /photos）token 过期仍正常跳登录页，行为不回退

关联需求：[REQ-101](https://feedback.trailsnap.cn/REQ-101)

## 变更类型

- [x] 🐛 修复错误 (Bug Fix)
- [x] ✅ 测试增加/修改 (Tests)
- [x] 📝 文档更新 (Documentation)

## 相关 Issue

平台需求创建后由后台同步 GitHub Issue，合并时通过需求平台自动关闭（关联需求：[REQ-101](https://feedback.trailsnap.cn/REQ-101)）。

## 如何测试

- **Android JVM 单测**：`./gradlew testDebugUnitTest` — 14/14 通过（新增 7 个覆盖 origin 格式对齐、TTL 过期、revoke、scheme/host 大小写）
- **e2e**：`npx playwright test tests/e2e/specs/login/mobile-server-login.spec.ts` — 8/8 通过，新增两个用例：①连接页收到 401 时静默清除过期登录态、不踢回登录页；②受保护页面收到 401 仍会退出并跳转登录页
- **e2e 回归**：`server-settings.spec.ts` 5/5 通过
- **真机验证路径**（需要重新构建 APK）：已配置服务器 A → 连接页扫码/输入服务器 B → "测试并保存"应成功；登录页点"扫码或自动查找"进入连接页不应再弹"登录已过期"

## 检查清单

- [x] 我已阅读并遵循项目的贡献指南
- [x] 我的代码遵循项目的代码风格
- [x] 我已添加/更新了必要的测试
- [x] 所有测试均已通过
- [x] 我已更新了相关文档

I have read and agree to the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)